### PR TITLE
Lowercase matching the theme name

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -407,13 +407,13 @@ fn make_data(
     }
 
     let default_theme = match html_config.default_theme {
-        Some(ref theme) => theme,
-        None => "light",
+        Some(ref theme) => theme.to_lowercase(),
+        None => "light".to_string(),
     };
     data.insert("default_theme".to_owned(), json!(default_theme));
 
     let preferred_dark_theme = match html_config.preferred_dark_theme {
-        Some(ref theme) => theme,
+        Some(ref theme) => theme.to_string(),
         None => default_theme,
     };
     data.insert(

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -413,7 +413,7 @@ fn make_data(
     data.insert("default_theme".to_owned(), json!(default_theme));
 
     let preferred_dark_theme = match html_config.preferred_dark_theme {
-        Some(ref theme) => theme.to_string(),
+        Some(ref theme) => theme.to_lowercase(),
         None => default_theme,
     };
     data.insert(


### PR DESCRIPTION
Using `.to_lowercase()` on the theme matching to avoid needing exact capitalization in the `book.toml`. Fixes #1078 