### PR TITLE
Fix sidebar scrolling with part titles.

### DIFF
--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -101,7 +101,7 @@ impl HelperDef for RenderToc {
 
             // Part title
             if let Some(title) = item.get("part") {
-                out.write("<li class=\"part-title active\">")?;
+                out.write("<li class=\"part-title\">")?;
                 out.write(title)?;
                 out.write("</li>")?;
                 continue;


### PR DESCRIPTION
If a summary included section titles, then the automatic scrolling for the sidebar was broken (it was always scrolled to the top of the sidebar).
