### PR TITLE
Mention that uninstalled backend isn't marked optional.

### DIFF
--- a/book-example/src/for_developers/backends.md
+++ b/book-example/src/for_developers/backends.md
@@ -334,7 +334,9 @@ the usual `RUST_LOG` to control logging verbosity.
 If you enable a backend that isn't installed, the default behavior is to throw an error:
 
 ```text
-The command wasn't found, is the "wordcount" backend installed?
+The command `mdbook-wordcount` wasn't found, is the "wordcount" backend installed?
+If you want to ignore this error when the "wordcount" backend is not installed,
+set `optional = true` in the `[output.wordcount]` section of the book.toml configuration file.
 ```
 
 This behavior can be changed by marking the backend as optional.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -173,7 +173,9 @@ impl CmdRenderer {
                 return Ok(());
             } else {
                 error!(
-                    "The command `{}` wasn't found, is the `{}` backend installed?",
+                    "The command `{0}` wasn't found, is the \"{1}\" backend installed? \
+                    If you want to ignore this error when the \"{1}\" backend is not installed, \
+                    set `optional = true` in the `[output.{1}]` section of the book.toml configuration file.",
                     self.cmd, self.name
                 );
             }


### PR DESCRIPTION
If an uninstalled backend (command not found) isn't marked optional,
warn about it, since it causes mdbook commands to error out.

Fixes #1283