### PR TITLE
Export the mdbook version from the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,12 @@ pub mod renderer;
 pub mod theme;
 pub mod utils;
 
+/// The current version of `mdbook`.
+///
+/// This is provided as a way for custom preprocessors and renderers to do
+/// compatibility checks.
+pub const MDBOOK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub use book::BookItem;
 pub use book::MDBook;
 pub use config::Config;

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -21,12 +21,21 @@ pub struct PreprocessorContext {
     pub config: Config,
     /// The `Renderer` this preprocessor is being used with.
     pub renderer: String,
+    /// The calling `mdbook` version.
+    pub mdbook_version: String,
+    __non_exhaustive: (),
 }
 
 impl PreprocessorContext {
     /// Create a new `PreprocessorContext`.
     pub(crate) fn new(root: PathBuf, config: Config, renderer: String) -> Self {
-        PreprocessorContext { root, config, renderer }
+        PreprocessorContext {
+            root,
+            config,
+            renderer,
+            mdbook_version: ::MDBOOK_VERSION.to_string(),
+            __non_exhaustive: (),
+        }
     }
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,8 +26,6 @@ use book::Book;
 use config::Config;
 use errors::*;
 
-const MDBOOK_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 /// An arbitrary `mdbook` backend.
 ///
 /// Although it's quite possible for you to import `mdbook` as a library and
@@ -78,7 +76,7 @@ impl RenderContext {
         RenderContext {
             book: book,
             config: config,
-            version: MDBOOK_VERSION.to_string(),
+            version: ::MDBOOK_VERSION.to_string(),
             root: root.into(),
             destination: destination.into(),
         }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -64,6 +64,7 @@ pub struct RenderContext {
     /// renderers to cache intermediate results, this directory is not
     /// guaranteed to be empty or even exist.
     pub destination: PathBuf,
+    __non_exhaustive: (),
 }
 
 impl RenderContext {
@@ -79,6 +80,7 @@ impl RenderContext {
             version: ::MDBOOK_VERSION.to_string(),
             root: root.into(),
             destination: destination.into(),
+            __non_exhaustive: (),
         }
     }
 


### PR DESCRIPTION
This allows custom preprocessors and renderers to use the `semver` crate to make sure they're compatible with whatever version of `mdbook` is calling them.