### PR TITLE
Corrects inner/outer space in sidebar <li>s

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -417,6 +417,11 @@ ul#searchresults span.teaser em {
     display: none;
 }
 
+.chapter li.expanded {
+    line-height: 1.5em;
+    margin-top: 0.6em;
+}
+
 .chapter li.expanded > a.toggle div {
     transform: rotate(90deg);
 }


### PR DESCRIPTION
A multiline element (`<p>`, `<li>`, a block of text etc.) has inner space (space between its lines). That space should be smaller than that element's outer margin (distance to another element).

![explanation](https://user-images.githubusercontent.com/2311484/73618813-c4264780-465c-11ea-8dca-bd12ce7a7abd.png)
