### PR TITLE
Convert project to use RelativePath where appropriate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tempdir = "0.3.4"
 itertools = "0.7"
 shlex = "0.1"
 toml-query = "0.6"
+relative-path = { version = "0.3", features = ["serde"] }
 
 # Watch feature
 notify = { version = "4.0", optional = true }

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -221,13 +221,13 @@ impl MDBook {
 
         for item in self.iter() {
             if let BookItem::Chapter(ref ch) = *item {
-                if !ch.path.as_os_str().is_empty() {
-                    let path = self.source_dir().join(&ch.path);
+                if !ch.path.as_str().is_empty() {
+                    let path = ch.path.to_path(self.source_dir());
                     let content = utils::fs::file_to_string(&path)?;
                     info!("Testing file: {:?}", path);
 
                     // write preprocessed file to tempdir
-                    let path = temp_dir.path().join(&ch.path);
+                    let path = ch.path.to_path(temp_dir.path());
                     let mut tmpf = utils::fs::create_file(&path)?;
                     tmpf.write_all(content.as_bytes())?;
 

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -1,9 +1,9 @@
 use std::fmt::{self, Display, Formatter};
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
-use std::path::{Path, PathBuf};
 use memchr::{self, Memchr};
 use pulldown_cmark::{self, Alignment, Event, Tag};
+use relative_path::{RelativePath, RelativePathBuf};
 use errors::*;
 
 /// Parse the text from a `SUMMARY.md` file into a sort of "recipe" to be
@@ -71,7 +71,7 @@ pub struct Link {
     pub name: String,
     /// The location of the chapter's source file, taking the book's `src`
     /// directory as the root.
-    pub location: PathBuf,
+    pub location: RelativePathBuf,
     /// The section number, if this chapter is in the numbered section.
     pub number: Option<SectionNumber>,
     /// Any nested items this chapter may contain.
@@ -80,10 +80,10 @@ pub struct Link {
 
 impl Link {
     /// Create a new link with no nested items.
-    pub fn new<S: Into<String>, P: AsRef<Path>>(name: S, location: P) -> Link {
+    pub fn new<S: Into<String>, P: AsRef<RelativePath>>(name: S, location: P) -> Link {
         Link {
             name: name.into(),
-            location: location.as_ref().to_path_buf(),
+            location: location.as_ref().to_relative_path_buf(),
             number: None,
             nested_items: Vec::new(),
         }
@@ -94,7 +94,7 @@ impl Default for Link {
     fn default() -> Self {
         Link {
             name: String::new(),
-            location: PathBuf::new(),
+            location: RelativePathBuf::new(),
             number: None,
             nested_items: Vec::new(),
         }
@@ -277,7 +277,7 @@ impl<'a> SummaryParser<'a> {
         } else {
             Ok(Link {
                 name: name,
-                location: PathBuf::from(href.to_string()),
+                location: RelativePathBuf::from(href.to_string()),
                 number: None,
                 nested_items: Vec::new(),
             })
@@ -617,12 +617,12 @@ mod tests {
         let should_be = vec![
             SummaryItem::Link(Link {
                 name: String::from("First"),
-                location: PathBuf::from("./first.md"),
+                location: RelativePathBuf::from("./first.md"),
                 ..Default::default()
             }),
             SummaryItem::Link(Link {
                 name: String::from("Second"),
-                location: PathBuf::from("./second.md"),
+                location: RelativePathBuf::from("./second.md"),
                 ..Default::default()
             }),
         ];
@@ -661,7 +661,7 @@ mod tests {
         let src = "[First](./first.md)";
         let should_be = Link {
             name: String::from("First"),
-            location: PathBuf::from("./first.md"),
+            location: RelativePathBuf::from("./first.md"),
             ..Default::default()
         };
 
@@ -682,7 +682,7 @@ mod tests {
         let src = "- [First](./first.md)\n";
         let link = Link {
             name: String::from("First"),
-            location: PathBuf::from("./first.md"),
+            location: RelativePathBuf::from("./first.md"),
             number: Some(SectionNumber(vec![1])),
             ..Default::default()
         };
@@ -703,12 +703,12 @@ mod tests {
         let should_be = vec![
             SummaryItem::Link(Link {
                 name: String::from("First"),
-                location: PathBuf::from("./first.md"),
+                location: RelativePathBuf::from("./first.md"),
                 number: Some(SectionNumber(vec![1])),
                 nested_items: vec![
                     SummaryItem::Link(Link {
                         name: String::from("Nested"),
-                        location: PathBuf::from("./nested.md"),
+                        location: RelativePathBuf::from("./nested.md"),
                         number: Some(SectionNumber(vec![1, 1])),
                         nested_items: Vec::new(),
                     }),
@@ -716,7 +716,7 @@ mod tests {
             }),
             SummaryItem::Link(Link {
                 name: String::from("Second"),
-                location: PathBuf::from("./second.md"),
+                location: RelativePathBuf::from("./second.md"),
                 number: Some(SectionNumber(vec![2])),
                 nested_items: Vec::new(),
             }),
@@ -740,13 +740,13 @@ mod tests {
         let should_be = vec![
             SummaryItem::Link(Link {
                 name: String::from("First"),
-                location: PathBuf::from("./first.md"),
+                location: RelativePathBuf::from("./first.md"),
                 number: Some(SectionNumber(vec![1])),
                 nested_items: Vec::new(),
             }),
             SummaryItem::Link(Link {
                 name: String::from("Second"),
-                location: PathBuf::from("./second.md"),
+                location: RelativePathBuf::from("./second.md"),
                 number: Some(SectionNumber(vec![2])),
                 nested_items: Vec::new(),
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ extern crate shlex;
 extern crate tempdir;
 extern crate toml;
 extern crate toml_query;
+extern crate relative_path;
 
 #[cfg(test)]
 #[macro_use]
@@ -114,7 +115,7 @@ pub use config::Config;
 
 /// The error types used through out this crate.
 pub mod errors {
-    use std::path::PathBuf;
+    use relative_path::RelativePathBuf;
 
     error_chain!{
         foreign_links {
@@ -142,7 +143,7 @@ pub mod errors {
             }
 
             /// The user tried to use a reserved filename.
-            ReservedFilenameError(filename: PathBuf) {
+            ReservedFilenameError(filename: RelativePathBuf) {
                 description("Reserved Filename")
                 display("{} is reserved for internal use", filename.display())
             }

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -31,10 +31,10 @@ impl Preprocessor for LinkPreprocessor {
 
         book.for_each_mut(|section: &mut BookItem| {
             if let BookItem::Chapter(ref mut ch) = *section {
-                let base = ch.path
+                let base = ch.path.to_path(&src_dir)
                     .parent()
-                    .map(|dir| src_dir.join(dir))
-                    .expect("All book items have a parent");
+                    .expect("All book items have a parent")
+                    .to_owned();
 
                 let content = replace_all(&ch.content, base);
                 ch.content = content;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 use errors::*;
 use std::io::Read;
 use std::fs::{self, File};
@@ -14,48 +14,6 @@ pub fn file_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
         .chain_err(|| "Unable to read the file")?;
 
     Ok(content)
-}
-
-/// Takes a path and returns a path containing just enough `../` to point to
-/// the root of the given path.
-///
-/// This is mostly interesting for a relative path to point back to the
-/// directory from where the path starts.
-///
-/// ```rust
-/// # extern crate mdbook;
-/// #
-/// # use std::path::Path;
-/// # use mdbook::utils::fs::path_to_root;
-/// #
-/// # fn main() {
-/// let path = Path::new("some/relative/path");
-/// assert_eq!(path_to_root(path), "../../");
-/// # }
-/// ```
-///
-/// **note:** it's not very fool-proof, if you find a situation where
-/// it doesn't return the correct path.
-/// Consider [submitting a new issue](https://github.com/rust-lang-nursery/mdBook/issues)
-/// or a [pull-request](https://github.com/rust-lang-nursery/mdBook/pulls) to improve it.
-
-pub fn path_to_root<P: Into<PathBuf>>(path: P) -> String {
-    debug!("path_to_root");
-    // Remove filename and add "../" for every directory
-
-    path.into()
-        .parent()
-        .expect("")
-        .components()
-        .fold(String::new(), |mut s, c| {
-            match c {
-                Component::Normal(_) => s.push_str("../"),
-                _ => {
-                    debug!("Other path component... {:?}", c);
-                }
-            }
-            s
-        })
 }
 
 /// This function creates a file and returns it. But before creating the file


### PR DESCRIPTION
This switches the project to use `RelativePath` where it is more appropriate than `Path`.

Relative paths have consistent directory separators, and platform-neutral serialization (helps when converting to JSON). They are converted into `Path`s through `RelativePath::to_path`, which is provided the path that they are relative to.

This means that some of the awkward "convert back to relative path, or a platform neutral variant" patterns can be avoided (stop using `path_to_root`, `normalize_path`, and probably more that I haven't cleaned up yet).

This will also help with #589 since relative paths can easily be normalized to determine if a link destination exists or not.

I've compiled both editions of the rust book, and the example project. And both come up with a no-op diff.