### PR TITLE
Prevent scrolling to the top of the page on websocket reload

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -204,7 +204,7 @@
             socket.onmessage = function (event) {
                 if (event.data === "reload") {
                     socket.close();
-                    location.reload(true); // force reload from server (not from cache)
+                    location.reload();
                 }
             };
 


### PR DESCRIPTION
When using `mdbook serve` with large files, it's tedious to have to scroll back to the bottom of the page on each reload triggered by the websocket.

The problem stems from [`location.reload(true)`](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Location/reload), which I've changed to `location.reload()`.

However we still want to always load a fresh version of the page. To fix this I've added the header `Cache-Control: no-store, max-age=0` in the server response.