### PR TITLE
#1098 Links preprocessor: support pluses

### DIFF
--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -364,14 +364,14 @@ fn find_links(contents: &str) -> LinkIter<'_> {
     // r"\\\{\{#.*\}\}|\{\{#([a-zA-Z0-9]+)\s*([a-zA-Z0-9_.\-:/\\\s]+)\}\}")?;
     lazy_static! {
         static ref RE: Regex = Regex::new(
-            r"(?x)                     # insignificant whitespace mode
-            \\\{\{\#.*\}\}             # match escaped link
-            |                          # or
-            \{\{\s*                    # link opening parens and whitespace
-            \#([a-zA-Z0-9_]+)          # link type
-            \s+                        # separating whitespace
-            ([a-zA-Z0-9\s_.\-:/\\]+)   # link target path and space separated properties
-            \s*\}\}                    # whitespace and link closing parens"
+            r"(?x)                       # insignificant whitespace mode
+            \\\{\{\#.*\}\}               # match escaped link
+            |                            # or
+            \{\{\s*                      # link opening parens and whitespace
+            \#([a-zA-Z0-9_]+)            # link type
+            \s+                          # separating whitespace
+            ([a-zA-Z0-9\s_.\-:/\\\+]+)   # link target path and space separated properties
+            \s*\}\}                      # whitespace and link closing parens"
         )
         .unwrap();
     }

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -452,6 +452,24 @@ mod tests {
     }
 
     #[test]
+    fn test_find_links_with_special_characters() {
+        let s = "Some random text with {{#playpen foo-bar\\baz/_c++.rs}}...";
+
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+
+        assert_eq!(
+            res,
+            vec![Link {
+                start_index: 22,
+                end_index: 54,
+                link_type: LinkType::Playpen(PathBuf::from("foo-bar\\baz/_c++.rs"), vec![]),
+                link_text: "{{#playpen foo-bar\\baz/_c++.rs}}",
+            },]
+        );
+    }
+
+    #[test]
     fn test_find_links_with_range() {
         let s = "Some random text with {{#include file.rs:10:20}}...";
         let res = find_links(s).collect::<Vec<_>>();


### PR DESCRIPTION
* A simple fix to support `+` in links paths.
* A test for special characters _mdBook_ does support.

This partially solves #1098.