### PR TITLE
Add support for Rust edition 2018 in playpens

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -10,6 +10,7 @@ mathjax-support = true
 [output.html.playpen]
 editable = true
 line-numbers = true
+edition = "2018"
 
 [output.html.search]
 limit-results = 20

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -178,7 +178,7 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-  
+
 Available configuration options for the `[output.html.fold]` table:
 
 - **enable:** Enable section-folding. When off, all folds are open.
@@ -193,6 +193,7 @@ Available configuration options for the `[output.html.playpen]` table:
 - **copy-js:** Copy JavaScript files for the editor to the output directory.
   Defaults to `true`.
 - **line-numbers** Display line numbers on editable sections of code. Requires both `editable` and `copy-js` to be `true`. Defaults to `false`.
+- **edition**: Rust edition to use by default for the code snippets. Defaults to `2015`.
 
 [Ace]: https://ace.c9.io/
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -27,7 +27,7 @@ use crate::preprocess::{
 use crate::renderer::{CmdRenderer, HtmlHandlebars, MarkdownRenderer, RenderContext, Renderer};
 use crate::utils;
 
-use crate::config::Config;
+use crate::config::{Config, RustEdition};
 
 /// The object used to manage and build a book.
 pub struct MDBook {
@@ -262,11 +262,20 @@ impl MDBook {
                     let mut tmpf = utils::fs::create_file(&path)?;
                     tmpf.write_all(ch.content.as_bytes())?;
 
-                    let output = Command::new("rustdoc")
+                    let mut cmd = Command::new("rustdoc");
+
+                    cmd
                         .arg(&path)
                         .arg("--test")
-                        .args(&library_args)
-                        .output()?;
+                        .args(&library_args);
+
+                    if let Some(html_cfg) = self.config.html_config() {
+                        if html_cfg.playpen.edition == RustEdition::E2018 {
+                            cmd.args(&["--edition", "2018"]);
+                        }
+                    }
+
+                    let output = cmd.output()?;
 
                     if !output.status.success() {
                         bail!(ErrorKind::Subprocess(

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -264,10 +264,7 @@ impl MDBook {
 
                     let mut cmd = Command::new("rustdoc");
 
-                    cmd
-                        .arg(&path)
-                        .arg("--test")
-                        .args(&library_args);
+                    cmd.arg(&path).arg("--test").args(&library_args);
 
                     if let Some(html_cfg) = self.config.html_config() {
                         if html_cfg.playpen.edition == RustEdition::E2018 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -513,6 +513,8 @@ pub struct Playpen {
     pub copy_js: bool,
     /// Display line numbers on playpen snippets. Default: `false`.
     pub line_numbers: bool,
+    /// Rust edition to use for the code. Default: `2015`.
+    pub edition: RustEdition,
 }
 
 impl Default for Playpen {
@@ -522,7 +524,67 @@ impl Default for Playpen {
             copyable: true,
             copy_js: true,
             line_numbers: false,
+            edition: RustEdition::E2015,
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// The edition of Rust used in a playpen code snippet
+pub enum RustEdition {
+    /// The 2018 edition of Rust
+    E2018,
+    /// The 2015 edition of Rust
+    E2015,
+}
+
+impl Default for RustEdition {
+    fn default() -> Self {
+        RustEdition::E2015
+    }
+}
+
+impl Serialize for RustEdition {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::E2015 => serializer.serialize_str("2015"),
+            Self::E2018 => serializer.serialize_str("2018"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RustEdition {
+    fn deserialize<D>(de: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>
+    {
+        use serde::de::Error;
+
+        let raw = Value::deserialize(de)?;
+
+        let edition = match raw {
+            Value::String(s) => s,
+            _ => {
+                return Err(D::Error::custom(
+                    "Rust edition should be a string",
+                ));
+            }
+        };
+
+        let edition = match edition.as_str() {
+            "2018" => RustEdition::E2018,
+            "2015" => RustEdition::E2015,
+            _ => {
+                return Err(D::Error::custom(
+                    "Unknown Rust edition"
+                ));
+            }
+        };
+
+        Ok(edition)
     }
 }
 
@@ -630,6 +692,7 @@ mod tests {
         [output.html.playpen]
         editable = true
         editor = "ace"
+        edition = "2018"
 
         [preprocessor.first]
 
@@ -658,6 +721,7 @@ mod tests {
             copyable: true,
             copy_js: true,
             line_numbers: false,
+            edition: RustEdition::E2018,
         };
         let html_should_be = HtmlConfig {
             curly_quotes: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,7 +559,7 @@ impl Serialize for RustEdition {
 impl<'de> Deserialize<'de> for RustEdition {
     fn deserialize<D>(de: D) -> std::result::Result<Self, D::Error>
     where
-        D: Deserializer<'de>
+        D: Deserializer<'de>,
     {
         use serde::de::Error;
 
@@ -568,9 +568,7 @@ impl<'de> Deserialize<'de> for RustEdition {
         let edition = match raw {
             Value::String(s) => s,
             _ => {
-                return Err(D::Error::custom(
-                    "Rust edition should be a string",
-                ));
+                return Err(D::Error::custom("Rust edition should be a string"));
             }
         };
 
@@ -578,9 +576,7 @@ impl<'de> Deserialize<'de> for RustEdition {
             "2018" => RustEdition::E2018,
             "2015" => RustEdition::E2015,
             _ => {
-                return Err(D::Error::custom(
-                    "Unknown Rust edition"
-                ));
+                return Err(D::Error::custom("Unknown Rust edition"));
             }
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -550,8 +550,8 @@ impl Serialize for RustEdition {
         S: Serializer,
     {
         match self {
-            Self::E2015 => serializer.serialize_str("2015"),
-            Self::E2018 => serializer.serialize_str("2018"),
+            RustEdition::E2015 => serializer.serialize_str("2015"),
+            RustEdition::E2018 => serializer.serialize_str("2018"),
         }
     }
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -1,5 +1,5 @@
 use crate::book::{Book, BookItem};
-use crate::config::{Config, HtmlConfig, Playpen};
+use crate::config::{Config, HtmlConfig, Playpen, RustEdition};
 use crate::errors::*;
 use crate::renderer::html_handlebars::helpers;
 use crate::renderer::{RenderContext, Renderer};
@@ -614,6 +614,12 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
                 && !classes.contains("noplaypen"))
                 || classes.contains("mdbook-runnable")
             {
+                let mut classes = classes.to_string();
+                match playpen_config.edition {
+                    RustEdition::E2018 => classes += " edition2018",
+                    _ => (),
+                }
+
                 // wrap the contents in an external pre block
                 format!(
                     "<pre class=\"playpen\"><code class=\"{}\">{}</code></pre>",

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -490,12 +490,15 @@ fn markdown_options() {
             "<td>bim</td>",
         ],
     );
-    assert_contains_strings(&path, &[
-        r##"<sup class="footnote-reference"><a href="#1">1</a></sup>"##,
-        r##"<sup class="footnote-reference"><a href="#word">2</a></sup>"##,
-        r##"<div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>"##,
-        r##"<div class="footnote-definition" id="word"><sup class="footnote-definition-label">2</sup>"##,
-    ]);
+    assert_contains_strings(
+        &path,
+        &[
+            r##"<sup class="footnote-reference"><a href="#1">1</a></sup>"##,
+            r##"<sup class="footnote-reference"><a href="#word">2</a></sup>"##,
+            r##"<div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>"##,
+            r##"<div class="footnote-definition" id="word"><sup class="footnote-definition-label">2</sup>"##,
+        ],
+    );
     assert_contains_strings(&path, &["<del>strikethrough example</del>"]);
     assert_contains_strings(
         &path,


### PR DESCRIPTION
This PR adds a config option to support Rust edition 2018 in playpens. Fixes #812.