### PR TITLE
Exposed the MDBook::execute_build_process() method to 3rd parties

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -182,7 +182,7 @@ impl MDBook {
     }
 
     /// Run the entire build process for a particular `Renderer`.
-    fn execute_build_process(&self, renderer: &dyn Renderer) -> Result<()> {
+    pub fn execute_build_process(&self, renderer: &dyn Renderer) -> Result<()> {
         let mut preprocessed_book = self.book.clone();
         let preprocess_ctx = PreprocessorContext::new(
             self.root.clone(),


### PR DESCRIPTION
I think it's pretty common for 3rd party backends to expose some sort of `--standalone` flag so you could (for example) run `mdbook-linkcheck --standalone user-guide` to load the book and execute just that renderer.

Exposing the `MDBook::execute_build_process()` means we can replace [this](https://github.com/Michael-F-Bryan/mdbook-linkcheck/blob/ceae3b56afc0822a2c9d321c76a297366855930d/src/bin/mdbook-linkcheck.rs#L11-L24) manual construction of a `RenderContext` and invoking the rendering system:

```rust
    // get a `RenderContext`, either from stdin (because we're used as a plugin)
    // or by instrumenting MDBook directly (in standalone mode).
    let ctx: RenderContext = if args.standalone {
        let md = MDBook::load(dunce::canonicalize(&args.root)?)
            .map_err(SyncFailure::new)?;
        let destination = md.build_dir_for("linkcheck");
        RenderContext::new(md.root, md.book, md.config, destination)
    } else {
        serde_json::from_reader(io::stdin())
            .context("Unable to parse RenderContext")?
    };

    let cache_file = ctx.destination.join("cache.json");
    mdbook_linkcheck::run(&cache_file, args.colour, &ctx)
```

With something like this:

```rust
let renderer = Renderer::new();

if is_standalone {
    let book = MDBook::load(&args.book_directory)?;
    book.execute_build_process(&renderer)?;
} else {
    let ctx = RenderContext::from_json(io::stdin())?;
    renderer.run(&ctx)?;
}
```

EDIT: Looking more closely, I think `mdbook-linkcheck` isn't even doing things correctly here. We forget to run all applicable preprocessors over the book because it's trying to execute the rendering pipeline manually.