### PR TITLE
Mention that .gitignore is used for watch excludes (#1160)

### DIFF
--- a/book-example/src/cli/serve.md
+++ b/book-example/src/cli/serve.md
@@ -46,3 +46,14 @@ The `--dest-dir` (`-d`) option allows you to change the output directory for the
 book. Relative paths are interpreted relative to the book's root directory. If
 not specified it will default to the value of the `build.build-dir` key in
 `book.toml`, or to `./book`.
+
+#### Specify exclude patterns
+
+The `serve` command will not automatically trigger a build for files listed in
+the `.gitignore` file in the book root directory. The `.gitignore` file may
+contain file patterns described in the [gitignore
+documentation](https://git-scm.com/docs/gitignore). This can be useful for
+ignoring temporary files created by some editors.
+
+_Note: Only `.gitignore` from book root directory is used. Global
+`$HOME/.gitignore` or `.gitignore` files in parent directories are not used._

--- a/book-example/src/cli/watch.md
+++ b/book-example/src/cli/watch.md
@@ -25,3 +25,15 @@ The `--dest-dir` (`-d`) option allows you to change the output directory for the
 book. Relative paths are interpreted relative to the book's root directory. If
 not specified it will default to the value of the `build.build-dir` key in
 `book.toml`, or to `./book`.
+
+
+#### Specify exclude patterns
+
+The `watch` command will not automatically trigger a build for files listed in
+the `.gitignore` file in the book root directory. The `.gitignore` file may
+contain file patterns described in the [gitignore
+documentation](https://git-scm.com/docs/gitignore). This can be useful for
+ignoring temporary files created by some editors.
+
+_Note: Only `.gitignore` from book root directory is used. Global
+`$HOME/.gitignore` or `.gitignore` files in parent directories are not used._


### PR DESCRIPTION
This PR is adding documentation of `.gitignore` file use for `watch` and `serve` command exclude patterns when checking for modified files.

It is a follow-up to #1160 and incorporates answer from @ehuss and my observation that global `.gitignore` files are not used.

I confirmed that by checking the code, but feel free to let me know if I've overlooked something.