### PR TITLE
Fix hiding of empty boring lines

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -601,7 +601,7 @@ fn fix_code_blocks(html: &str) -> String {
 }
 
 fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
-    let boring_line_regex = Regex::new(r"^(\s*)#(#|.)(.*)$").unwrap();
+    let boring_line_regex = Regex::new(r"^(\s*)#(.?)(.*)$").unwrap();
     let regex = Regex::new(r##"((?s)<code[^>]?class="([^"]+)".*?>(.*?)</code>)"##).unwrap();
     regex
         .replace_all(html, |caps: &Captures<'_>| {
@@ -747,6 +747,8 @@ mod tests {
            "<pre class=\"playpen\"><code class=\"language-rust editable\">let s = \"foo\n<span class=\"boring\"> bar\n</span>\";\n</code></pre>"),
           ("<code class=\"language-rust editable\">let s = \"foo\n ## bar\n\";</code>",
            "<pre class=\"playpen\"><code class=\"language-rust editable\">let s = \"foo\n # bar\n\";\n</code></pre>"),
+          ("<code class=\"language-rust editable\">let s = \"foo\n # bar\n#\n\";</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust editable\">let s = \"foo\n<span class=\"boring\"> bar\n\n</span>\";\n</code></pre>"),
         ];
         for (src, should_be) in &inputs {
             let got = add_playpen_pre(

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -16,9 +16,6 @@ function playpen_text(playpen) {
 }
 
 (function codeSnippets() {
-    // Hide Rust code lines prepended with a specific character
-    var hiding_character = "#";
-
     function fetch_with_timeout(url, options, timeout = 6000) {
         return Promise.race([
             fetch(url, options),


### PR DESCRIPTION
#1065 introduced a regression where lines in a playpen starting with `#` but nothing after that are now not hidden anymore. This PR fixes that regression and also adds a test case for this behavior.