### PR TITLE
Add a case for an empty `book_title` parameter

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -61,7 +61,11 @@ impl HtmlHandlebars {
                     .get("book_title")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("");
-                title = ch.name.clone() + " - " + book_title;
+
+                title = match book_title {
+                    "" => ch.name.clone(),
+                    _ => ch.name.clone() + " - " + book_title,
+                }
             }
 
             ctx.data.insert("path".to_owned(), json!(path));


### PR DESCRIPTION
Html page title for every chapter in the book is created by the following code:
```rust
let title: String;
{
	let book_title = ctx
	.data
	.get("book_title")
	.and_then(serde_json::Value::as_str)
	.unwrap_or("");

	title = ch.name.clone() + " - " + book_title;
}
```

If the `book.toml` file is missing, and `book_title` parameter is empty, there's an awkward ` - ` string hanging at the end of each chapter's title.

This PR adds a `match` case to handle that kind of situation.