### PR TITLE
Scroll sidebar to middle instead of top.

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -505,10 +505,12 @@ function playpen_text(playpen) {
     }, { passive: true });
 
     // Scroll sidebar to current active section
-    var activeSection = document.getElementById("sidebar").querySelector(".active");
-    if (activeSection) {
-        sidebarScrollBox.scrollTop = activeSection.offsetTop;
-    }
+    window.addEventListener('load', function() {
+        var activeSection = document.getElementById("sidebar").querySelector(".active");
+        if (activeSection) {
+            activeSection.scrollIntoViewIfNeeded();
+        }
+    });
 })();
 
 (function chapterNavigation() {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -504,13 +504,11 @@ function playpen_text(playpen) {
     }, { passive: true });
 
     // Scroll sidebar to current active section
-    window.addEventListener('load', function() {
-        var activeSection = document.getElementById("sidebar").querySelector(".active");
-        if (activeSection) {
-            // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
-            activeSection.scrollIntoView({ block: 'center' });
-        }
-    });
+    var activeSection = document.getElementById("sidebar").querySelector(".active");
+    if (activeSection) {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+        activeSection.scrollIntoView({ block: 'center' });
+    }
 })();
 
 (function chapterNavigation() {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -408,7 +408,6 @@ function playpen_text(playpen) {
 (function sidebar() {
     var html = document.querySelector("html");
     var sidebar = document.getElementById("sidebar");
-    var sidebarScrollBox = document.querySelector(".sidebar-scrollbox");
     var sidebarLinks = document.querySelectorAll('#sidebar a');
     var sidebarToggleButton = document.getElementById("sidebar-toggle");
     var sidebarResizeHandle = document.getElementById("sidebar-resize-handle");

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -507,7 +507,8 @@ function playpen_text(playpen) {
     window.addEventListener('load', function() {
         var activeSection = document.getElementById("sidebar").querySelector(".active");
         if (activeSection) {
-            activeSection.scrollIntoViewIfNeeded();
+            // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+            activeSection.scrollIntoView({ block: 'center' });
         }
     });
 })();

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -87,7 +87,7 @@
         </script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
-            <div id="sidebar-scrollbox" class="sidebar-scrollbox">
+            <div class="sidebar-scrollbox">
                 {{#toc}}{{/toc}}
             </div>
             <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>


### PR DESCRIPTION
This is a re-submission of #1068. It changes the side bar so that the current page is in the vertical center instead of the top of the window.  From the previous PR, I removed the onload event handler since it caused some jumping, and it doesn't seem to be necessary.