### PR TITLE
stop auto-wrapping code snippets in fn main()

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -579,21 +579,7 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
                 || classes.contains("mdbook-runnable")
             {
                 // wrap the contents in an external pre block
-                if playpen_config.editable && classes.contains("editable")
-                    || text.contains("fn main")
-                    || text.contains("quick_main!")
-                {
-                    format!("<pre class=\"playpen\">{}</pre>", text)
-                } else {
-                    // we need to inject our own main
-                    let (attrs, code) = partition_source(code);
-
-                    format!(
-                        "<pre class=\"playpen\"><code class=\"{}\">\n# \
-                         #![allow(unused_variables)]\n{}#fn main() {{\n{}#}}</code></pre>",
-                        classes, attrs, code
-                    )
-                }
+                format!("<pre class=\"playpen\">{}</pre>", text)
             } else {
                 // not language-rust, so no-op
                 text.to_owned()


### PR DESCRIPTION
I'm guessing this would be a semver breaking change, but would be happy to do the accompanying work of migrating code snippets in https://github.com/rust-lang/book to include `fn main() {}` wrapping explicitly (and `#![allow(unused_variables)]` where necessary) if this change is accepted (and the book migration could actually happen first because of the current `text.contains("fn main")` exclusion).

This seems to be a somewhat persistent issue in code snippet formatting in the Rust book, particularly for `src/lib.rs` files, with [some awkward fixes](https://github.com/rust-lang/book/pull/1339) (see expanded Listing 11-12 in https://doc.rust-lang.org/stable/book/ch11-03-test-organization.html for implications of this approach, extraneous code still added) without a particularly good solution (using the `ignore` class seems [undesirable](https://github.com/rust-lang-nursery/mdBook/issues/712#issuecomment-398902592)).

An alternative implementation could be adding support for a class like `nomain` or `nowrap` instead of changing this default behavior.

Refs #222 for initial implementation, #283 (`quick_main!` macro), #618, #712, https://github.com/rust-lang/book/issues/1206, https://github.com/rust-lang/book/issues/1874 (`editable` prevents `fn main()` wrapping), https://github.com/rust-lang/book/issues/1982

Examples of problematic code snippets in the Rust book:
- https://doc.rust-lang.org/stable/book/ch11-03-test-organization.html
- https://doc.rust-lang.org/stable/book/ch15-05-interior-mutability.html#a-use-case-for-interior-mutability-mock-objects
- https://doc.rust-lang.org/stable/book/ch17-02-trait-objects.html
- https://doc.rust-lang.org/stable/book/ch17-03-oo-design-patterns.html#defining-post-and-creating-a-new-instance-in-the-draft-state