### PR TITLE
Do not allow the sidebar to be dragged outside the window.

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -456,6 +456,11 @@ function playpen_text(playpen) {
     // Toggle sidebar
     sidebarToggleButton.addEventListener('click', function sidebarToggle() {
         if (html.classList.contains("sidebar-hidden")) {
+            var current_width = parseInt(
+                document.documentElement.style.getPropertyValue('--sidebar-width'), 10);
+            if (current_width < 150) {
+                document.documentElement.style.setProperty('--sidebar-width', '150px');
+            }
             showSidebar();
         } else if (html.classList.contains("sidebar-visible")) {
             hideSidebar();
@@ -476,7 +481,16 @@ function playpen_text(playpen) {
         html.classList.add('sidebar-resizing');
     }
     function resize(e) {
-        document.documentElement.style.setProperty('--sidebar-width', (e.clientX - sidebar.offsetLeft) + 'px');
+        var pos = (e.clientX - sidebar.offsetLeft);
+        if (pos < 20) {
+            hideSidebar();
+        } else {
+            if (html.classList.contains("sidebar-hidden")) {
+                showSidebar();
+            }
+            pos = Math.min(pos, window.innerWidth - 100);
+            document.documentElement.style.setProperty('--sidebar-width', pos + 'px');
+        }
     }
     //on mouseup remove windows functions mousemove & mouseup
     function stopResize(e) {


### PR DESCRIPTION
This sets some limits so that the sidebar position cannot be dragged outside of the window.

Closes #1224

![sidebar-width](https://user-images.githubusercontent.com/43198/82157000-ac518880-9833-11ea-83e2-4cfac20280d8.gif)
