### PR TITLE
Fix dest-dir command-line flag.

### DIFF
--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -28,7 +28,14 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
 // Watch command implementation
 pub fn execute(args: &ArgMatches) -> Result<()> {
     let book_dir = get_book_dir(args);
-    let book = MDBook::load(&book_dir)?;
+    let mut book = MDBook::load(&book_dir)?;
+
+    let update_config = |book: &mut MDBook| {
+        if let Some(dest_dir) = args.value_of("dest-dir") {
+            book.config.build.build_dir = dest_dir.into();
+        }
+    };
+    update_config(&mut book);
 
     if args.is_present("open") {
         book.build()?;
@@ -37,7 +44,10 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     trigger_on_change(&book, |paths, book_dir| {
         info!("Files changed: {:?}\nBuilding book...\n", paths);
-        let result = MDBook::load(&book_dir).and_then(|b| b.build());
+        let result = MDBook::load(&book_dir).and_then(|mut b| {
+            update_config(&mut b);
+            b.build()
+        });
 
         if let Err(e) = result {
             error!("Unable to build the book");

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -151,7 +151,8 @@ impl HtmlHandlebars {
         data_404.insert("content".to_owned(), json!(html_content_404));
         let rendered = handlebars.render("index", &data_404)?;
 
-        let rendered = self.post_process(rendered, &html_config.playpen, ctx.config.rust.edition);
+        let rendered =
+            self.post_process(rendered, &html_config.playground, ctx.config.rust.edition);
         let output_file = get_404_output_file(&html_config.input_404);
         utils::fs::write_file(&destination, output_file, rendered.as_bytes())?;
         debug!("Creating 404.html ✓");


### PR DESCRIPTION
The `--dest-dir` flag was not working correctly for `serve` and `watch`.  `watch` was ignoring it completely.  `serve` was only using it during the first build, then ignoring it afterwards.

Closes #1226