### PR TITLE
Support anchors in SUMMARY

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -320,7 +320,7 @@ And here is some \
             .write_all(DUMMY_SRC.as_bytes())
             .unwrap();
 
-        let link = Link::new("Chapter 1", chapter_path);
+        let link = Link::new("Chapter 1", chapter_path, None);
 
         (link, temp)
     }
@@ -336,7 +336,7 @@ And here is some \
             .write_all(b"Hello World!")
             .unwrap();
 
-        let mut second = Link::new("Nested Chapter 1", &second_path);
+        let mut second = Link::new("Nested Chapter 1", &second_path, None);
         second.number = Some(SectionNumber(vec![1, 2]));
 
         root.nested_items.push(second.clone().into());
@@ -362,7 +362,7 @@ And here is some \
 
     #[test]
     fn cant_load_a_nonexistent_chapter() {
-        let link = Link::new("Chapter 1", "/foo/bar/baz.md");
+        let link = Link::new("Chapter 1", "/foo/bar/baz.md", None);
 
         let got = load_chapter(&link, "", Vec::new());
         assert!(got.is_err());

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -153,6 +153,8 @@ pub struct Chapter {
     pub sub_items: Vec<BookItem>,
     /// The chapter's location, relative to the `SUMMARY.md` file.
     pub path: PathBuf,
+    /// An optional anchor in the original link.
+    pub anchor: Option<String>,
     /// An ordered list of the names of each chapter above this one, in the hierarchy.
     pub parent_names: Vec<String>,
 }
@@ -243,6 +245,7 @@ fn load_chapter<P: AsRef<Path>>(
     let mut sub_item_parents = parent_names.clone();
     let mut ch = Chapter::new(&link.name, content, stripped, parent_names);
     ch.number = link.number.clone();
+    ch.anchor = link.anchor.clone();
 
     sub_item_parents.push(link.name.clone());
     let sub_items = link
@@ -379,6 +382,7 @@ And here is some \
             path: PathBuf::from("second.md"),
             parent_names: vec![String::from("Chapter 1")],
             sub_items: Vec::new(),
+            anchor: None,
         };
         let should_be = BookItem::Chapter(Chapter {
             name: String::from("Chapter 1"),
@@ -391,6 +395,7 @@ And here is some \
                 BookItem::Separator,
                 BookItem::Chapter(nested.clone()),
             ],
+            anchor: None,
         });
 
         let got = load_summary_item(&SummaryItem::Link(root), temp.path(), Vec::new()).unwrap();
@@ -465,6 +470,7 @@ And here is some \
                             Vec::new(),
                         )),
                     ],
+                    anchor: None,
                 }),
                 BookItem::Separator,
             ],
@@ -517,6 +523,7 @@ And here is some \
                             Vec::new(),
                         )),
                     ],
+                    anchor: None,
                 }),
                 BookItem::Separator,
             ],

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -31,8 +31,7 @@ impl HtmlHandlebars {
     ) -> Result<()> {
         // FIXME: This should be made DRY-er and rely less on mutable state
         if let BookItem::Chapter(ref ch) = *item {
-            let content = ch.content.clone();
-            let content = utils::render_markdown(&content, ctx.html_config.curly_quotes);
+            let content = utils::render_markdown(&ch.content, ctx.html_config.curly_quotes);
 
             let fixed_content = utils::render_markdown_with_path(
                 &ch.content,
@@ -79,6 +78,10 @@ impl HtmlHandlebars {
             if let Some(ref section) = ch.number {
                 ctx.data
                     .insert("section".to_owned(), json!(section.to_string()));
+            }
+
+            if let Some(anchor) = &ch.anchor {
+                ctx.data.insert("anchor".to_owned(), json!(anchor));
             }
 
             // Render the handlebars template with the data
@@ -520,6 +523,10 @@ fn make_data(
                     .to_str()
                     .chain_err(|| "Could not convert path to str")?;
                 chapter.insert("path".to_owned(), json!(path));
+
+                if let Some(anchor) = &ch.anchor {
+                    chapter.insert("anchor".to_owned(), json!(anchor));
+                }
             }
             BookItem::Separator => {
                 chapter.insert("spacer".to_owned(), json!("_spacer_"));

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -72,8 +72,8 @@ fn find_chapter(
             Target::Next => match chapters
                 .iter()
                 .filter(|chapter| {
-                    // Skip things like "spacer"
-                    chapter.contains_key("path")
+                    // Skip things like "spacer" or sub-links
+                    chapter.contains_key("path") && !chapter.contains_key("anchor")
                 })
                 .skip(1)
                 .next()
@@ -90,7 +90,7 @@ fn find_chapter(
 
     for item in chapters {
         match item.get("path") {
-            Some(path) if !path.is_empty() => {
+            Some(path) if !path.is_empty() && item.get("anchor").is_none() => {
                 if let Some(previous) = previous {
                     if let Some(item) = target.find(&base_path, &path, &item, &previous)? {
                         return Ok(Some(item));

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -111,7 +111,7 @@ impl HelperDef for RenderToc {
                 if !path.is_empty() {
                     out.write("<a href=\"")?;
 
-                    let tmp = Path::new(item.get("path").expect("Error: path should be Some(_)"))
+                    let tmp = Path::new(path)
                         .with_extension("html")
                         .to_str()
                         .unwrap()
@@ -121,9 +121,16 @@ impl HelperDef for RenderToc {
                     // Add link
                     out.write(&utils::fs::path_to_root(&current_path))?;
                     out.write(&tmp)?;
+
+                    let anchor = item.get("anchor");
+                    if let Some(anchor) = anchor {
+                        out.write("#")?;
+                        out.write(anchor)?;
+                    }
+
                     out.write("\"")?;
 
-                    if path == &current_path {
+                    if anchor.is_none() && path == &current_path {
                         out.write(" class=\"active\"")?;
                     }
 


### PR DESCRIPTION
While porting a [book of mine](https://github.com/mcarton/rust-derivative/tree/master/doc) from GitBook to mdBook, I noticed that anchors are not supported in the SUMMARY file:

For example, given the following summary:

```markdown
- [Foo](Foo.md)
    - [Subfoo 1](Foo.md#anchor-1)
    - [Subfoo 2](Foo.md#anchor-2)
- [Bar](Bar.md)
```

The following wrong things are going to happen when running `mdbook build`:

- Files `doc/Foo#anchor-1.md` and `doc/Foo#anchor-2.md` are going to be created.
- The navigation panel will only ever highlight "Subfoo 2" whether you click on "Foo", "Subfoo 1" or "Subfoo 2".
- The navigation arrows don't work: the left arrow can't go back, the right arrow points to the last sub-section.
- All 3 links in the `Foo` section point to `Foo.html`, which is empty.