### PR TITLE
Add support for Rust edition

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -3,6 +3,7 @@ title = "mdBook Documentation"
 description = "Create book from markdown files. Like Gitbook but implemented in Rust"
 authors = ["Mathieu David", "Michael-F-Bryan"]
 language = "en"
+edition = "2018"
 
 [output.html]
 mathjax-support = true

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -9,6 +9,7 @@ Here is an example of what a ***book.toml*** file might look like:
 title = "Example book"
 author = "John Doe"
 description = "The example book covers examples."
+edition = "2018"
 
 [build]
 build-dir = "my-example-book"
@@ -43,6 +44,7 @@ This is general information about your book.
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
+- **edition**: Rust edition to use by default for the code snippets. Defaults to `rustdoc` defaults (2015).
 
 **book.toml**
 ```toml
@@ -52,6 +54,7 @@ authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
 language = "en"
+edition = "2018"
 ```
 
 ### Build options
@@ -178,7 +181,7 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-  
+
 Available configuration options for the `[output.html.fold]` table:
 
 - **enable:** Enable section-folding. When off, all folds are open.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -1,5 +1,5 @@
 use crate::book::{Book, BookItem};
-use crate::config::{Config, HtmlConfig, Playpen};
+use crate::config::{Config, HtmlConfig, Playpen, RustEdition};
 use crate::errors::*;
 use crate::renderer::html_handlebars::helpers;
 use crate::renderer::{RenderContext, Renderer};
@@ -81,7 +81,7 @@ impl HtmlHandlebars {
             debug!("Render template");
             let rendered = ctx.handlebars.render("index", &ctx.data)?;
 
-            let rendered = self.post_process(rendered, &ctx.html_config.playpen);
+            let rendered = self.post_process(rendered, &ctx.html_config.playpen, ctx.edition);
 
             // Write to file
             debug!("Creating {}", filepath.display());
@@ -92,7 +92,8 @@ impl HtmlHandlebars {
                 ctx.data.insert("path_to_root".to_owned(), json!(""));
                 ctx.data.insert("is_index".to_owned(), json!("true"));
                 let rendered_index = ctx.handlebars.render("index", &ctx.data)?;
-                let rendered_index = self.post_process(rendered_index, &ctx.html_config.playpen);
+                let rendered_index =
+                    self.post_process(rendered_index, &ctx.html_config.playpen, ctx.edition);
                 debug!("Creating index.html from {}", path);
                 utils::fs::write_file(&ctx.destination, "index.html", rendered_index.as_bytes())?;
             }
@@ -102,10 +103,15 @@ impl HtmlHandlebars {
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))]
-    fn post_process(&self, rendered: String, playpen_config: &Playpen) -> String {
+    fn post_process(
+        &self,
+        rendered: String,
+        playpen_config: &Playpen,
+        edition: Option<RustEdition>,
+    ) -> String {
         let rendered = build_header_links(&rendered);
         let rendered = fix_code_blocks(&rendered);
-        let rendered = add_playpen_pre(&rendered, playpen_config);
+        let rendered = add_playpen_pre(&rendered, playpen_config, edition);
 
         rendered
     }
@@ -338,6 +344,7 @@ impl Renderer for HtmlHandlebars {
                 data: data.clone(),
                 is_index,
                 html_config: html_config.clone(),
+                edition: ctx.config.book.edition,
             };
             self.render_item(item, ctx, &mut print_content)?;
             is_index = false;
@@ -353,7 +360,7 @@ impl Renderer for HtmlHandlebars {
         debug!("Render template");
         let rendered = handlebars.render("index", &data)?;
 
-        let rendered = self.post_process(rendered, &html_config.playpen);
+        let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.book.edition);
 
         utils::fs::write_file(&destination, "print.html", rendered.as_bytes())?;
         debug!("Creating print.html ✓");
@@ -600,7 +607,7 @@ fn fix_code_blocks(html: &str) -> String {
         .into_owned()
 }
 
-fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
+fn add_playpen_pre(html: &str, playpen_config: &Playpen, edition: Option<RustEdition>) -> String {
     let regex = Regex::new(r##"((?s)<code[^>]?class="([^"]+)".*?>(.*?)</code>)"##).unwrap();
     regex
         .replace_all(html, |caps: &Captures<'_>| {
@@ -612,10 +619,24 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
                 if (!classes.contains("ignore") && !classes.contains("noplaypen"))
                     || classes.contains("mdbook-runnable")
                 {
+                    let contains_e2015 = classes.contains("edition2015");
+                    let contains_e2018 = classes.contains("edition2018");
+                    let edition_class = if contains_e2015 || contains_e2018 {
+                        // the user forced edition, we should not overwrite it
+                        ""
+                    } else {
+                        match edition {
+                            Some(RustEdition::E2015) => " edition2015",
+                            Some(RustEdition::E2018) => " edition2018",
+                            None => "",
+                        }
+                    };
+
                     // wrap the contents in an external pre block
                     format!(
-                        "<pre class=\"playpen\"><code class=\"{}\">{}</code></pre>",
+                        "<pre class=\"playpen\"><code class=\"{}{}\">{}</code></pre>",
                         classes,
+                        edition_class,
                         {
                             let content: Cow<'_, str> = if playpen_config.editable
                                 && classes.contains("editable")
@@ -706,6 +727,7 @@ struct RenderItemContext<'a> {
     data: serde_json::Map<String, serde_json::Value>,
     is_index: bool,
     html_config: HtmlConfig,
+    edition: Option<RustEdition>,
 }
 
 #[cfg(test)]
@@ -772,6 +794,55 @@ mod tests {
                     editable: true,
                     ..Playpen::default()
                 },
+                None,
+            );
+            assert_eq!(&*got, *should_be);
+        }
+    }
+    #[test]
+    fn add_playpen_edition2015() {
+        let inputs = [
+          ("<code class=\"language-rust\">x()</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">\n<span class=\"boring\">#![allow(unused_variables)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+          ("<code class=\"language-rust\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">fn main() {}\n</code></pre>"),
+          ("<code class=\"language-rust edition2015\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">fn main() {}\n</code></pre>"),
+          ("<code class=\"language-rust edition2018\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">fn main() {}\n</code></pre>"),
+        ];
+        for (src, should_be) in &inputs {
+            let got = add_playpen_pre(
+                src,
+                &Playpen {
+                    editable: true,
+                    ..Playpen::default()
+                },
+                Some(RustEdition::E2015),
+            );
+            assert_eq!(&*got, *should_be);
+        }
+    }
+    #[test]
+    fn add_playpen_edition2018() {
+        let inputs = [
+          ("<code class=\"language-rust\">x()</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">\n<span class=\"boring\">#![allow(unused_variables)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+          ("<code class=\"language-rust\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">fn main() {}\n</code></pre>"),
+          ("<code class=\"language-rust edition2015\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">fn main() {}\n</code></pre>"),
+          ("<code class=\"language-rust edition2018\">fn main() {}</code>",
+           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">fn main() {}\n</code></pre>"),
+        ];
+        for (src, should_be) in &inputs {
+            let got = add_playpen_pre(
+                src,
+                &Playpen {
+                    editable: true,
+                    ..Playpen::default()
+                },
+                Some(RustEdition::E2018),
             );
             assert_eq!(&*got, *should_be);
         }


### PR DESCRIPTION
Books will have to replace ` ```rust` with ` ```edition2018` everywhere to make it work, but it would be useful to change it in config only.

According to https://github.com/rust-lang/mdBook/issues/812#issuecomment-554758875