### PR TITLE
implement support for book parts

### DIFF
--- a/book-example/src/format/summary.md
+++ b/book-example/src/format/summary.md
@@ -22,9 +22,11 @@ allow for easy parsing. Let's see how you should format your `SUMMARY.md` file.
    [Title of prefix element](relative/path/to/markdown.md)
    ```
 
-3. ***Part Title:*** An optional title for the next collect of numbered
-   chapters. The numbered chapters can be broken into as many parts as
-   desired.
+3. ***Part Title:*** Headers can be used as a title for the following numbered
+   chapters. This can be used to logically separate different sections
+   of book. The title is rendered as unclickable text.
+   Titles are optional, and the numbered chapters can be broken into as many
+   parts as desired.
 
 4. ***Numbered Chapter*** Numbered chapters are the main content of the book,
    they will be numbered and can be nested, resulting in a nice hierarchy

--- a/book-example/src/format/summary.md
+++ b/book-example/src/format/summary.md
@@ -22,15 +22,25 @@ allow for easy parsing. Let's see how you should format your `SUMMARY.md` file.
    [Title of prefix element](relative/path/to/markdown.md)
    ```
 
-3. ***Numbered Chapter*** Numbered chapters are the main content of the book,
+3. ***Part Title:*** An optional title for the next collect of numbered
+   chapters. The numbered chapters can be broken into as many parts as
+   desired.
+
+4. ***Numbered Chapter*** Numbered chapters are the main content of the book,
    they will be numbered and can be nested, resulting in a nice hierarchy
    (chapters, sub-chapters, etc.)
    ```markdown
+   # Title of Part
+
    - [Title of the Chapter](relative/path/to/markdown.md)
+
+   # Title of Another Part
+
+   - [More Chapters](relative/path/to/markdown2.md)
    ```
    You can either use `-` or `*` to indicate a numbered chapter.
 
-4. ***Suffix Chapter*** After the numbered chapters you can add a couple of
+5. ***Suffix Chapter*** After the numbered chapters you can add a couple of
    non-numbered chapters. They are the same as prefix chapters but come after
    the numbered chapters instead of before.
 
@@ -50,5 +60,5 @@ error.
   of contents, as you can see for the next chapter in the table of contents on the left.
   Draft chapters are written like normal chapters but without writing the path to the file
   ```markdown
-  - [Draft chapter]()  
-  ``` 
+  - [Draft chapter]()
+  ```

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -31,7 +31,12 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
     let mut items: Vec<_> = summary
         .prefix_chapters
         .iter()
-        .chain(summary.numbered_chapters.iter())
+        .chain(
+            summary
+                .parts
+                .iter()
+                .flat_map(|part| part.numbered_chapters.iter()),
+        )
         .chain(summary.suffix_chapters.iter())
         .collect();
 
@@ -133,6 +138,8 @@ pub enum BookItem {
     Chapter(Chapter),
     /// A section separator.
     Separator,
+    /// A part title.
+    PartTitle(String),
 }
 
 impl From<Chapter> for BookItem {
@@ -205,17 +212,24 @@ pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P)
     debug!("Loading the book from disk");
     let src_dir = src_dir.as_ref();
 
-    let prefix = summary.prefix_chapters.iter();
-    let numbered = summary.numbered_chapters.iter();
-    let suffix = summary.suffix_chapters.iter();
-
-    let summary_items = prefix.chain(numbered).chain(suffix);
-
     let mut chapters = Vec::new();
 
-    for summary_item in summary_items {
-        let chapter = load_summary_item(summary_item, src_dir, Vec::new())?;
-        chapters.push(chapter);
+    for prefix_chapter in &summary.prefix_chapters {
+        chapters.push(load_summary_item(prefix_chapter, src_dir, Vec::new())?);
+    }
+
+    for part in &summary.parts {
+        if let Some(title) = &part.title {
+            chapters.push(BookItem::PartTitle(title.clone()));
+        }
+
+        for numbered_chapter in &part.numbered_chapters {
+            chapters.push(load_summary_item(numbered_chapter, src_dir, Vec::new())?);
+        }
+    }
+
+    for suffix_chapter in &summary.suffix_chapters {
+        chapters.push(load_summary_item(suffix_chapter, src_dir, Vec::new())?);
     }
 
     Ok(Book {
@@ -327,6 +341,7 @@ impl Display for Chapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::book::summary::Part;
     use std::io::Write;
     use tempfile::{Builder as TempFileBuilder, TempDir};
 
@@ -430,7 +445,10 @@ And here is some \
     fn load_a_book_with_a_single_chapter() {
         let (link, temp) = dummy_link();
         let summary = Summary {
-            numbered_chapters: vec![SummaryItem::Link(link)],
+            parts: vec![Part {
+                title: None,
+                numbered_chapters: vec![SummaryItem::Link(link)],
+            }],
             ..Default::default()
         };
         let should_be = Book {
@@ -564,11 +582,14 @@ And here is some \
     fn cant_load_chapters_with_an_empty_path() {
         let (_, temp) = dummy_link();
         let summary = Summary {
-            numbered_chapters: vec![SummaryItem::Link(Link {
-                name: String::from("Empty"),
-                location: Some(PathBuf::from("")),
-                ..Default::default()
-            })],
+            parts: vec![Part {
+                title: None,
+                numbered_chapters: vec![SummaryItem::Link(Link {
+                    name: String::from("Empty"),
+                    location: Some(PathBuf::from("")),
+                    ..Default::default()
+                })],
+            }],
             ..Default::default()
         };
 
@@ -583,11 +604,14 @@ And here is some \
         fs::create_dir(&dir).unwrap();
 
         let summary = Summary {
-            numbered_chapters: vec![SummaryItem::Link(Link {
-                name: String::from("nested"),
-                location: Some(dir),
-                ..Default::default()
-            })],
+            parts: vec![Part {
+                title: None,
+                numbered_chapters: vec![SummaryItem::Link(Link {
+                    name: String::from("nested"),
+                    location: Some(dir),
+                    ..Default::default()
+                })],
+            }],
             ..Default::default()
         };
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -132,6 +132,7 @@ impl MDBook {
     ///     match *item {
     ///         BookItem::Chapter(ref chapter) => {},
     ///         BookItem::Separator => {},
+    ///         BookItem::PartTitle(ref title) => {}
     ///     }
     /// }
     ///

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -374,10 +374,12 @@ impl<'a> SummaryParser<'a> {
 
         loop {
             match self.next_event() {
-                Some(ev @ Event::Start(Tag::Paragraph)) if !first => {
-                    // we're starting the suffix chapters
-                    self.back(ev);
-                    break;
+                Some(ev @ Event::Start(Tag::Paragraph)) => {
+                    if !first {
+                        // we're starting the suffix chapters
+                        self.back(ev);
+                        break;
+                    }
                 }
                 // The expectation is that pulldown cmark will terminate a paragraph before a new
                 // heading, so we can always count on this to return without skipping headings.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -514,6 +514,9 @@ fn make_data(
         let mut chapter = BTreeMap::new();
 
         match *item {
+            BookItem::PartTitle(ref title) => {
+                chapter.insert("part".to_owned(), json!(title));
+            }
             BookItem::Chapter(ref ch) => {
                 if let Some(ref section) = ch.number {
                     chapter.insert("section".to_owned(), json!(section.to_string()));

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -99,6 +99,14 @@ impl HelperDef for RenderToc {
                 write_li_open_tag(out, is_expanded, item.get("section").is_none())?;
             }
 
+            // Part title
+            if let Some(title) = item.get("part") {
+                out.write("<li class=\"part-title active\">")?;
+                out.write(title)?;
+                out.write("</li>")?;
+                continue;
+            }
+
             // Link
             let path_exists = if let Some(path) = item.get("path") {
                 if !path.is_empty() {

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -166,3 +166,8 @@ blockquote {
 .tooltipped .tooltiptext {
     visibility: visible;
 }
+
+.chapter li.part-title {
+    color: var(--sidebar-fg);
+    margin: 5px 0px;
+}

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -170,4 +170,5 @@ blockquote {
 .chapter li.part-title {
     color: var(--sidebar-fg);
     margin: 5px 0px;
+    font-weight: bold;
 }


### PR DESCRIPTION
Implements support for breaking the list of chapters in `SUMMARY.md` into parts. This is useful for really long books that (e.g. rustc-dev-guide).

Some notable things:
- I think this makes breaking changes to some public APIs of the `mdbook` crate.
- I did some refactoring on the `SUMMARY.md` parser that I think cleans things up a bit. In particular, I gave the parser the ability to lookahead 1 token, which got rid of some edge cases and prevents every combinator from having to figure out if they are missing their first token. The new convention is that if your combinator discovers it has gone too far, it puts back the last token it read.

Here is a sample of what it looks like:

![image](https://user-images.githubusercontent.com/8827840/77217631-df0c2880-6af1-11ea-95de-03ff48657154.png)

