### PR TITLE
Broaden scope of suppressed warnings for listings without a main fn

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -633,7 +633,7 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
                                 let (attrs, code) = partition_source(code);
 
                                 format!(
-                                    "\n# #![allow(unused_variables)]\n{}#fn main() {{\n{}#}}",
+                                    "\n# #![allow(unused)]\n{}#fn main() {{\n{}#}}",
                                     attrs, code
                                 )
                                 .into()
@@ -756,7 +756,7 @@ mod tests {
     fn add_playpen() {
         let inputs = [
           ("<code class=\"language-rust\">x()</code>",
-           "<pre class=\"playpen\"><code class=\"language-rust\">\n<span class=\"boring\">#![allow(unused_variables)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+           "<pre class=\"playpen\"><code class=\"language-rust\">\n<span class=\"boring\">#![allow(unused)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
           ("<code class=\"language-rust\">fn main() {}</code>",
            "<pre class=\"playpen\"><code class=\"language-rust\">fn main() {}\n</code></pre>"),
           ("<code class=\"language-rust editable\">let s = \"foo\n # bar\n\";</code>",


### PR DESCRIPTION
At present, code listings without a main function will be wrapped in one and annotated with an allow lint check attribute provided by the following [code][]:

```rust
format!(
    "\n# #![allow(unused_variables)]\n{}#fn main() {{\n{}#}}",
    attrs, code
)
```

A broader lint check attribute such as `#![allow(unused)]` seems like it might better fit the apparent intent of this code.

Addresses: https://github.com/rust-lang/mdBook/issues/1192

[code]: https://github.com/rust-lang/mdBook/blob/769cc0a7c14fe133fc5eb223f435473730d0086e/src/renderer/html_handlebars/hbs_renderer.rs#L635-L638