### PR TITLE
Add {{#includecomment }} to src/preprocess/links.rs

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,7 @@ use pulldown_cmark::{
 
 use std::borrow::Cow;
 
-pub use self::string::{take_lines, RangeArgument};
+pub use self::string::{take_lines, take_lines_commented, RangeArgument};
 
 /// Replaces multiple consecutive whitespace characters with a single space character.
 pub fn collapse_whitespace<'a>(text: &'a str) -> Cow<'a, str> {

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -55,6 +55,16 @@ pub fn take_lines<R: RangeArgument<usize>>(s: &str, range: R) -> String {
     }
 }
 
+/// Take a range of lines from a string.
+pub fn take_lines_commented<R: RangeArgument<usize>>(s: &str, range: R) -> String {
+    let start = *range.start().unwrap_or(&0);
+    let mut lines = s.lines().skip(start);
+    match range.end() {
+        Some(&end) => String::from("# ") + &lines.take(end.saturating_sub(start)).join("\n# "),
+        None => String::from("# ") + &lines.join("\n# "),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::take_lines;


### PR DESCRIPTION
{{#includecomment }} adds a file with the lines prefixed with '# '.
This automatically hides the code.

This is very useful for library documentation, where you want to do:
```
~~~rust
use crate::mycrate::*;
{{#include ../examples/tutorial.rs:2:}}
{{#includecomment ../src/lib.rs}}
~~~
```
I didn't write a separate preprocessor, because of the massive code
reuse.