### PR TITLE
Fix sidebar line-height.

### DIFF
--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -191,7 +191,7 @@ fn write_li_open_tag(
     is_expanded: bool,
     is_affix: bool,
 ) -> Result<(), std::io::Error> {
-    let mut li = String::from("<li class=\"");
+    let mut li = String::from("<li class=\"chapter-item ");
     if is_expanded {
         li.push_str("expanded ");
     }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -423,7 +423,7 @@ ul#searchresults span.teaser em {
     display: none;
 }
 
-.chapter li.expanded {
+.chapter li.chapter-item {
     line-height: 1.5em;
     margin-top: 0.6em;
 }


### PR DESCRIPTION
Fixes #1168.

The issue is that the CSS was selecting for `.expanded`, but that doesn't match collapsed items, causing the lines to jump around as the "expanded" class was added/removed.

The solution is to give a dedicated class for chapter items, and apply the styling to those.  A separate class is more convenient, so it doesn't need to deal with matching the bare `<li>` which is used for grouping collapsed sections, and also "spacer" entries.
