### PR TITLE
Fix highlighting theme order of precedence

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -29,9 +29,9 @@
         {{/if}}
 
         <!-- Highlight.js Stylesheets -->
-        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
         <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
         <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
 
         <!-- Custom theme stylesheets -->
         {{#each additional_css}}


### PR DESCRIPTION
> the files used for syntax highlighting can be overridden with your own

> Now your theme will be used instead of the default theme.

With the old order of stylesheets, the default theme would override the
custom one.