### PR TITLE
Enable `MDBOOK_BOOK`  to overwrite `book.toml`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,22 @@ impl Config {
             let parsed_value = serde_json::from_str(&value)
                 .unwrap_or_else(|_| serde_json::Value::String(value.to_string()));
 
+            if matches!(&*key, "book" | "build") {
+                if let serde_json::Value::Object(ref map) = parsed_value {
+                    // To `set` each `key`, we wrap them as `prefix.key`
+                    let prefix = &key; // "book" or "build"
+                    let mut s = String::new();
+                    for (k, v) in map {
+                        s.clear();
+                        s.push_str(prefix);
+                        s.push('.');
+                        s.push_str(k);
+                        self.set(&s, v).expect("unreachable");
+                    }
+                    return;
+                }
+            }
+
             self.set(key, parsed_value).expect("unreachable");
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,7 @@ impl Config {
     /// > when building the book with something like
     /// >
     /// > ```text
-    /// > $ export MDBOOK_BOOK="{'title': 'My Awesome Book', authors: ['Michael-F-Bryan']}"
+    /// > $ export MDBOOK_BOOK="{'title': 'My Awesome Book', 'authors': ['Michael-F-Bryan']}"
     /// > $ mdbook build
     /// > ```
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,7 @@ impl Config {
     /// > when building the book with something like
     /// >
     /// > ```text
-    /// > $ export MDBOOK_BOOK="{'title': 'My Awesome Book', 'authors': ['Michael-F-Bryan']}"
+    /// > $ export MDBOOK_BOOK='{"title": "My Awesome Book", "authors": ["Michael-F-Bryan"]}'
     /// > $ mdbook build
     /// > ```
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ impl Config {
             let parsed_value = serde_json::from_str(&value)
                 .unwrap_or_else(|_| serde_json::Value::String(value.to_string()));
 
-            if matches!(&*key, "book" | "build") {
+            if key == "book" || key == "build" {
                 if let serde_json::Value::Object(ref map) = parsed_value {
                     // To `set` each `key`, we wrap them as `prefix.key`
                     let prefix = &key; // "book" or "build"

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,14 +145,9 @@ impl Config {
             if key == "book" || key == "build" {
                 if let serde_json::Value::Object(ref map) = parsed_value {
                     // To `set` each `key`, we wrap them as `prefix.key`
-                    let prefix = &key; // "book" or "build"
-                    let mut s = String::new();
                     for (k, v) in map {
-                        s.clear();
-                        s.push_str(prefix);
-                        s.push('.');
-                        s.push_str(k);
-                        self.set(&s, v).expect("unreachable");
+                        let full_key = format!("{}.{}", key, k);
+                        self.set(&full_key, v).expect("unreachable");
                     }
                     return;
                 }


### PR DESCRIPTION
[Config::update_from_env](https://github.com/rust-lang/mdBook/blob/master/src/config.rs#L134) says:

```rust
/// > This means, if you so desired, you could override all book metadata
/// > when building the book with something like
/// >
/// > ```text
/// > $ export MDBOOK_BOOK="{'title': 'My Awesome Book', authors: ['Michael-F-Bryan']}"
/// > $ mdbook build
/// > ```
```

This is wrong in two ways:

1. We can't overwrite `book.toml` with `MDBOOK_BOOK`
2. The example value of `MDBOOK_BOOK` is a wrong JSON string (missing/wrong quotes)

So I fixed them so that the example works. But I didn't add any automated test.