### PR TITLE
Fix CI due to new rustup.

### DIFF
--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -12,7 +12,7 @@ TOOLCHAIN="$1"
 
 rustup set profile minimal
 rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
-rustup update $TOOLCHAIN
+rustup update --no-self-update $TOOLCHAIN
 rustup default $TOOLCHAIN
 rustup -V
 rustc -Vv


### PR DESCRIPTION
For some reason, on Windows, `rustup update` fails with `/c/Rust/.cargo/bin/rustup: Device or resource busy`. Just skip rustup self-updates for now.
