### PR TITLE
fix: ayu theme meta highlighting

### DIFF
--- a/src/theme/ayu-highlight.css
+++ b/src/theme/ayu-highlight.css
@@ -12,8 +12,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 }
 
 .hljs-comment,
-.hljs-quote,
-.hljs-meta {
+.hljs-quote {
   color: #5c6773;
   font-style: italic;
 }
@@ -30,6 +29,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 }
 
 .hljs-number,
+.hljs-meta,
 .hljs-builtin-name,
 .hljs-literal,
 .hljs-type,


### PR DESCRIPTION
Was previously highlighting `#[derive(Clone)]` like it was a comment. This updates the css to match the grouping of other themes.

For an example see https://rust-lang.github.io/async-book/02_execution/04_executor.html. Note the `#[derive(Clone)]` highlighting color in line 7 of the following screenshots

For reference, here is the regular theme:

![image](https://user-images.githubusercontent.com/9408157/73554718-dd878380-4411-11ea-9927-51dd31c9fc1b.png)


And here is the ayu theme today:

![image](https://user-images.githubusercontent.com/9408157/73554565-9a2d1500-4411-11ea-9eba-5d2d2ea2e07d.png)


And here is the ayu theme after the change proposed in this PR:

![image](https://user-images.githubusercontent.com/9408157/73554649-bcbf2e00-4411-11ea-9ee0-2f2d1fa974f8.png)
