### PR TITLE
allow space in SUMMARY.md's link destination

### DIFF
--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -333,6 +333,7 @@ impl<'a> SummaryParser<'a> {
 
     /// Finishes parsing a link once the `Event::Start(Tag::Link(..))` has been opened.
     fn parse_link(&mut self, href: String) -> Link {
+        let href = href.replace("%20", " ").replace("+", " ");
         let link_content = collect_events!(self.stream, end Tag::Link(..));
         let name = stringify_events(link_content);
 
@@ -945,6 +946,37 @@ mod tests {
             .parse_numbered(&mut 0, &mut SectionNumber::default())
             .unwrap();
 
+        assert_eq!(got, should_be);
+    }
+    
+    #[test]
+    fn allow_space_in_link_destination() {
+        let src = "- [test1](./test%20link1.md)\n- [test2](./test+link2.md)\n- [test3](<./test link3.md>)";
+        let should_be = vec![
+            SummaryItem::Link(Link {
+                name: String::from("test1"),
+                location: Some(PathBuf::from("./test link1.md")),
+                number: Some(SectionNumber(vec![1])),
+                nested_items: Vec::new(),
+            }),
+            SummaryItem::Link(Link {
+                name: String::from("test2"),
+                location: Some(PathBuf::from("./test link2.md")),
+                number: Some(SectionNumber(vec![2])),
+                nested_items: Vec::new(),
+            }),
+            SummaryItem::Link(Link {
+                name: String::from("test3"),
+                location: Some(PathBuf::from("./test link3.md")),
+                number: Some(SectionNumber(vec![3])),
+                nested_items: Vec::new(),
+            }),
+        ];
+        let mut parser = SummaryParser::new(src);
+        let got = parser
+            .parse_numbered(&mut 0, &mut SectionNumber::default())
+            .unwrap();
+        
         assert_eq!(got, should_be);
     }
 }

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -333,7 +333,7 @@ impl<'a> SummaryParser<'a> {
 
     /// Finishes parsing a link once the `Event::Start(Tag::Link(..))` has been opened.
     fn parse_link(&mut self, href: String) -> Link {
-        let href = href.replace("%20", " ").replace("+", " ");
+        let href = href.replace("%20", " ");
         let link_content = collect_events!(self.stream, end Tag::Link(..));
         let name = stringify_events(link_content);
 
@@ -948,10 +948,10 @@ mod tests {
 
         assert_eq!(got, should_be);
     }
-    
+
     #[test]
     fn allow_space_in_link_destination() {
-        let src = "- [test1](./test%20link1.md)\n- [test2](./test+link2.md)\n- [test3](<./test link3.md>)";
+        let src = "- [test1](./test%20link1.md)\n- [test2](<./test link2.md>)";
         let should_be = vec![
             SummaryItem::Link(Link {
                 name: String::from("test1"),
@@ -965,18 +965,12 @@ mod tests {
                 number: Some(SectionNumber(vec![2])),
                 nested_items: Vec::new(),
             }),
-            SummaryItem::Link(Link {
-                name: String::from("test3"),
-                location: Some(PathBuf::from("./test link3.md")),
-                number: Some(SectionNumber(vec![3])),
-                nested_items: Vec::new(),
-            }),
         ];
         let mut parser = SummaryParser::new(src);
         let got = parser
             .parse_numbered(&mut 0, &mut SectionNumber::default())
             .unwrap();
-        
+
         assert_eq!(got, should_be);
     }
 }


### PR DESCRIPTION
Related issues: #527 #1287 

As stated in [CommonMark Spec](https://spec.commonmark.org/0.28/#link-destination):

> A link destination consists of either
>
> *  a sequence of zero or more characters between an opening `<` and a closing `>` that contains no spaces, line breaks, or unescaped `<` or `>` characters, or
>
> * a nonempty sequence of characters that does not include ASCII space or control characters, and includes parentheses only if (a) they are backslash-escaped or (b) they are part of a balanced pair of unescaped parentheses. (Implementations may impose limits on parentheses nesting to avoid performance issues, but at least three levels of nesting should be supported.)

and [according to this](https://github.com/Microsoft/vscode/issues/24763) and MDN spec [Percent-encoding](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding), there are three ways to allow space in link destination:

```markdown
- [test1](./test%20link1.md)
- [test2](./test+link2.md)
- [test3](<./test link3.md>)
```

For now, mdBook only supports method 3, which is rarely used compared to method 1 and 2.

So I fix it and add a test.