### PR TITLE
 Make new [rust] section to config and  place edition under it 

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -3,6 +3,7 @@ title = "mdBook Documentation"
 description = "Create book from markdown files. Like Gitbook but implemented in Rust"
 authors = ["Mathieu David", "Michael-F-Bryan"]
 language = "en"
+edition = "2018"
 
 [output.html]
 mathjax-support = true

--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -3,6 +3,8 @@ title = "mdBook Documentation"
 description = "Create book from markdown files. Like Gitbook but implemented in Rust"
 authors = ["Mathieu David", "Michael-F-Bryan"]
 language = "en"
+
+[rust]
 edition = "2018"
 
 [output.html]

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -9,6 +9,7 @@ Here is an example of what a ***book.toml*** file might look like:
 title = "Example book"
 author = "John Doe"
 description = "The example book covers examples."
+edition = "2018"
 
 [build]
 build-dir = "my-example-book"
@@ -43,6 +44,7 @@ This is general information about your book.
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
+- **edition**: Rust edition to use by default for the code snippets. Defaults to `rustdoc` defaults (2015).
 
 **book.toml**
 ```toml
@@ -52,6 +54,7 @@ authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
 language = "en"
+edition = "2018"
 ```
 
 ### Build options
@@ -178,7 +181,7 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-  
+
 Available configuration options for the `[output.html.fold]` table:
 
 - **enable:** Enable section-folding. When off, all folds are open.

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -59,9 +59,19 @@ language = "en"
 
 ### Rust options
 
-Options for the Rust compiler used for playpen.
+Options for the Rust language, relevant to running tests and playground
+integration.
 
-- **edition**: Rust edition to use by default for the code snippets. Defaults to `rustdoc` defaults (2015).
+- **edition**: Rust edition to use by default for the code snippets. Default
+  is "2015". Individual code blocks can be controlled with the `edition2015`
+  or `edition2018` annotations, such as:
+
+  ~~~text
+  ```rust,edition2015
+  // This only works in 2015.
+  let try = true;
+  ```
+  ~~~
 
 ### Build options
 

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -9,6 +9,8 @@ Here is an example of what a ***book.toml*** file might look like:
 title = "Example book"
 author = "John Doe"
 description = "The example book covers examples."
+
+[rust]
 edition = "2018"
 
 [build]
@@ -44,7 +46,6 @@ This is general information about your book.
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
-- **edition**: Rust edition to use by default for the code snippets. Defaults to `rustdoc` defaults (2015).
 
 **book.toml**
 ```toml
@@ -54,8 +55,13 @@ authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
 language = "en"
-edition = "2018"
 ```
+
+### Rust options
+
+Options for the Rust compiler used for playpen.
+
+- **edition**: Rust edition to use by default for the code snippets. Defaults to `rustdoc` defaults (2015).
 
 ### Build options
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -265,7 +265,7 @@ impl MDBook {
                     let mut cmd = Command::new("rustdoc");
                     cmd.arg(&path).arg("--test").args(&library_args);
 
-                    if let Some(edition) = self.config.book.edition {
+                    if let Some(edition) = self.config.rust.edition {
                         match edition {
                             RustEdition::E2015 => {
                                 cmd.args(&["--edition", "2015"]);

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -808,7 +808,7 @@ mod tests {
     fn add_playpen_edition2015() {
         let inputs = [
           ("<code class=\"language-rust\">x()</code>",
-           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">\n<span class=\"boring\">#![allow(unused_variables)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+           "<pre class=\"playpen\"><code class=\"language-rust edition2015\">\n<span class=\"boring\">#![allow(unused)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
           ("<code class=\"language-rust\">fn main() {}</code>",
            "<pre class=\"playpen\"><code class=\"language-rust edition2015\">fn main() {}\n</code></pre>"),
           ("<code class=\"language-rust edition2015\">fn main() {}</code>",
@@ -832,7 +832,7 @@ mod tests {
     fn add_playpen_edition2018() {
         let inputs = [
           ("<code class=\"language-rust\">x()</code>",
-           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">\n<span class=\"boring\">#![allow(unused_variables)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+           "<pre class=\"playpen\"><code class=\"language-rust edition2018\">\n<span class=\"boring\">#![allow(unused)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
           ("<code class=\"language-rust\">fn main() {}</code>",
            "<pre class=\"playpen\"><code class=\"language-rust edition2018\">fn main() {}\n</code></pre>"),
           ("<code class=\"language-rust edition2015\">fn main() {}</code>",

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -349,7 +349,7 @@ impl Renderer for HtmlHandlebars {
                 data: data.clone(),
                 is_index,
                 html_config: html_config.clone(),
-                edition: ctx.config.book.edition,
+                edition: ctx.config.rust.edition,
             };
             self.render_item(item, ctx, &mut print_content)?;
             is_index = false;
@@ -365,7 +365,7 @@ impl Renderer for HtmlHandlebars {
         debug!("Render template");
         let rendered = handlebars.render("index", &data)?;
 
-        let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.book.edition);
+        let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.rust.edition);
 
         utils::fs::write_file(&destination, "print.html", rendered.as_bytes())?;
         debug!("Creating print.html ✓");


### PR DESCRIPTION
On #1100.
Made new top-level configuration `[rust]` and moved edition config under it.
cc: @kpp @ehuss 