### PR TITLE
Reduce logging output

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -46,7 +46,7 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
                         fs::create_dir_all(parent)?;
                     }
                 }
-                debug!("[*] Creating missing file {}", filename.display());
+                debug!("Creating missing file {}", filename.display());
 
                 let mut f = File::create(&filename)?;
                 writeln!(f, "# {}", link.name)?;
@@ -159,7 +159,7 @@ impl Chapter {
 /// You need to pass in the book's source directory because all the links in
 /// `SUMMARY.md` give the chapter locations relative to it.
 fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P) -> Result<Book> {
-    debug!("[*] Loading the book from disk");
+    debug!("Loading the book from disk");
     let src_dir = src_dir.as_ref();
 
     let prefix = summary.prefix_chapters.iter();
@@ -186,7 +186,7 @@ fn load_summary_item<P: AsRef<Path>>(item: &SummaryItem, src_dir: P) -> Result<B
 }
 
 fn load_chapter<P: AsRef<Path>>(link: &Link, src_dir: P) -> Result<Chapter> {
-    debug!("[*] Loading {} ({})", link.name, link.location.display());
+    debug!("Loading {} ({})", link.name, link.location.display());
     let src_dir = src_dir.as_ref();
 
     let location = if link.location.is_absolute() {

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -8,7 +8,6 @@ use super::MDBook;
 use theme;
 use errors::*;
 
-
 /// A helper for setting up a new book and its directory structure.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BookBuilder {
@@ -97,7 +96,7 @@ impl BookBuilder {
     }
 
     fn write_book_toml(&self) -> Result<()> {
-        debug!("[*] Writing book.toml");
+        debug!("Writing book.toml");
         let book_toml = self.root.join("book.toml");
         let cfg = toml::to_vec(&self.config).chain_err(|| "Unable to serialize the config")?;
 
@@ -109,7 +108,7 @@ impl BookBuilder {
     }
 
     fn copy_across_theme(&self) -> Result<()> {
-        debug!("[*] Copying theme");
+        debug!("Copying theme");
 
         let themedir = self.config
             .html_config()
@@ -118,7 +117,10 @@ impl BookBuilder {
         let themedir = self.root.join(themedir);
 
         if !themedir.exists() {
-            debug!("[*]: {:?} does not exist, creating the directory", themedir);
+            debug!(
+                "{} does not exist, creating the directory",
+                themedir.display()
+            );
             fs::create_dir(&themedir)?;
         }
 
@@ -144,7 +146,7 @@ impl BookBuilder {
     }
 
     fn build_gitignore(&self) -> Result<()> {
-        debug!("[*]: Creating .gitignore");
+        debug!("Creating .gitignore");
 
         let mut f = File::create(self.root.join(".gitignore"))?;
 
@@ -154,7 +156,7 @@ impl BookBuilder {
     }
 
     fn create_stub_files(&self) -> Result<()> {
-        debug!("[*] Creating example book contents");
+        debug!("Creating example book contents");
         let src_dir = self.root.join(&self.config.book.src);
 
         let summary = src_dir.join("SUMMARY.md");
@@ -171,7 +173,7 @@ impl BookBuilder {
     }
 
     fn create_directory_structure(&self) -> Result<()> {
-        debug!("[*]: Creating directory tree");
+        debug!("Creating directory tree");
         fs::create_dir_all(&self.root)?;
 
         let src = self.root.join(&self.config.book.src);

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -240,7 +240,7 @@ impl<'a> SummaryParser<'a> {
     fn parse_affix(&mut self, is_prefix: bool) -> Result<Vec<SummaryItem>> {
         let mut items = Vec::new();
         debug!(
-            "[*] Parsing {} items",
+            "Parsing {} items",
             if is_prefix { "prefix" } else { "suffix" }
         );
 
@@ -362,7 +362,7 @@ impl<'a> SummaryParser<'a> {
     }
 
     fn parse_nested_numbered(&mut self, parent: &SectionNumber) -> Result<Vec<SummaryItem>> {
-        debug!("[*] Parsing numbered chapters at level {}", parent);
+        debug!("Parsing numbered chapters at level {}", parent);
         let mut items = Vec::new();
 
         loop {
@@ -406,7 +406,7 @@ impl<'a> SummaryParser<'a> {
                     let mut number = parent.clone();
                     number.0.push(num_existing_items as u32 + 1);
                     trace!(
-                        "[*] Found chapter: {} {} ({})",
+                        "Found chapter: {} {} ({})",
                         number,
                         link.name,
                         link.location.display()
@@ -435,7 +435,7 @@ impl<'a> SummaryParser<'a> {
     /// Try to parse the title line.
     fn parse_title(&mut self) -> Option<String> {
         if let Some(Event::Start(Tag::Header(1))) = self.next_event() {
-            debug!("[*] Found a h1 in the SUMMARY");
+            debug!("Found a h1 in the SUMMARY");
 
             let tags = collect_events!(self.stream, end Tag::Header(1));
             Some(stringify_events(tags))

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -47,7 +47,7 @@ fn find_chapter(
     rc: &mut RenderContext,
     target: Target
 ) -> Result<Option<StringMap>, RenderError> {
-    debug!("[*]: Get data from context");
+    debug!("Get data from context");
 
     let chapters = rc.evaluate_absolute("chapters").and_then(|c| {
         serde_json::value::from_value::<Vec<StringMap>>(c.clone())
@@ -61,7 +61,7 @@ fn find_chapter(
 
     let mut previous: Option<StringMap> = None;
 
-    debug!("[*]: Search for chapter");
+    debug!("Search for chapter");
 
     for item in chapters {
         match item.get("path") {
@@ -87,7 +87,7 @@ fn render(
     rc: &mut RenderContext,
     chapter: &StringMap,
 ) -> Result<(), RenderError> {
-    debug!("[*]: Creating BTreeMap to inject in context");
+    trace!("Creating BTreeMap to inject in context");
 
     let mut context = BTreeMap::new();
 
@@ -104,7 +104,7 @@ fn render(
                     .map(|p| context.insert("link".to_owned(), json!(p.replace("\\", "/"))))
             })?;
 
-    debug!("[*]: Render template");
+    trace!("Render template");
 
     _h.template()
         .ok_or_else(|| RenderError::new("Error with the handlebars template"))
@@ -117,7 +117,7 @@ fn render(
 }
 
 pub fn previous(_h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-    debug!("[fn]: previous (handlebars helper)");
+    trace!("previous (handlebars helper)");
 
     if let Some(previous) = find_chapter(rc, Target::Previous)? {
         render(_h, r, rc, &previous)?;
@@ -127,7 +127,7 @@ pub fn previous(_h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(
 }
 
 pub fn next(_h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-    debug!("[fn]: next (handlebars helper)");
+    trace!("next (handlebars helper)");
 
     if let Some(next) = find_chapter(rc, Target::Next)? {
         render(_h, r, rc, &next)?;


### PR DESCRIPTION
To be more in line with the "rule of silence" (only print output when the user needs to act on something) I've changed a lot of the logging from `info!()` to `debug!()`. This way it's a lot harder for errors and warnings to get buried in the noise.