### PR TITLE
Change erroneous syntax highlighting definition

### DIFF
--- a/book-example/src/format/theme/syntax-highlighting.md
+++ b/book-example/src/format/theme/syntax-highlighting.md
@@ -22,7 +22,7 @@ overridden with your own.
 
 If you want to use another theme for `highlight.js` download it from their
 website, or make it yourself, rename it to `highlight.css` and put it in
-`src/theme` (or the equivalent if you changed your source folder)
+the `theme` folder of your book.
 
 Now your theme will be used instead of the default theme.
 


### PR DESCRIPTION
Doing what it says results in:

```
2019-11-04 16:13:15 [WARN] (mdbook::renderer::html_handlebars::hbs_renderer): Previous versions of mdBook erroneously accepted `./src/theme` as an automatic theme directory
2019-11-04 16:13:15 [WARN] (mdbook::renderer::html_handlebars::hbs_renderer): Please move your theme files to `./theme` for them to continue being used
```