### PR TITLE
Implement URL redirecting

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -198,6 +198,10 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
+- **redirect:** A subtable used for generating redirects when a page is moved.
+  The table contains key-value pairs where the key is the path to the moved
+  page, relative to the build directory and the value can be an ordinary URL
+  or the *absolute* path to another page in the book
 
 Available configuration options for the `[output.html.fold]` table:
 
@@ -281,6 +285,10 @@ boost-paragraph = 1
 expand = true
 heading-split-level = 3
 copy-js = true
+
+[output.html.redirect]
+"other-installation-methods.html" = "/infra/other-installation-methods.html"
+"bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
 ```
 
 ### Markdown Renderer
@@ -291,7 +299,7 @@ conjunction with `mdbook test` to see the Markdown that `mdbook` is passing
 to `rustdoc`.
 
 The Markdown renderer is included with `mdbook` but disabled by default.
-Enable it by adding an emtpy table to your `book.toml` as follows:
+Enable it by adding an empty table to your `book.toml` as follows:
 
 ```toml
 [output.markdown]

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -289,7 +289,7 @@ heading-split-level = 3
 copy-js = true
 
 [output.html.redirect]
-/appendices/"bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
+"/appendices/bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
 "/other-installation-methods.html" = "../infra/other-installation-methods.html"
 ```
 

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -199,9 +199,11 @@ The following configuration options are available:
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
 - **redirect:** A subtable used for generating redirects when a page is moved.
-  The table contains key-value pairs where the key is the path to the moved
-  page, relative to the build directory and the value can be an ordinary URL
-  or the *absolute* path to another page in the book
+  The table contains key-value pairs where the key is where the redirect file
+  needs to be created, as an absolute path from the build directory, (e.g.
+  `/appendices/bibliography.html`). The value can be any valid URI the
+  browser should navigate to (e.g. `https://rust-lang.org/`,
+  `/overview.html`, or `../bibliography.html`).
 
 Available configuration options for the `[output.html.fold]` table:
 
@@ -287,8 +289,8 @@ heading-split-level = 3
 copy-js = true
 
 [output.html.redirect]
-"other-installation-methods.html" = "/infra/other-installation-methods.html"
-"bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
+/appendices/"bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
+"/other-installation-methods.html" = "../infra/other-installation-methods.html"
 ```
 
 ### Markdown Renderer

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@
 #![deny(missing_docs)]
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::Read;
@@ -514,6 +515,9 @@ pub struct HtmlConfig {
     /// This config item *should not be edited* by the end user.
     #[doc(hidden)]
     pub livereload_url: Option<String>,
+    /// The mapping from old pages to new pages/URLs to use when generating
+    /// redirects.
+    pub redirect: HashMap<PathBuf, String>,
 }
 
 impl Default for HtmlConfig {
@@ -693,6 +697,10 @@ mod tests {
         editable = true
         editor = "ace"
 
+        [output.html.redirect]
+        "index.html" = "overview.html"
+        "nexted/page.md" = "https://rust-lang.org/"
+
         [preprocessor.first]
 
         [preprocessor.second]
@@ -731,6 +739,15 @@ mod tests {
             playpen: playpen_should_be,
             git_repository_url: Some(String::from("https://foo.com/")),
             git_repository_icon: Some(String::from("fa-code-fork")),
+            redirect: vec![
+                (PathBuf::from("index.html"), String::from("overview.html")),
+                (
+                    PathBuf::from("nexted/page.md"),
+                    String::from("https://rust-lang.org/"),
+                ),
+            ]
+            .into_iter()
+            .collect(),
             ..Default::default()
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -539,6 +539,7 @@ impl Default for HtmlConfig {
             git_repository_url: None,
             git_repository_icon: None,
             livereload_url: None,
+            redirect: HashMap::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -517,7 +517,7 @@ pub struct HtmlConfig {
     pub livereload_url: Option<String>,
     /// The mapping from old pages to new pages/URLs to use when generating
     /// redirects.
-    pub redirect: HashMap<PathBuf, String>,
+    pub redirect: HashMap<String, String>,
 }
 
 impl Default for HtmlConfig {
@@ -741,9 +741,9 @@ mod tests {
             git_repository_url: Some(String::from("https://foo.com/")),
             git_repository_icon: Some(String::from("fa-code-fork")),
             redirect: vec![
-                (PathBuf::from("index.html"), String::from("overview.html")),
+                (String::from("index.html"), String::from("overview.html")),
                 (
-                    PathBuf::from("nexted/page.md"),
+                    String::from("nexted/page.md"),
                     String::from("https://rust-lang.org/"),
                 ),
             ]

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -9,7 +9,7 @@ use crate::utils;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
 use handlebars::Handlebars;
@@ -279,6 +279,46 @@ impl HtmlHandlebars {
 
         Ok(())
     }
+
+    fn emit_redirects(
+        &self,
+        root: &Path,
+        handlebars: &Handlebars<'_>,
+        redirects: &HashMap<PathBuf, String>,
+    ) -> Result<()> {
+        if redirects.is_empty() {
+            return Ok(());
+        }
+
+        log::debug!("Emitting redirects");
+
+        for (original, new) in redirects {
+            log::debug!("Redirecting \"{}\" → \"{}\"", original.display(), new);
+            let filename = root.join(original);
+            self.emit_redirect(handlebars, &filename, new)?;
+        }
+
+        Ok(())
+    }
+
+    fn emit_redirect(
+        &self,
+        handlebars: &Handlebars<'_>,
+        original: &Path,
+        destination: &str,
+    ) -> Result<()> {
+        if let Some(parent) = original.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let ctx = json!({
+            "url": destination,
+        });
+        let f = File::create(original)?;
+        handlebars.render_to_write("redirect", &ctx, f)?;
+
+        Ok(())
+    }
 }
 
 // TODO(mattico): Remove some time after the 0.1.8 release
@@ -343,6 +383,10 @@ impl Renderer for HtmlHandlebars {
         debug!("Register the head handlebars template");
         handlebars.register_partial("head", String::from_utf8(theme.head.clone())?)?;
 
+        debug!("Register the redirect handlebars template");
+        handlebars
+            .register_template_string("redirect", String::from_utf8(theme.redirect.clone())?)?;
+
         debug!("Register the header handlebars template");
         handlebars.register_partial("header", String::from_utf8(theme.header.clone())?)?;
 
@@ -400,6 +444,8 @@ impl Renderer for HtmlHandlebars {
                 super::search::create_files(&search, &destination, &book)?;
             }
         }
+
+        self.emit_redirects(&ctx.destination, &handlebars, &html_config.redirect)?;
 
         // Copy all remaining files, avoid a recursive copy from/to the book build dir
         utils::fs::copy_files_except_ext(&src_dir, &destination, true, Some(&build_dir), &["md"])?;

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -15,6 +15,7 @@ use crate::errors::*;
 
 pub static INDEX: &[u8] = include_bytes!("index.hbs");
 pub static HEAD: &[u8] = include_bytes!("head.hbs");
+pub static REDIRECT: &[u8] = include_bytes!("redirect.hbs");
 pub static HEADER: &[u8] = include_bytes!("header.hbs");
 pub static CHROME_CSS: &[u8] = include_bytes!("css/chrome.css");
 pub static GENERAL_CSS: &[u8] = include_bytes!("css/general.css");
@@ -46,6 +47,7 @@ pub static FONT_AWESOME_OTF: &[u8] = include_bytes!("FontAwesome/fonts/FontAweso
 pub struct Theme {
     pub index: Vec<u8>,
     pub head: Vec<u8>,
+    pub redirect: Vec<u8>,
     pub header: Vec<u8>,
     pub chrome_css: Vec<u8>,
     pub general_css: Vec<u8>,
@@ -77,6 +79,7 @@ impl Theme {
             let files = vec![
                 (theme_dir.join("index.hbs"), &mut theme.index),
                 (theme_dir.join("head.hbs"), &mut theme.head),
+                (theme_dir.join("redirect.hbs"), &mut theme.redirect),
                 (theme_dir.join("header.hbs"), &mut theme.header),
                 (theme_dir.join("book.js"), &mut theme.js),
                 (theme_dir.join("css/chrome.css"), &mut theme.chrome_css),
@@ -120,6 +123,7 @@ impl Default for Theme {
         Theme {
             index: INDEX.to_owned(),
             head: HEAD.to_owned(),
+            redirect: REDIRECT.to_owned(),
             header: HEADER.to_owned(),
             chrome_css: CHROME_CSS.to_owned(),
             general_css: GENERAL_CSS.to_owned(),
@@ -175,6 +179,7 @@ mod tests {
         let files = [
             "index.hbs",
             "head.hbs",
+            "redirect.hbs",
             "header.hbs",
             "favicon.png",
             "css/chrome.css",
@@ -203,6 +208,7 @@ mod tests {
         let empty = Theme {
             index: Vec::new(),
             head: Vec::new(),
+            redirect: Vec::new(),
             header: Vec::new(),
             chrome_css: Vec::new(),
             general_css: Vec::new(),

--- a/src/theme/redirect.hbs
+++ b/src/theme/redirect.hbs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;URL='{{url}}'">
+    <meta rel="canonical" href="{{url}}">
+  </head>
+  <body>
+      <p>Redirecting to... <a href="{{url}}">{{url}}</a>.</p>
+  </body>
+</html>

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -519,7 +519,7 @@ fn redirects_are_emitted_correctly() {
 
     // override the "outputs.html.redirect" table
     let redirects: HashMap<PathBuf, String> = vec![
-        (PathBuf::from("index.html"), String::from("overview.html")),
+        (PathBuf::from("overview.html"), String::from("index.html")),
         (
             PathBuf::from("nexted/page.md"),
             String::from("https://rust-lang.org/"),

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -519,9 +519,9 @@ fn redirects_are_emitted_correctly() {
 
     // override the "outputs.html.redirect" table
     let redirects: HashMap<PathBuf, String> = vec![
-        (PathBuf::from("overview.html"), String::from("index.html")),
+        (PathBuf::from("/overview.html"), String::from("index.html")),
         (
-            PathBuf::from("nexted/page.md"),
+            PathBuf::from("/nexted/page.md"),
             String::from("https://rust-lang.org/"),
         ),
     ]


### PR DESCRIPTION
This is a fairly straightforward implementation based on the comments from #430.

Fixes #430, CC #1235.

---

Some potential future work would be allowing the user to configure redirects inline with a `[output.html.redirect]` table in `book.toml` or reading from a `key = value` file discovered by having some sort of `redirect = "redirects.txt"` under the `[output.html]` table. 

This is easy enough to implement in a backwards-compatible way (backwards-compatible for end users, it would require a library change) by swapping the `HashMap<String, String>` for some `RedirectsMap` enum that is either a `HashMap` or ` PathBuf`, and giving the `RedirectsMap` a `load_redirects() -> Result<impl Iterator<Item = (String, String)>, Error>` method.

I've decided to skip that for now, seeing as it's not really needed for @XAMPPRocky's use case and seems like overkill.
