### PR TITLE
Offline support fixes #546

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -6,6 +6,7 @@ language = "en"
 
 [output.html]
 mathjax-support = true
+offline-support = true
 
 [output.html.playpen]
 editable = true

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -1,8 +1,8 @@
 # Configuration
 
-You can configure the parameters for your book in the ***book.toml*** file.
+You can configure the parameters for your book in the **_book.toml_** file.
 
-Here is an example of what a ***book.toml*** file might look like:
+Here is an example of what a **_book.toml_** file might look like:
 
 ```toml
 [book]
@@ -45,6 +45,7 @@ This is general information about your book.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
 
 **book.toml**
+
 ```toml
 [book]
 title = "Example book"
@@ -87,8 +88,8 @@ The following preprocessors are available and included by default:
   to say, all `README.md` would be rendered to an index file `index.html` in the
   rendered book.
 
-
 **book.toml**
+
 ```toml
 [build]
 build-dir = "build"
@@ -148,6 +149,8 @@ The following configuration options are available:
 - **theme:** mdBook comes with a default theme and all the resource files needed
   for it. But if this option is set, mdBook will selectively overwrite the theme
   files with the ones found in the specified folder.
+- **offline-support** Precache the chapters so that users can view the book
+  while offline. Available in [browsers supporting Service Worker](https://caniuse.com/#feat=serviceworkers).
 - **default-theme:** The theme color scheme to select by default in the
   'Change Theme' dropdown. Defaults to `light`.
 - **preferred-dark-theme:** The default dark theme. This theme will be used if
@@ -173,7 +176,7 @@ The following configuration options are available:
 - **playpen:** A subtable for configuring various playpen settings.
 - **search:** A subtable for configuring the in-browser search functionality.
   mdBook must be compiled with the `search` feature enabled (on by default).
-- **git-repository-url:**  A url to the git repository for the book. If provided
+- **git-repository-url:** A url to the git repository for the book. If provided
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
@@ -186,7 +189,7 @@ Available configuration options for the `[output.html.playpen]` table:
   Defaults to `true`.
 - **line-numbers** Display line numbers on editable sections of code. Requires both `editable` and `copy-js` to be `true`. Defaults to `false`.
 
-[Ace]: https://ace.c9.io/
+[ace]: https://ace.c9.io/
 
 Available configuration options for the `[output.html.search]` table:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,6 +447,8 @@ pub struct HtmlConfig {
     pub curly_quotes: bool,
     /// Should mathjax be enabled?
     pub mathjax_support: bool,
+    /// Cache chapters for offline viewing
+    pub offline_support: bool,
     /// An optional google analytics code.
     pub google_analytics: Option<String>,
     /// Additional CSS stylesheets to include in the rendered page's `<head>`.
@@ -609,6 +611,7 @@ mod tests {
         default-theme = "rust"
         curly-quotes = true
         google-analytics = "123456"
+        offline-support = true
         additional-css = ["./foo/bar/baz.css"]
         git-repository-url = "https://foo.com/"
         git-repository-icon = "fa-code-fork"
@@ -647,6 +650,7 @@ mod tests {
         };
         let html_should_be = HtmlConfig {
             curly_quotes: true,
+            offline_support: true,
             google_analytics: Some(String::from("123456")),
             additional_css: vec![PathBuf::from("./foo/bar/baz.css")],
             theme: Some(PathBuf::from("./themedir")),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -58,7 +58,7 @@ impl HtmlHandlebars {
         }
 
          content.push_str("];\n");
-        content.push_str("\nworkbox.precache(chapters);\n");
+        content.push_str("\nworkbox.precaching.precacheAndRoute(chapters);\n");
 
          file.write(content.as_bytes())?;
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -7,11 +7,11 @@ use crate::theme::{self, playpen_editor, Theme};
 use crate::utils;
 
 use std::borrow::Cow;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
 use std::fs::{self, OpenOptions};
+use std::hash::Hasher;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -32,15 +32,19 @@ impl HtmlHandlebars {
         HtmlHandlebars
     }
 
-    fn build_service_worker(&self, build_dir: &Path, chapter_files: &Vec<ChapterFile>) -> Result<()> {
+    fn build_service_worker(
+        &self,
+        build_dir: &Path,
+        chapter_files: &Vec<ChapterFile>,
+    ) -> Result<()> {
         let path = build_dir.join("sw.js");
         let mut file = OpenOptions::new().append(true).open(path)?;
         let mut content = String::from("\nconst chapters = [\n");
 
-         for chapter_file in chapter_files {
+        for chapter_file in chapter_files {
             content.push_str("  { url: ");
 
-             // Rewrite "/" to point to the current directory
+            // Rewrite "/" to point to the current directory
             // https://rust-lang-nursery.github.io/ => https://rust-lang-nursery.github.io/mdBook/
             // location.href is https://rust-lang-nursery.github.io/mdBook/sw.js
             // so we remove the sw.js from the end to get the correct path
@@ -52,17 +56,17 @@ impl HtmlHandlebars {
                 content.push_str("'");
             }
 
-             content.push_str(", revision: '");
+            content.push_str(", revision: '");
             content.push_str(&chapter_file.revision.to_string());
             content.push_str("' },\n");
         }
 
-         content.push_str("];\n");
+        content.push_str("];\n");
         content.push_str("\nworkbox.precaching.precacheAndRoute(chapters);\n");
 
-         file.write(content.as_bytes())?;
+        file.write(content.as_bytes())?;
 
-         Ok(())
+        Ok(())
     }
 
     fn render_item(
@@ -90,9 +94,9 @@ impl HtmlHandlebars {
                 .to_str()
                 .chain_err(|| "Could not convert path to str")?;
             let filepath = Path::new(&ch.path).with_extension("html");
-	        let filepath_str = filepath.to_str().ok_or_else(|| {
-                Error::from(format!("Bad file name: {}", filepath.display()))
-            })?;
+            let filepath_str = filepath
+                .to_str()
+                .ok_or_else(|| Error::from(format!("Bad file name: {}", filepath.display())))?;
 
             // "print.html" is used for the print page.
             if ch.path == Path::new("print.md") {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -548,6 +548,10 @@ fn make_data(
         )
     }
 
+    if html_config.offline_support {
+        data.insert("offline_support".to_owned(), json!(true));
+    }
+
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
     }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -62,7 +62,7 @@ impl HtmlHandlebars {
         }
 
         content.push_str("];\n");
-        content.push_str("\nworkbox.precaching.precacheAndRoute(chapters);\n");
+        content.push_str("\nworkbox.precaching.precacheAndRoute(chapters, {ignoreURLParametersMatching: [/.*/]});\n");
 
         file.write(content.as_bytes())?;
 

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -600,9 +600,15 @@ function playpen_text(playpen) {
   var isLocalhost =
     ["localhost", "127.0.0.1", ""].indexOf(document.location.hostname) !== -1;
 
-  if ("serviceWorker" in navigator && !isLocalhost) {
-    navigator.serviceWorker.register("sw.js").catch(function(error) {
-      console.error("Service worker registration failed:", error);
-    });
+  if (
+    window.sevice_worker_script_src &&
+    "serviceWorker" in navigator &&
+    !isLocalhost
+  ) {
+    navigator.serviceWorker
+      .register(window.sevice_worker_script_src)
+      .catch(function(error) {
+        console.error("Service worker registration failed:", error);
+      });
   }
 })();

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -594,3 +594,17 @@ function playpen_text(playpen) {
         previousScrollTop = document.scrollingElement.scrollTop;
     }, { passive: true });
 })();
+
+
+(function serviceWorker() {
+  var isLocalhost =
+    ["localhost", "127.0.0.1", ""].indexOf(document.location.hostname) !== -1;
+
+  if ("serviceWorker" in navigator && true) {
+    navigator.serviceWorker
+      .register(document.baseURI + "sw.js")
+      .catch(function(error) {
+        console.error("Service worker registration failed:", error);
+      });
+  }
+})();

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -602,7 +602,7 @@ function playpen_text(playpen) {
 
   if ("serviceWorker" in navigator && !isLocalhost) {
     navigator.serviceWorker
-      .register(document.baseURI + "sw.js")
+      .register(document.location.origin + "/sw.js")
       .catch(function(error) {
         console.error("Service worker registration failed:", error);
       });

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -601,10 +601,8 @@ function playpen_text(playpen) {
     ["localhost", "127.0.0.1", ""].indexOf(document.location.hostname) !== -1;
 
   if ("serviceWorker" in navigator && !isLocalhost) {
-    navigator.serviceWorker
-      .register(document.location.origin + "/sw.js")
-      .catch(function(error) {
-        console.error("Service worker registration failed:", error);
-      });
+    navigator.serviceWorker.register("sw.js").catch(function(error) {
+      console.error("Service worker registration failed:", error);
+    });
   }
 })();

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -600,7 +600,7 @@ function playpen_text(playpen) {
   var isLocalhost =
     ["localhost", "127.0.0.1", ""].indexOf(document.location.hostname) !== -1;
 
-  if ("serviceWorker" in navigator && true) {
+  if ("serviceWorker" in navigator && !isLocalhost) {
     navigator.serviceWorker
       .register(document.baseURI + "sw.js")
       .catch(function(error) {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -601,12 +601,12 @@ function playpen_text(playpen) {
     ["localhost", "127.0.0.1", ""].indexOf(document.location.hostname) !== -1;
 
   if (
-    window.sevice_worker_script_src &&
+    window.service_worker_script_src &&
     "serviceWorker" in navigator &&
     !isLocalhost
   ) {
     navigator.serviceWorker
-      .register(window.sevice_worker_script_src)
+      .register(window.service_worker_script_src)
       .catch(function(error) {
         console.error("Service worker registration failed:", error);
       });

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -259,7 +259,7 @@
         {{#if offline_support}}
         <script type="text/javascript">
             // Must insert before loading book.js
-            window.sevice_worker_script_src = "{{ path_to_root }}sw.js";
+            window.service_worker_script_src = "{{ path_to_root }}sw.js";
         </script>
         {{/if}}
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -235,7 +235,7 @@
             window.playpen_line_numbers = true;
         </script>
         {{/if}}
-        
+
         {{#if playpen_copyable}}
         <script type="text/javascript">
             window.playpen_copyable = true;
@@ -254,6 +254,13 @@
         <script src="{{ path_to_root }}elasticlunr.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="{{ path_to_root }}mark.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="{{ path_to_root }}searcher.js" type="text/javascript" charset="utf-8"></script>
+        {{/if}}
+
+        {{#if offline_support}}
+        <script type="text/javascript">
+            // Must insert before loading book.js
+            window.sevice_worker_script_src = "{{ path_to_root }}sw.js";
+        </script>
         {{/if}}
 
         <script src="{{ path_to_root }}clipboard.min.js" type="text/javascript" charset="utf-8"></script>

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -23,6 +23,7 @@ pub static HIGHLIGHT_JS: &[u8] = include_bytes!("highlight.js");
 pub static TOMORROW_NIGHT_CSS: &[u8] = include_bytes!("tomorrow-night.css");
 pub static HIGHLIGHT_CSS: &[u8] = include_bytes!("highlight.css");
 pub static AYU_HIGHLIGHT_CSS: &[u8] = include_bytes!("ayu-highlight.css");
+pub static SERVICE_WORKER: &'static [u8] = include_bytes!("sw.js");
 pub static CLIPBOARD_JS: &[u8] = include_bytes!("clipboard.min.js");
 pub static FONT_AWESOME: &[u8] = include_bytes!("FontAwesome/css/font-awesome.min.css");
 pub static FONT_AWESOME_EOT: &[u8] = include_bytes!("FontAwesome/fonts/fontawesome-webfont.eot");
@@ -52,6 +53,7 @@ pub struct Theme {
     pub highlight_css: Vec<u8>,
     pub tomorrow_night_css: Vec<u8>,
     pub ayu_highlight_css: Vec<u8>,
+    pub service_worker: Vec<u8>,
     pub highlight_js: Vec<u8>,
     pub clipboard_js: Vec<u8>,
 }
@@ -84,6 +86,7 @@ impl Theme {
                 (theme_dir.join("favicon.png"), &mut theme.favicon),
                 (theme_dir.join("highlight.js"), &mut theme.highlight_js),
                 (theme_dir.join("clipboard.min.js"), &mut theme.clipboard_js),
+                (theme_dir.join("sw.js"), &mut theme.service_worker),
                 (theme_dir.join("highlight.css"), &mut theme.highlight_css),
                 (
                     theme_dir.join("tomorrow-night.css"),
@@ -124,6 +127,7 @@ impl Default for Theme {
             highlight_css: HIGHLIGHT_CSS.to_owned(),
             tomorrow_night_css: TOMORROW_NIGHT_CSS.to_owned(),
             ayu_highlight_css: AYU_HIGHLIGHT_CSS.to_owned(),
+            service_worker: SERVICE_WORKER.to_owned(),
             highlight_js: HIGHLIGHT_JS.to_owned(),
             clipboard_js: CLIPBOARD_JS.to_owned(),
         }
@@ -204,6 +208,7 @@ mod tests {
             highlight_css: Vec::new(),
             tomorrow_night_css: Vec::new(),
             ayu_highlight_css: Vec::new(),
+            service_worker: Vec::new(),
             highlight_js: Vec::new(),
             clipboard_js: Vec::new(),
         };

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -180,6 +180,7 @@ mod tests {
             "css/variables.css",
             "book.js",
             "highlight.js",
+            "sw.js",
             "tomorrow-night.css",
             "highlight.css",
             "ayu-highlight.css",

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -30,7 +30,7 @@ workbox.routing.registerRoute(
 
 // Local resources
 workbox.routing.registerRoute(
-  /\.(woff2?|ttf|css|js|json|png|svg)$/,
+  /\.(woff2?|ttf|css|js|json|png|svg)(\?v\=.*)?$/,
   staleWhileRevalidate
 );
 

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -30,7 +30,7 @@ workbox.routing.registerRoute(
 
 // Local resources
 workbox.routing.registerRoute(
-  new RegExp(".woff2?|.ttf|.css|.js|.json"),
+  new RegExp(".woff2?|.ttf|.css|.js|.json|.png|.svg"),
   staleWhileRevalidate
 );
 

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -30,7 +30,7 @@ workbox.routing.registerRoute(
 
 // Local resources
 workbox.routing.registerRoute(
-  new RegExp(".woff2?|.ttf|.css|.js|.json|.png|.svg"),
+  /\.(woff2?|ttf|css|js|json|png|svg)$/,
   staleWhileRevalidate
 );
 

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -1,0 +1,46 @@
+importScripts(
+  "https://unpkg.com/workbox-sw@2.0.3/build/importScripts/workbox-sw.dev.v2.0.3.js"
+);
+
+// clientsClaims tells the Service Worker to take control as soon as it's activated
+const workbox = new WorkboxSW({ clientsClaim: true });
+
+// https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate
+// TLDR: If there's a cached version available, use it, but fetch an update for next time.
+const staleWhileRevalidate = workbox.strategies.staleWhileRevalidate();
+
+// Remote fonts and JavaScript libraries
+workbox.router.registerRoute(
+  new RegExp("https://fonts.googleapis.com/css"),
+  staleWhileRevalidate
+);
+workbox.router.registerRoute(
+  new RegExp("https://fonts.gstatic.com"),
+  staleWhileRevalidate
+);
+workbox.router.registerRoute(
+  new RegExp("https://maxcdn.bootstrapcdn.com/font-awesome"),
+  staleWhileRevalidate
+);
+workbox.router.registerRoute(
+  new RegExp("https://cdnjs.cloudflare.com/ajax/libs/mathjax"),
+  staleWhileRevalidate
+);
+workbox.router.registerRoute(
+  new RegExp("https://cdn.jsdelivr.net/clipboard.js"),
+  staleWhileRevalidate
+);
+
+// Local resources
+workbox.router.registerRoute(new RegExp(".js$"), staleWhileRevalidate);
+workbox.router.registerRoute(new RegExp(".css$"), staleWhileRevalidate);
+
+// Here hbs_renderer.rs will inject the chapters, making sure they are precached.
+//
+// const chapters = [
+//     { url: '/', revision: '11120' },
+//     { url: 'cli/cli-tool.html', revision: '12722' },
+//     { url: 'cli/init.html', revision: '12801' },
+// ];
+//
+//   workbox.precaching.precacheAndRoute(chapters);

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -29,8 +29,10 @@ workbox.routing.registerRoute(
 );
 
 // Local resources
-workbox.routing.registerRoute(new RegExp(".js$"), staleWhileRevalidate);
-workbox.routing.registerRoute(new RegExp(".css$"), staleWhileRevalidate);
+workbox.routing.registerRoute(
+  new RegExp(".woff2?|.ttf|.css|.js|.json"),
+  staleWhileRevalidate
+);
 
 // Here hbs_renderer.rs will inject the chapters, making sure they are precached.
 //

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -1,39 +1,36 @@
 importScripts(
-  "https://unpkg.com/workbox-sw@2.0.3/build/importScripts/workbox-sw.dev.v2.0.3.js"
+  "https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js"
 );
-
-// clientsClaims tells the Service Worker to take control as soon as it's activated
-const workbox = new WorkboxSW({ clientsClaim: true });
 
 // https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate
 // TLDR: If there's a cached version available, use it, but fetch an update for next time.
-const staleWhileRevalidate = workbox.strategies.staleWhileRevalidate();
+const staleWhileRevalidate = new workbox.strategies.StaleWhileRevalidate();
 
 // Remote fonts and JavaScript libraries
-workbox.router.registerRoute(
+workbox.routing.registerRoute(
   new RegExp("https://fonts.googleapis.com/css"),
   staleWhileRevalidate
 );
-workbox.router.registerRoute(
+workbox.routing.registerRoute(
   new RegExp("https://fonts.gstatic.com"),
   staleWhileRevalidate
 );
-workbox.router.registerRoute(
+workbox.routing.registerRoute(
   new RegExp("https://maxcdn.bootstrapcdn.com/font-awesome"),
   staleWhileRevalidate
 );
-workbox.router.registerRoute(
+workbox.routing.registerRoute(
   new RegExp("https://cdnjs.cloudflare.com/ajax/libs/mathjax"),
   staleWhileRevalidate
 );
-workbox.router.registerRoute(
+workbox.routing.registerRoute(
   new RegExp("https://cdn.jsdelivr.net/clipboard.js"),
   staleWhileRevalidate
 );
 
 // Local resources
-workbox.router.registerRoute(new RegExp(".js$"), staleWhileRevalidate);
-workbox.router.registerRoute(new RegExp(".css$"), staleWhileRevalidate);
+workbox.routing.registerRoute(new RegExp(".js$"), staleWhileRevalidate);
+workbox.routing.registerRoute(new RegExp(".css$"), staleWhileRevalidate);
 
 // Here hbs_renderer.rs will inject the chapters, making sure they are precached.
 //

--- a/src/theme/sw.js
+++ b/src/theme/sw.js
@@ -2,6 +2,11 @@ importScripts(
   "https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js"
 );
 
+self.addEventListener("install", event => {
+  // Take over old service worker immediately, should hopefully fix weird caching issues
+  self.skipWaiting();
+});
+
 // https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate
 // TLDR: If there's a cached version available, use it, but fetch an update for next time.
 const staleWhileRevalidate = new workbox.strategies.StaleWhileRevalidate();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -359,8 +359,7 @@ more text with spaces
 ```
 "#;
 
-            let expected =
-                r#"<pre><code class="language-rust,no_run,should_panic,property_3"></code></pre>
+            let expected = r#"<pre><code class="language-rust,no_run,should_panic,property_3"></code></pre>
 "#;
             assert_eq!(render_markdown(input, false), expected);
             assert_eq!(render_markdown(input, true), expected);
@@ -373,8 +372,7 @@ more text with spaces
 ```
 "#;
 
-            let expected =
-                r#"<pre><code class="language-rust,no_run,,,should_panic,,property_3"></code></pre>
+            let expected = r#"<pre><code class="language-rust,no_run,,,should_panic,,property_3"></code></pre>
 "#;
             assert_eq!(render_markdown(input, false), expected);
             assert_eq!(render_markdown(input, true), expected);

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -481,12 +481,15 @@ fn markdown_options() {
             "<td>bim</td>",
         ],
     );
-    assert_contains_strings(&path, &[
-        r##"<sup class="footnote-reference"><a href="#1">1</a></sup>"##,
-        r##"<sup class="footnote-reference"><a href="#word">2</a></sup>"##,
-        r##"<div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>"##,
-        r##"<div class="footnote-definition" id="word"><sup class="footnote-definition-label">2</sup>"##,
-    ]);
+    assert_contains_strings(
+        &path,
+        &[
+            r##"<sup class="footnote-reference"><a href="#1">1</a></sup>"##,
+            r##"<sup class="footnote-reference"><a href="#word">2</a></sup>"##,
+            r##"<div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>"##,
+            r##"<div class="footnote-definition" id="word"><sup class="footnote-definition-label">2</sup>"##,
+        ],
+    );
     assert_contains_strings(&path, &["<del>strikethrough example</del>"]);
     assert_contains_strings(
         &path,


### PR DESCRIPTION
This PR is adding a service worker (via the use of [workbox.js](https://developers.google.com/web/tools/workbox/)) to the mdBook pages which allows for offline navigation and usage. We use the `StaleWhileRevalidate` mode from workbox

In the gif below the red you see in the network tab is the _StaleWhileRevalidate_ kicking in and trying to load a fresh version, this obviously fails offline so is expected.

Gif, click for animation:
![swRust](https://user-images.githubusercontent.com/936006/62904791-9e7c4d80-bd5f-11e9-862f-923b14647e45.gif)

I have updated the workbox library as it was very out of date. Not sure on the failing test though
@sorin-davidoi  @Michael-F-Bryan

**How does this work?**
When you visit the page the service worker will start to pre-cache all of the chapters within the book, it basically visits those urls and caches the response (but not the assets on those pages). So it doesn't matter which page you hit first, the service work will cache all pages in the book. 
When you visit a page in the book, the contents are served from the cache, if there is no matching content in the cache it is served from the network.

Below is an image of what the cache table looks like in Chrome.
I made a slight change to the appendix page, you can see workbox replaced the cache with the updated version, but kept the other pages as they are. (Time Cached is different to the other entries)
![image](https://user-images.githubusercontent.com/936006/63017236-b6ea8600-be8d-11e9-9564-a09a41175404.png)


**When does the cache invalidate?**
The mode set is staleWhileRevalidate so it will always try to pull a fresh copy in the background (whilst serving you content from the cache). If the content is the same it is basically thrown away. If the content is new workbox replaces the cache with the up to date page and uses that instead.

There is no explicit expiry time set.

**Testing Instructions**
* Navigate to https://jason-williams.co.uk/book/
* Go offline, (open console, go to network tab, set preset to offline)
* Try clicking some links

**Testing Instructions (build)**
* Checkout https://github.com/rust-lang/book
* Add offline-support = true to the [output.html] section
* Disable the check for localhost at the end of book.js in mdBook repo
* Build mdBook (set the binary in your path `target/debug/mdBook`)
* call mdBook serve in the `book` repo