### PR TITLE
Use ALT+S to trigger search

### DIFF
--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -323,7 +323,7 @@ window.search = window.search || {};
             }
             showSearch(false);
             marker.unmark();
-        } else if (!hasFocus() && e.keyCode === SEARCH_HOTKEY_KEYCODE) {
+        } else if (!hasFocus() && e.keyCode === SEARCH_HOTKEY_KEYCODE && e.altKey) {
             e.preventDefault();
             showSearch(true);
             window.scrollTo(0, 0);


### PR DESCRIPTION
As currently implemented, any time the S key is pressed outside of the search interface, that keystroke is intercepted and the search interface is displayed. This causes problems when interactive widgets are embedded on the page (as raised in https://github.com/rust-lang/mdBook/issues/1020).

This PR instead switches to ALT+S so that interactive widgets can be displayed on the page (and more generally, makes the S key available to JavaScript running on the page). Rationale for ALT+S:

 * Current implementation uses 'S' -- so we want to stay close to that
 * 'S' is a great mnemonic device for _search_
 * Windows desktop applications uses CTRL+S for save, which would likely cause the page to be downloaded
 * MacOS desktop applications use CMD+S (or `event.keyMeta` in javascript) to save 
 * Ubuntu follows one of these conventions (can't remember which offhand...maybe both?)
 * ALT+S appears not to be in widespread usage on either of those platforms
 * ALT+S is only key-stroke different than current implementation