### PR TITLE
Sets favicon order for Chrome, modifies favicon.png

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -20,8 +20,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />
 
+        <link rel="icon" href="{{ path_to_root }}favicon.png">
         <link rel="icon" href="{{ path_to_root }}favicon.svg">
-        <link rel="shortcut icon" href="{{ path_to_root }}favicon.png">
         <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/general.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/chrome.css">


### PR DESCRIPTION
A couple of small changes I want to bring to attention (sorry for the lengthy description!)

1. Chrome does not seem to favour SVG favicons over PNG favicons. Rather, it loads the last favicon defined in the HTML. In Firefox, SVG favicons take precedence regardless of how it's defined in the HTML. One caveat I discovered when making this small change: I originally thought the PNG favicon was being loaded before my change. However, due to the size of the PNG favicon being 196x196, Chrome ignored it and loaded the SVG favicon instead. It seems to ignore PNG favicons larger than 32x32. When I fixed the PNG favicon to be 32x32, it unfortunately does not look great in dark mode:

<img width="300" alt="Screenshot 2020-07-12 at 18 52 05" src="https://user-images.githubusercontent.com/47347/87263195-3d7a5f80-c471-11ea-8fa5-6a21af4d23de.png">

The PNG favicon change in this PR simply reduces the resolution to 32x32, but longer term solution should be to update the favicon to support both system modes (dark, light) since it's not something that can be manipulated via CSS `@media` query.

2. The `shortcut` link type seems to be non-conforming and should not be used anymore according to [MDN web docs][1]. Hence, it was removed as part of the PR.

Both browsers tested on the latest: Chrome 83.0.4103.116, Firefox 78.0.2. I reported the favicon issue to [Chromium][2]. We'll see what they have to say.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
[2]: https://bugs.chromium.org/p/chromium/issues/detail?id=1104663