### PR TITLE
Fix issue where Font Awesome overrides `.hidden`'s `display: none`

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -34,7 +34,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
 .right { float: right; }
 .boring { opacity: 0.6; }
 .hide-boring .boring { display: none; }
-.hidden { display: none; }
+.hidden { display: none !important; }
 
 h2, h3 { margin-top: 2.5em; }
 h4, h5 { margin-top: 2em; }


### PR DESCRIPTION
By adding `!important` to `display: none` in `.hidden`, it will prevent Font Awesome's `.fa` class from overriding the `display` property. This fixes #1247 