### PR TITLE
Adds information about markdown flavor in the documentation.

### DIFF
--- a/book-example/src/README.md
+++ b/book-example/src/README.md
@@ -1,8 +1,8 @@
 # mdBook
 
 **mdBook** is a command line tool and Rust crate to create books using Markdown
-files. It's very similar to Gitbook but written in
-[Rust](http://www.rust-lang.org).
+(as by the [CommonMark](https://commonmark.org/) specification) files. It's very
+similar to Gitbook but written in [Rust](http://www.rust-lang.org).
 
 What you are reading serves as an example of the output of mdBook and at the
 same time as a high-level documentation.


### PR DESCRIPTION
I could only find the information about which interpretation of markdown was used in the changelog and in some github issues.

I thought it would make sense to make it explicit in the documentation.