### PR TITLE
Add "Suggest an edit" link next to "Git repository"

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -178,6 +178,12 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
+- **git-repository-edit-baseurl:** The base url for suggesting an edit
+  to individual pages/chapters of the book. If **git-repository-url** is defined,
+  defaults to **git-repository-url**/blob/master which works for e.g. GitHub.
+  The page source path is appended to this url, e.g. `/src/SUMMARY.md`. So when
+  this or **git-repository-url** is configured an icon link will be output in
+  the menu bar of the book.
   
 Available configuration options for the `[output.html.fold]` table:
 

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -178,12 +178,15 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-- **git-repository-edit-baseurl:** The base url for suggesting an edit
-  to individual pages/chapters of the book. If **git-repository-url** is defined,
-  defaults to **git-repository-url**/blob/master which works for e.g. GitHub.
-  The page source path is appended to this url, e.g. `/src/SUMMARY.md`. So when
-  this or **git-repository-url** is configured an icon link will be output in
-  the menu bar of the book.
+- **git-repository-edit-url-template:** Git repository file edit url
+  template, when provided shows an "Suggest an edit" button for
+  directly jumping to editing the currently viewed page in the git
+  repository. For e.g. GitHub projects set this to
+  `https://github.com/<owner>/<repo>/edit/master/{path}` or for
+  Bitbucket projects set it to
+  `https://bitbucket.org/<owner>/<repo>/src/master/{path}?mode=edit`
+  where {path} will be replaced with the full path of the file in the
+  repository.
   
 Available configuration options for the `[output.html.fold]` table:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -467,11 +467,11 @@ pub struct HtmlConfig {
     /// FontAwesome icon class to use for the Git repository link.
     /// Defaults to `fa-github` if `None`.
     pub git_repository_icon: Option<String>,
-    /// Git repository file edit baseurl, below which e.g. src/SUMMARY.md can
-    /// be viewed/edited
-    /// Defaults to git_repository_url + `/blob/master` if `None` and
-    /// git_repository_url is not `None` - works for e.g. GitHub master branch
-    pub git_repository_edit_baseurl: Option<String>,
+    /// Git repository file edit url template, when set shows an
+    /// "Suggest an edit" button for directly jumping to editing the
+    /// currently viewed page in the git repository. Contains {path}
+    /// that is replaced with chapter source file path
+    pub git_repository_edit_url_template: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where

--- a/src/config.rs
+++ b/src/config.rs
@@ -467,6 +467,11 @@ pub struct HtmlConfig {
     /// FontAwesome icon class to use for the Git repository link.
     /// Defaults to `fa-github` if `None`.
     pub git_repository_icon: Option<String>,
+    /// Git repository file edit baseurl, below which e.g. src/SUMMARY.md can
+    /// be viewed/edited
+    /// Defaults to git_repository_url + `/blob/master` if `None` and
+    /// git_repository_url is not `None` - works for e.g. GitHub master branch
+    pub git_repository_edit_baseurl: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -489,10 +489,10 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
-        let defaultEditBaseUrl = git_repository_url.to_owned() + "/blob/master";
+        let default_edit_baseurl = git_repository_url.to_owned() + "/blob/master";
         let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
             Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
-            None => &defaultEditBaseUrl,
+            None => &default_edit_baseurl,
         };
         data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
     } else {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -494,10 +494,16 @@ fn make_data(
             Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
             None => &default_edit_baseurl,
         };
-        data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+        data.insert(
+            "git_repository_edit_baseurl".to_owned(),
+            json!(git_repository_edit_baseurl),
+        );
     } else {
         if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
-            data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+            data.insert(
+                "git_repository_edit_baseurl".to_owned(),
+                json!(git_repository_edit_baseurl),
+            );
         }
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -489,6 +489,16 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
+        let defaultEditBaseUrl = git_repository_url.to_owned() + "/blob/master";
+        let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
+            Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
+            None => &defaultEditBaseUrl,
+        };
+        data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+    } else {
+        if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
+            data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+        }
     }
 
     let git_repository_icon = match html_config.git_repository_icon {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -53,6 +53,15 @@ impl HtmlHandlebars {
                 bail!(ErrorKind::ReservedFilenameError(ch.path.clone()));
             };
 
+            if let Some(ref git_repository_edit_url_template) =
+                ctx.html_config.git_repository_edit_url_template
+            {
+                let full_path = "src/".to_owned() + path;
+                let edit_url = git_repository_edit_url_template.replace("{path}", &full_path);
+                ctx.data
+                    .insert("git_repository_edit_url".to_owned(), json!(edit_url));
+            }
+
             // Non-lexical lifetimes needed :'(
             let title: String;
             {
@@ -489,22 +498,6 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
-        let default_edit_baseurl = git_repository_url.to_owned() + "/blob/master";
-        let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
-            Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
-            None => &default_edit_baseurl,
-        };
-        data.insert(
-            "git_repository_edit_baseurl".to_owned(),
-            json!(git_repository_edit_baseurl),
-        );
-    } else {
-        if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
-            data.insert(
-                "git_repository_edit_baseurl".to_owned(),
-                json!(git_repository_edit_baseurl),
-            );
-        }
     }
 
     let git_repository_icon = match html_config.git_repository_icon {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -131,6 +131,11 @@
                                 <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                             </a>
                             {{/if}}
+                            {{#if git_repository_edit_baseurl}}
+                            <a href="{{git_repository_edit_baseurl}}/src/{{path}}" title="Suggest an edit" aria-label="Suggest an edit">
+                                <i id="git-edit-button" class="fa fa-edit"></i>
+                            </a>
+                            {{/if}}
                         </div>
                     </div>
                 </div>

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -131,8 +131,8 @@
                                 <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                             </a>
                             {{/if}}
-                            {{#if git_repository_edit_baseurl}}
-                            <a href="{{git_repository_edit_baseurl}}/src/{{path}}" title="Suggest an edit" aria-label="Suggest an edit">
+                            {{#if git_repository_edit_url}}
+                            <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
                                 <i id="git-edit-button" class="fa fa-edit"></i>
                             </a>
                             {{/if}}


### PR DESCRIPTION
Includes new configuration option `git-repository-edit-baseurl` for
supporting non-GitHub repository layouts.