### PR TITLE
Generate 404.html page (#539)

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [output.html]
 mathjax-support = true
-site-url = "/"
+site-url = "/mdBook/"
 
 [output.html.playpen]
 editable = true

--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [output.html]
 mathjax-support = true
+site-url = "/"
 
 [output.html.playpen]
 editable = true

--- a/book-example/src/404.md
+++ b/book-example/src/404.md
@@ -1,0 +1,3 @@
+# Document not found (404)
+
+This URL is invalid, sorry. Try the search instead!

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -204,6 +204,12 @@ The following configuration options are available:
   `/appendices/bibliography.html`). The value can be any valid URI the
   browser should navigate to (e.g. `https://rust-lang.org/`,
   `/overview.html`, or `../bibliography.html`).
+- **input-404:** The name of the markdown file used for misssing files.
+  The corresponding output file will be the same, with the extension replaced with `html`.
+  Defaults to `404.md`.
+- **site-url:** The url where the book will be hosted. This is required to ensure
+  navigation links and script/css imports in the 404 file work correctly, even when accessing
+  urls in subdirectories. Defaults to `/`.
 
 Available configuration options for the `[output.html.fold]` table:
 
@@ -266,6 +272,8 @@ additional-js = ["custom.js"]
 no-section-label = false
 git-repository-url = "https://github.com/rust-lang/mdBook"
 git-repository-icon = "fa-github"
+site-url = "/example-book/"
+input-404 = "not-found.md"
 
 [output.html.fold]
 enable = false

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -142,7 +142,11 @@ async fn serve(build_dir: PathBuf, address: SocketAddr, reload_tx: broadcast::Se
             })
         });
     // A warp Filter that serves from the filesystem.
-    let book_route = warp::fs::dir(build_dir);
-    let routes = livereload.or(book_route);
+    let book_route = warp::fs::dir(build_dir.clone());
+    // The fallback route for 404 errors
+    let fallback_file = "404.html";
+    let fallback_route = warp::fs::file(build_dir.join(fallback_file))
+        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::NOT_FOUND));
+    let routes = livereload.or(book_route).or(fallback_route);
     warp::serve(routes).run(address).await;
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -83,7 +83,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         .config
         .get("output.html.input-404")
         .map(toml::Value::as_str)
-        .flatten()
+        .and_then(std::convert::identity) // flatten
         .map(ToString::to_string);
     let file_404 = get_404_output_file(&input_404);
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -83,8 +83,9 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         .config
         .get("output.html.input-404")
         .map(toml::Value::as_str)
-        .flatten();
-    let file_404 = get_404_output_file(input_404);
+        .flatten()
+        .map(ToString::to_string);
+    let file_404 = get_404_output_file(&input_404);
 
     // A channel used to broadcast to any websockets to reload when a file changes.
     let (tx, _rx) = tokio::sync::broadcast::channel::<Message>(100);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1022,10 +1022,7 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, None);
-        assert_eq!(
-            &get_404_output_file(&html_config.input_404),
-            "404.html"
-        );
+        assert_eq!(&get_404_output_file(&html_config.input_404), "404.html");
     }
 
     #[test]
@@ -1039,9 +1036,6 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, Some("missing.md".to_string()));
-        assert_eq!(
-            &get_404_output_file(&html_config.input_404),
-            "missing.html"
-        );
+        assert_eq!(&get_404_output_file(&html_config.input_404), "missing.html");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -511,6 +511,8 @@ pub struct HtmlConfig {
     pub input_404: Option<String>,
     /// Output path for 404.html file, defaults to 404.html, set to "" to disable 404 file output
     pub output_404: Option<String>,
+    /// Absolute url to site, used to emit correct paths for the 404 page, which might be accessed in a deeply nested directory
+    pub site_url: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where
@@ -544,6 +546,7 @@ impl Default for HtmlConfig {
             git_repository_icon: None,
             input_404: None,
             output_404: None,
+            site_url: None,
             livereload_url: None,
             redirect: HashMap::new(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1023,7 +1023,7 @@ mod tests {
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, None);
         assert_eq!(
-            &get_404_output_file(html_config.input_404.as_deref()),
+            &get_404_output_file(&html_config.input_404),
             "404.html"
         );
     }
@@ -1040,7 +1040,7 @@ mod tests {
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, Some("missing.md".to_string()));
         assert_eq!(
-            &get_404_output_file(html_config.input_404.as_deref()),
+            &get_404_output_file(&html_config.input_404),
             "missing.html"
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,10 +507,8 @@ pub struct HtmlConfig {
     /// FontAwesome icon class to use for the Git repository link.
     /// Defaults to `fa-github` if `None`.
     pub git_repository_icon: Option<String>,
-    /// Input path for the 404 file, defaults to 404.md
+    /// Input path for the 404 file, defaults to 404.md, set to "" to disable 404 file output
     pub input_404: Option<String>,
-    /// Output path for 404.html file, defaults to 404.html, set to "" to disable 404 file output
-    pub output_404: Option<String>,
     /// Absolute url to site, used to emit correct paths for the 404 page, which might be accessed in a deeply nested directory
     pub site_url: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
@@ -545,7 +543,6 @@ impl Default for HtmlConfig {
             git_repository_url: None,
             git_repository_icon: None,
             input_404: None,
-            output_404: None,
             site_url: None,
             livereload_url: None,
             redirect: HashMap::new(),
@@ -679,6 +676,7 @@ impl<'de, T> Updateable<'de> for T where T: Serialize + Deserialize<'de> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::fs::get_404_output_file;
 
     const COMPLEX_CONFIG: &str = r#"
         [book]
@@ -1024,7 +1022,10 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, None);
-        assert_eq!(html_config.output_404, None);
+        assert_eq!(
+            &get_404_output_file(html_config.input_404.as_deref()),
+            "404.html"
+        );
     }
 
     #[test]
@@ -1038,6 +1039,9 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, Some("missing.md".to_string()));
-        assert_eq!(html_config.output_404, Some("missing.html".to_string()));
+        assert_eq!(
+            &get_404_output_file(html_config.input_404.as_deref()),
+            "missing.html"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,6 +507,10 @@ pub struct HtmlConfig {
     /// FontAwesome icon class to use for the Git repository link.
     /// Defaults to `fa-github` if `None`.
     pub git_repository_icon: Option<String>,
+    /// Input path for the 404 file, defaults to 404.md
+    pub input_404: Option<String>,
+    /// Output path for 404.html file, defaults to 404.html, set to "" to disable 404 file output
+    pub output_404: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where
@@ -538,6 +542,8 @@ impl Default for HtmlConfig {
             search: None,
             git_repository_url: None,
             git_repository_icon: None,
+            input_404: None,
+            output_404: None,
             livereload_url: None,
             redirect: HashMap::new(),
         }
@@ -1003,5 +1009,32 @@ mod tests {
         cfg.update_from_env();
 
         assert_eq!(cfg.book.title, Some(should_be));
+    }
+
+    #[test]
+    fn file_404_default() {
+        let src = r#"
+        [output.html]
+        destination = "my-book"
+        "#;
+
+        let got = Config::from_str(src).unwrap();
+        let html_config = got.html_config().unwrap();
+        assert_eq!(html_config.input_404, None);
+        assert_eq!(html_config.output_404, None);
+    }
+
+    #[test]
+    fn file_404_custom() {
+        let src = r#"
+        [output.html]
+        input-404= "missing.md"
+        output-404= "missing.html"
+        "#;
+
+        let got = Config::from_str(src).unwrap();
+        let html_config = got.html_config().unwrap();
+        assert_eq!(html_config.input_404, Some("missing.md".to_string()));
+        assert_eq!(html_config.output_404, Some("missing.html".to_string()));
     }
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -464,6 +464,13 @@ impl Renderer for HtmlHandlebars {
             let html_content_404 = utils::render_markdown(&content_404, html_config.curly_quotes);
 
             let mut data_404 = data.clone();
+            let base_url = if let Some(site_url) = &html_config.site_url {
+                site_url
+            } else {
+                warn!("HTML 'site-url' parameter not set, defaulting to '/'. Please configure this to ensure the 404 page work correctly, especially if your site is hosted in a subdirectory on the HTTP server.");
+                "/"
+            };
+            data_404.insert("base_url".to_owned(), json!(base_url));
             data_404.insert("path".to_owned(), json!("404.md"));
             data_404.insert("content".to_owned(), json!(html_content_404));
             let rendered = handlebars.render("index", &data_404)?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
+use crate::utils::fs::get_404_output_file;
 use handlebars::Handlebars;
 use regex::{Captures, Regex};
 
@@ -102,6 +103,58 @@ impl HtmlHandlebars {
             utils::fs::write_file(&ctx.destination, "index.html", rendered_index.as_bytes())?;
         }
 
+        Ok(())
+    }
+
+    fn render_404(
+        &self,
+        ctx: &RenderContext,
+        html_config: &HtmlConfig,
+        src_dir: &PathBuf,
+        handlebars: &mut Handlebars<'_>,
+        data: &mut serde_json::Map<String, serde_json::Value>,
+    ) -> Result<()> {
+        let destination = &ctx.destination;
+        let content_404 = if let Some(ref filename) = html_config.input_404 {
+            let path = src_dir.join(filename);
+            std::fs::read_to_string(&path)
+                .with_context(|| format!("unable to open 404 input file {:?}", path))?
+        } else {
+            // 404 input not explicitly configured try the default file 404.md
+            let default_404_location = src_dir.join("404.md");
+            if default_404_location.exists() {
+                std::fs::read_to_string(&default_404_location).with_context(|| {
+                    format!("unable to open 404 input file {:?}", default_404_location)
+                })?
+            } else {
+                "# Document not found (404)\n\nThis URL is invalid, sorry. Please use the \
+                navigation bar or search to continue."
+                    .to_string()
+            }
+        };
+        let html_content_404 = utils::render_markdown(&content_404, html_config.curly_quotes);
+
+        let mut data_404 = data.clone();
+        let base_url = if let Some(site_url) = &html_config.site_url {
+            site_url
+        } else {
+            debug!(
+                "HTML 'site-url' parameter not set, defaulting to '/'. Please configure \
+                this to ensure the 404 page work correctly, especially if your site is hosted in a \
+                subdirectory on the HTTP server."
+            );
+            "/"
+        };
+        data_404.insert("base_url".to_owned(), json!(base_url));
+        // Set a dummy path to ensure other paths (e.g. in the TOC) are generated correctly
+        data_404.insert("path".to_owned(), json!("404.md"));
+        data_404.insert("content".to_owned(), json!(html_content_404));
+        let rendered = handlebars.render("index", &data_404)?;
+
+        let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.rust.edition);
+        let output_file = get_404_output_file(html_config.input_404.as_deref());
+        utils::fs::write_file(&destination, output_file, rendered.as_bytes())?;
+        debug!("Creating 404.html ✓");
         Ok(())
     }
 
@@ -438,51 +491,8 @@ impl Renderer for HtmlHandlebars {
         }
 
         // Render 404 page
-        if html_config.output_404 != Some("".to_string()) {
-            let default_404_location = src_dir.join("404.md");
-            let content_404 = if let Some(ref filename) = html_config.input_404 {
-                let path = src_dir.join(filename);
-                std::fs::read_to_string(&path).map_err(|failure| {
-                    std::io::Error::new(
-                        failure.kind(),
-                        format!("Unable to open 404 input file {:?}", &path),
-                    )
-                })?
-            } else if default_404_location.exists() {
-                std::fs::read_to_string(&default_404_location).map_err(|failure| {
-                    std::io::Error::new(
-                        failure.kind(),
-                        format!(
-                            "Unable to open default 404 input file {:?}",
-                            &default_404_location
-                        ),
-                    )
-                })?
-            } else {
-                "# 404 - Document not found\n\nUnfortunately, this URL is no longer valid, please use the navigation bar or search to continue.".to_string()
-            };
-            let html_content_404 = utils::render_markdown(&content_404, html_config.curly_quotes);
-
-            let mut data_404 = data.clone();
-            let base_url = if let Some(site_url) = &html_config.site_url {
-                site_url
-            } else {
-                warn!("HTML 'site-url' parameter not set, defaulting to '/'. Please configure this to ensure the 404 page work correctly, especially if your site is hosted in a subdirectory on the HTTP server.");
-                "/"
-            };
-            data_404.insert("base_url".to_owned(), json!(base_url));
-            data_404.insert("path".to_owned(), json!("404.md"));
-            data_404.insert("content".to_owned(), json!(html_content_404));
-            let rendered = handlebars.render("index", &data_404)?;
-
-            let rendered =
-                self.post_process(rendered, &html_config.playpen, ctx.config.rust.edition);
-            let output_file = match &html_config.output_404 {
-                None => "404.html",
-                Some(file) => &file,
-            };
-            utils::fs::write_file(&destination, output_file, rendered.as_bytes())?;
-            debug!("Creating 404.html ✓");
+        if html_config.input_404 != Some("".to_string()) {
+            self.render_404(ctx, &html_config, &src_dir, &mut handlebars, &mut data)?;
         }
 
         // Print version

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -152,7 +152,7 @@ impl HtmlHandlebars {
         let rendered = handlebars.render("index", &data_404)?;
 
         let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.rust.edition);
-        let output_file = get_404_output_file(html_config.input_404.as_deref());
+        let output_file = get_404_output_file(&html_config.input_404);
         utils::fs::write_file(&destination, output_file, rendered.as_bytes())?;
         debug!("Creating 404.html ✓");
         Ok(())

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -7,6 +7,10 @@
         {{#if is_print }}
         <meta name="robots" content="noindex" />
         {{/if}}
+        {{#if base_url}}
+        <base href="{{ base_url }}">
+        {{/if}}
+
 
         <!-- Custom HTML head -->
         {{> head}}

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -177,6 +177,10 @@ pub fn copy_files_except_ext(
     Ok(())
 }
 
+pub fn get_404_output_file(input_404: Option<&str>) -> String {
+    input_404.unwrap_or("404.md").replace(".md", ".html")
+}
+
 #[cfg(test)]
 mod tests {
     use super::copy_files_except_ext;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -178,7 +178,10 @@ pub fn copy_files_except_ext(
 }
 
 pub fn get_404_output_file(input_404: &Option<String>) -> String {
-    input_404.as_ref().unwrap_or(&"404.md".to_string()).replace(".md", ".html")
+    input_404
+        .as_ref()
+        .unwrap_or(&"404.md".to_string())
+        .replace(".md", ".html")
 }
 
 #[cfg(test)]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -177,8 +177,8 @@ pub fn copy_files_except_ext(
     Ok(())
 }
 
-pub fn get_404_output_file(input_404: Option<&str>) -> String {
-    input_404.unwrap_or("404.md").replace(".md", ".html")
+pub fn get_404_output_file(input_404: &Option<String>) -> String {
+    input_404.as_ref().unwrap_or(&"404.md".to_string()).replace(".md", ".html")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Prototype spike for a 404 page (cf #539).

This PR generates a 404.html file with sidebar navigation and search intact, to better handle broken or stale links.
Additionally, the builtin server serves this file on 404 errors.

Comments and feedback appreciated!