### PR TITLE
refactor(js): persist selected theme in cookie when viewing book locally

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -284,7 +284,6 @@ function playpen_text(playpen) {
     function showThemes() {
         themePopup.style.display = 'block';
         themeToggleButton.setAttribute('aria-expanded', true);
-        themePopup.querySelector("button#" + document.body.className).focus();
     }
 
     function hideThemes() {
@@ -293,7 +292,7 @@ function playpen_text(playpen) {
         themeToggleButton.focus();
     }
 
-    function set_theme(theme, store = true) {
+    function setTheme(theme, store = true) {
         let ace_theme;
 
         if (theme == 'coal' || theme == 'navy') {
@@ -330,18 +329,63 @@ function playpen_text(playpen) {
 
         if (store) {
             try { localStorage.setItem('mdbook-theme', theme); } catch (e) { }
+            try { createCookie('mdbook-theme', theme); } catch (e) { }
         }
 
         html.classList.remove(previousTheme);
         html.classList.add(theme);
     }
 
-    // Set theme
-    var theme;
-    try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
-    if (theme === null || theme === undefined) { theme = default_theme; }
+    function getTheme() {
+        var theme
+        var localAddrs = ["localhost", "127.0.0.1", ""];
+        // Only check cookies for theme if user is viewing book locally
+        if (localAddrs.indexOf(document.location.hostname) > -1) {
+            // Get remembered theme from cookies
+            const THEME_COOKIE = getCookie('mdbook-theme')
+            if (THEME_COOKIE !== null && THEME_COOKIE !== undefined) {
+                theme = THEME_COOKIE
+            } else {
+                // Check localStorage
+                theme = localStorage.getItem('mdbook-theme')
+            }
+        } else {
+            // Check localStorage
+            theme = localStorage.getItem('mdbook-theme')
+        }
+        // Check if a theme was found and valid
+        if (theme === null || theme === '' || theme === undefined) {
+            // Use default theme
+            theme = default_theme
+        }
+        // Return user selected theme
+        return theme
+    }
 
-    set_theme(theme, false);
+    function createCookie(name, value, days) {
+        document.cookie = name + "=" + value + "; path=/";
+    }
+
+    function getCookie(name) {
+        if (document.cookie.length > 0) {
+            c_start = document.cookie.indexOf(name + "=");
+            if (c_start != -1) {
+                c_start = c_start + name.length + 1;
+                c_end = document.cookie.indexOf(";", c_start);
+                if (c_end == -1) {
+                    c_end = document.cookie.length;
+                }
+                const cookie = unescape(document.cookie.substring(c_start, c_end));
+                return cookie === '' ? null : cookie
+            }
+        }
+        return null;
+    }
+
+    // Get theme
+    var theme = getTheme()
+    // Set theme
+    setTheme(theme, true);
 
     themeToggleButton.addEventListener('click', function () {
         if (themePopup.style.display === 'block') {
@@ -353,7 +397,7 @@ function playpen_text(playpen) {
 
     themePopup.addEventListener('click', function (e) {
         var theme = e.target.id || e.target.parentElement.id;
-        set_theme(theme);
+        setTheme(theme);
     });
 
     themePopup.addEventListener('focusout', function(e) {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -49,12 +49,7 @@
         <!-- Work around some values being stored in localStorage wrapped in quotes -->
         <script type="text/javascript">
             try {
-                var theme = localStorage.getItem('mdbook-theme');
                 var sidebar = localStorage.getItem('mdbook-sidebar');
-
-                if (theme.startsWith('"') && theme.endsWith('"')) {
-                    localStorage.setItem('mdbook-theme', theme.slice(1, theme.length - 1));
-                }
 
                 if (sidebar.startsWith('"') && sidebar.endsWith('"')) {
                     localStorage.setItem('mdbook-sidebar', sidebar.slice(1, sidebar.length - 1));
@@ -64,9 +59,50 @@
 
         <!-- Set the theme before any content is loaded, prevents flash -->
         <script type="text/javascript">
-            var theme;
-            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
-            if (theme === null || theme === undefined) { theme = default_theme; }
+
+            function getCookie (name) {
+                if (document.cookie.length > 0) {
+                    c_start = document.cookie.indexOf(name + "=");
+                    if (c_start != -1) {
+                        c_start = c_start + name.length + 1;
+                        c_end = document.cookie.indexOf(";", c_start);
+                        if (c_end == -1) {
+                            c_end = document.cookie.length;
+                        }
+                        const cookie = unescape(document.cookie.substring(c_start, c_end));
+                        return cookie === '' ? null : cookie
+                    }
+                }
+                return null;
+            }
+
+            function getTheme () {
+                var theme
+                var localAddrs = ["localhost", "127.0.0.1", ""];
+                // Only check cookies for theme if user is viewing book locally
+                if (localAddrs.indexOf(document.location.hostname) > -1) {
+                    // Get remembered theme from cookies
+                    const THEME_COOKIE = getCookie('mdbook-theme')
+                    if (THEME_COOKIE !== null && THEME_COOKIE !== undefined) {
+                        theme = THEME_COOKIE
+                    } else {
+                        // Check localStorage
+                        theme = localStorage.getItem('mdbook-theme')
+                    }
+                } else {
+                    // Check localStorage
+                    theme = localStorage.getItem('mdbook-theme')
+                }
+                // Check if a theme was found
+                if (theme === null && theme === undefined) {
+                    // Use default theme
+                    theme = default_theme
+                }
+                return theme === 'null' || theme === null || theme === ''
+                     ? default_theme : theme
+            }
+            
+            var theme = getTheme()
             var html = document.querySelector('html');
             html.classList.remove('no-js')
             html.classList.remove('{{ default_theme }}')
@@ -238,7 +274,7 @@
             window.playpen_line_numbers = true;
         </script>
         {{/if}}
-        
+
         {{#if playpen_copyable}}
         <script type="text/javascript">
             window.playpen_copyable = true;


### PR DESCRIPTION
I created issue #1112 because I am learning rust and use the offline docs provided from the rustup toolchain. Since the files are being served locally the theme I selected would not persist between page changes on Firefox (Developer Edition 72.0b5).

This PR provides a cookie mechanism to persist the selected theme across pages when viewing mdBooks locally.

For an easily reproducible instance of this bug simply us mdBook on the book-example provided in the repository and view that book locally in Firefox. Select a theme and notice how the theme defaults once you change pages. 

Now build mdBook with the code from this PR and see that themes a persisted across page changes.

The code is meant to only perform this check if a book is being viewed locally so this will not change behavior for books served from a domain.

I removed line 287 also because it was throwing an error for invalid selector and I couldn't figure out why that code existed. I understand it was trying to focus a button but even if it got the CSS selector correct the focus did nothing.