### PR TITLE
Build Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM rust:1.30.1-stretch
 
-RUN cargo install mdbook --no-default-features
+ARG VERSION
+
+RUN cargo install --vers "$VERSION" mdbook --no-default-features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM rust:1.30.1-stretch
+
+RUN cargo install mdbook --no-default-features

--- a/bin/releaseDocker.sh
+++ b/bin/releaseDocker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# USAGE: ./bin/releaseDocker.sh <ACCOUNT_NAME> <VERSION>
+#
+# Example usage: ./bin/releaseDocker.sh dockeruser 0.2.1
+
+set -e
+
+SCRIPT_DIRECTORY="$(dirname "$0")"
+PROJECT_DIRECTORY="$(dirname "${SCRIPT_DIRECTORY}")"
+
+cd "${PROJECT_DIRECTORY}"
+
+docker build --no-cache  -t mdbook .
+docker tag mdbook "${1}/mdbook:${2}"
+
+echo "To run image:"
+echo docker run -it mdbook sh
+
+echo "To push (publish) image"
+echo docker push "${1}/mdbook:${2}"
+

--- a/bin/releaseDocker.sh
+++ b/bin/releaseDocker.sh
@@ -11,7 +11,7 @@ PROJECT_DIRECTORY="$(dirname "${SCRIPT_DIRECTORY}")"
 
 cd "${PROJECT_DIRECTORY}"
 
-docker build --no-cache  -t mdbook .
+docker build --no-cache --build-arg VERSION="${2}" -t mdbook .
 docker tag mdbook "${1}/mdbook:${2}"
 
 echo "To run image:"


### PR DESCRIPTION
Useful for GitLab CI. Compared to job installing `mdBook`, runtime decreased from `8m 30s` to `1m 18s`, which saves lots of time.

For example, can be used with job declaration mentioned in #813:

```yaml
pages:
  # https://hub.docker.com/_/rust/
  image: "kravemir/mdbook:0.2.1"
  stage: pages
  script:
    - mkdir public-tmp
    - ./bin/copyJavadocToBook.sh
    - mdbook build docs
    - cp -r docs/book/* public-tmp
    - mv public-tmp public
    - find $PWD/public
  artifacts:
    paths:
      - public
```

I had built it for myself and pushed to https://hub.docker.com/r/kravemir/mdbook/, with command:

```bash
./bin/releaseDocker.sh kravemir 0.2.1
```

IMHO: there's lots of space for improvements, but this provides at least initial working image, which can be used to build mdBook GitLab Pages with GitLab Runner quite easily.