### PR TITLE
Fix: Scroll sidebar to current active section (#1067)

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -521,10 +521,12 @@ function playpen_text(playpen) {
     }, { passive: true });
 
     // Scroll sidebar to current active section
-    var activeSection = sidebar.querySelector(".active");
-    if (activeSection) {
-        sidebarScrollBox.scrollTop = activeSection.offsetTop;
-    }
+    window.addEventListener('load', function() {
+        var activeSection = sidebar.querySelector(".active");
+        if (activeSection) {
+            activeSection.scrollIntoViewIfNeeded();
+        }
+    });
 })();
 
 (function chapterNavigation() {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -523,7 +523,8 @@ function playpen_text(playpen) {
     window.addEventListener('load', function() {
         var activeSection = sidebar.querySelector(".active");
         if (activeSection) {
-            activeSection.scrollIntoViewIfNeeded();
+            // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+            activeSection.scrollIntoView({ block: 'center' });
         }
     });
 })();

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -435,7 +435,6 @@ function playpen_text(playpen) {
 (function sidebar() {
     var html = document.querySelector("html");
     var sidebar = document.getElementById("sidebar");
-    var sidebarScrollBox = document.getElementById("sidebar-scrollbox");
     var sidebarLinks = document.querySelectorAll('#sidebar a');
     var sidebarToggleButton = document.getElementById("sidebar-toggle");
     var sidebarResizeHandle = document.getElementById("sidebar-resize-handle");

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -84,7 +84,7 @@
         </script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
-            <div id="sidebar-scrollbox" class="sidebar-scrollbox">
+            <div class="sidebar-scrollbox">
                 {{#toc}}{{/toc}}
             </div>
             <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>


### PR DESCRIPTION
Sidebar on the left can't auto scroll to the current active section. This is something to do with the `book.js`.

**Edit:** I just aware that there already has been a [PR #1052](https://github.com/rust-lang-nursery/mdBook/pull/1052) fixing this problem. But I think my PR is a bit cleaner and using the nice Web API. My solution places the active item [in the middle of the sidebar](https://ngolin.github.io/rust-by-example/fn.html) whenever possible, which I think it's a bit nicer. 😉 

> Note: This [on the top of the sidebar](https://rustbook-sidebar-autoscroll.s3-ap-southeast-2.amazonaws.com/ch09-00-error-handling.html) by @morphologue.