### PR TITLE
Add config option to disable print html, css, and icon

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -187,6 +187,9 @@ The following configuration options are available:
 - **additional-js:** If you need to add some behaviour to your book without
   removing the current behaviour, you can specify a set of JavaScript files that
   will be loaded alongside the default one.
+- **print:** A subtable for configuration print settings. mdBook by default adds
+  support for printing out the book as a single page. This is accessed using the
+  print icon on the top right of the book.
 - **no-section-label:** mdBook by defaults adds section label in table of
   contents column. For example, "1.", "2.1". Set this option to true to disable
   those labels. Defaults to `false`.
@@ -216,6 +219,11 @@ The following configuration options are available:
   site*][custom domain]).
 
 [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
+
+Available configuration options for the `[output.html.print]` table:
+
+- **enable:** Enable print support. When `false`, all print support will not be
+  rendered. Defaults to `true`.
 
 Available configuration options for the `[output.html.fold]` table:
 
@@ -281,6 +289,9 @@ git-repository-icon = "fa-github"
 site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"
+
+[output.html.print]
+enable = true
 
 [output.html.fold]
 enable = false

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -109,10 +109,9 @@ impl BookBuilder {
     fn copy_across_theme(&self) -> Result<()> {
         debug!("Copying theme");
 
-        let themedir = self
-            .config
-            .html_config()
-            .and_then(|html| html.theme)
+        let html_config = self.config.html_config().unwrap_or_default();
+        let themedir = html_config
+            .theme
             .unwrap_or_else(|| self.config.book.src.join("theme"));
         let themedir = self.root.join(themedir);
 
@@ -136,8 +135,10 @@ impl BookBuilder {
         let mut chrome_css = File::create(cssdir.join("chrome.css"))?;
         chrome_css.write_all(theme::CHROME_CSS)?;
 
-        let mut print_css = File::create(cssdir.join("print.css"))?;
-        print_css.write_all(theme::PRINT_CSS)?;
+        if html_config.print.enable {
+            let mut print_css = File::create(cssdir.join("print.css"))?;
+            print_css.write_all(theme::PRINT_CSS)?;
+        }
 
         let mut variables_css = File::create(cssdir.join("variables.css"))?;
         variables_css.write_all(theme::VARIABLES_CSS)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -495,6 +495,8 @@ pub struct HtmlConfig {
     /// Playground settings.
     #[serde(alias = "playpen")]
     pub playground: Playground,
+    /// Print settings.
+    pub print: Print,
     /// Don't render section labels.
     pub no_section_label: bool,
     /// Search settings. If `None`, the default will be used.
@@ -542,6 +544,7 @@ impl Default for HtmlConfig {
             additional_js: Vec::new(),
             fold: Fold::default(),
             playground: Playground::default(),
+            print: Print::default(),
             no_section_label: false,
             search: None,
             git_repository_url: None,
@@ -563,6 +566,20 @@ impl HtmlConfig {
             Some(ref d) => root.join(d),
             None => root.join("theme"),
         }
+    }
+}
+
+/// Configuration for how to render the print icon, print.html, and print.css.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Print {
+    /// Whether print support is enabled.
+    pub enable: bool,
+}
+
+impl Default for Print {
+    fn default() -> Self {
+        Self { enable: true }
     }
 }
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -29,7 +29,9 @@
         <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/general.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/chrome.css">
+        {{#if print_enable}}
         <link rel="stylesheet" href="{{ path_to_root }}css/print.css" media="print">
+        {{/if}}
 
         <!-- Fonts -->
         <link rel="stylesheet" href="{{ path_to_root }}FontAwesome/css/font-awesome.css">
@@ -136,9 +138,11 @@
                     <h1 class="menu-title">{{ book_title }}</h1>
 
                     <div class="right-buttons">
+                        {{#if print_enable}}
                         <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
                             <i id="print-button" class="fa fa-print"></i>
                         </a>
+                        {{/if}}
                         {{#if git_repository_url}}
                         <a href="{{git_repository_url}}" title="Git repository" aria-label="Git repository">
                             <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>


### PR DESCRIPTION
This PR adds a new config option which allows you to disable all "print" support.

```toml
[output.html.print]
enable = false
```

Resolves #1177