### PR TITLE
Bring back "draft chapters"

### DIFF
--- a/book-example/src/SUMMARY.md
+++ b/book-example/src/SUMMARY.md
@@ -10,6 +10,7 @@
     - [clean](cli/clean.md)
 - [Format](format/README.md)
     - [SUMMARY.md](format/summary.md)
+        - [Draft chapter]()
     - [Configuration](format/config.md)
     - [Theme](format/theme/README.md)
         - [index.hbs](format/theme/index-hbs.md)

--- a/book-example/src/format/summary.md
+++ b/book-example/src/format/summary.md
@@ -7,7 +7,7 @@ are. Without this file, there is no book.
 Even though `SUMMARY.md` is a markdown file, the formatting is very strict to
 allow for easy parsing. Let's see how you should format your `SUMMARY.md` file.
 
-#### Allowed elements
+#### Structure
 
 1. ***Title*** It's common practice to begin with a title, generally <code
    class="language-markdown"># Summary</code>. But it is not mandatory, the
@@ -36,3 +36,19 @@ allow for easy parsing. Let's see how you should format your `SUMMARY.md` file.
 
 All other elements are unsupported and will be ignored at best or result in an
 error.
+
+#### Other elements
+
+- ***Separators*** In between chapters you can add a separator. In the HTML renderer
+  this will result in a line being rendered in the table of contents. A separator is
+  a line containing exclusively dashes and at least three of them: `---`.
+- ***Draft chapters*** Draft chapters are chapters without a file and thus content.
+  The purpose of a draft chapter is to signal future chapters still to be written.
+  Or when still laying out the structure of the book to avoid creating the files
+  while you are still changing the structure of the book a lot.
+  Draft chapters will be rendered in the HTML renderer as disabled links in the table
+  of contents, as you can see for the next chapter in the table of contents on the left.
+  Draft chapters are written like normal chapters but without writing the path to the file
+  ```markdown
+  - [Draft chapter]()  
+  ``` 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -132,6 +132,7 @@ impl MDBook {
     /// for item in book.iter() {
     ///     match *item {
     ///         BookItem::Chapter(ref chapter) => {},
+    ///         BookItem::DraftChapter(ref chapter) => {},
     ///         BookItem::Separator => {},
     ///     }
     /// }

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -64,6 +64,13 @@ fn find_chapter(
         .replace("\"", "");
 
     if !rc.evaluate(ctx, "@root/is_index")?.is_missing() {
+        // If the first chapter is a draft, don't skip the first real chapter
+        // otherwise skip it because the index is a copy of it
+        let skip_n = if chapters[0].contains_key("draft") {
+            0
+        } else {
+            1
+        };
         // Special case for index.md which may be a synthetic page.
         // Target::find won't match because there is no page with the path
         // "index.md" (unless there really is an index.md in SUMMARY.md).
@@ -75,7 +82,7 @@ fn find_chapter(
                     // Skip things like "spacer"
                     chapter.contains_key("path")
                 })
-                .skip(1)
+                .skip(skip_n)
                 .next()
             {
                 Some(chapter) => return Ok(Some(chapter.clone())),

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -139,7 +139,7 @@ impl HelperDef for RenderToc {
             if !self.no_section_label {
                 // Section does not necessarily exist
                 if let Some(section) = item.get("section") {
-                    out.write("<strong aria-hidden=\"true\">")?;
+                    out.write("<span><strong aria-hidden=\"true\">")?;
                     out.write(&section)?;
                     out.write("</strong> ")?;
                 }
@@ -160,6 +160,7 @@ impl HelperDef for RenderToc {
 
                 // write to the handlebars template
                 out.write(&markdown_parsed_name)?;
+                out.write("</span>")?;
             }
 
             if path_exists {


### PR DESCRIPTION
Hi there, it has been a while since I contributed. :sweat_smile: 

For this PR I want to brink back an old feature I miss: "draft chapters"
Draft chapters are chapters that don't have any content, no file associated with them and only show up in the table of contents. They were previously (a long time ago) supported by mdBook but at some point there was a regression and they were never brought back.

I found them particularly useful in two situations:

1. When I wanted to show that a specific chapter was planned for the future. It has no content, no file, but as it shows up in the TOC, users know that I plan to write it.
2. When I am playing with the structure of a new book or a series of new chapters. In this case, as the structure still changes a lot and I only want an overview, I don't want the files to be created. Having the possibility to first freely map out the structure of the table of contents before worrying about the actual files on disk is a huge advantage to me.

So with this PR I implemented draft chapters explicitly, they are a new kind of item in the summary and book. This means that the changes are **breaking changes**.

This is what it looks like:
![Screenshot_mdbook_draft_chapters](https://user-images.githubusercontent.com/7647338/70002973-fe427280-1561-11ea-9448-f2d19daa1fda.png)

As you can see in the image:
- Draft chapters can be used wherever a chapter can be used
- Draft chapters are rendered in the TOC but are not clickable
- Draft chapters can be the first chapter of the book, in that case the index page will be blank
- Navigation skips over draft chapters

It has been a while since I have been involved in the project and since I have actively programmed with Rust so feel free to point out anything that could be improved. :+1: 