### PR TITLE
ui: Fix the "Next chapter" link position

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -162,7 +162,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
 
 .next {
     float: right;
-    right: var(--page-padding);
+    right: 0;
 }
 
 @media only screen and (max-width: 1080px) {


### PR DESCRIPTION
Remove the gap between it and the right edge of the page.

Demo: https://wofwca.github.io/mdBook/format/config.html

This reverts f1cd9f54c243ac1da136c3cbddf6b6cf622deae7 (That fixed /rust-lang/book/issues/29)
The page layout has been restructured and this workaround is no
longer required