### PR TITLE
add page break and chapter name options for printing

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -255,7 +255,6 @@ Available configuration options for the `[output.html.search]` table:
 Available configuration options for the `[output.html.print]` table:
 
 - **page-break:** Insert page breaks between chapters. Defaults to `true`.
-- **chapter-name** Insert chapter name before each chapter. Defaults to `false`.
 
 This shows all available HTML output options in the **book.toml**:
 
@@ -303,8 +302,7 @@ heading-split-level = 3
 copy-js = true
 
 [output.html.print]
-page-break = true
-chapter-name = true
+page-break = false
 
 [output.html.redirect]
 "/appendices/bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -254,7 +254,7 @@ Available configuration options for the `[output.html.search]` table:
 
 Available configuration options for the `[output.html.print]` table:
 
-- **page-break:** Insert page breaks between chapters. Defaults to `false`.
+- **page-break:** Insert page breaks between chapters. Defaults to `true`.
 - **chapter-name** Insert chapter name before each chapter. Defaults to `false`.
 
 This shows all available HTML output options in the **book.toml**:

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -210,6 +210,7 @@ The following configuration options are available:
 - **site-url:** The url where the book will be hosted. This is required to ensure
   navigation links and script/css imports in the 404 file work correctly, even when accessing
   urls in subdirectories. Defaults to `/`.
+- **print:** A subtable for configuring the printed version (PDF in most case) of HTML.
 
 Available configuration options for the `[output.html.fold]` table:
 
@@ -250,6 +251,11 @@ Available configuration options for the `[output.html.search]` table:
   level or less. Defaults to `3`. (`### This is a level 3 heading`)
 - **copy-js:** Copy JavaScript files for the search implementation to the output
   directory. Defaults to `true`.
+
+Available configuration options for the `[output.html.print]` table:
+
+- **page-break:** Insert page breaks between chapters. Defaults to `false`.
+- **chapter-name** Insert chapter name before each chapter. Defaults to `false`.
 
 This shows all available HTML output options in the **book.toml**:
 
@@ -295,6 +301,10 @@ boost-paragraph = 1
 expand = true
 heading-split-level = 3
 copy-js = true
+
+[output.html.print]
+page-break = true
+chapter-name = true
 
 [output.html.redirect]
 "/appendices/bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"

--- a/src/config.rs
+++ b/src/config.rs
@@ -519,6 +519,8 @@ pub struct HtmlConfig {
     /// The mapping from old pages to new pages/URLs to use when generating
     /// redirects.
     pub redirect: HashMap<String, String>,
+    /// Print settings.
+    pub print: Print,
 }
 
 impl Default for HtmlConfig {
@@ -543,6 +545,7 @@ impl Default for HtmlConfig {
             site_url: None,
             livereload_url: None,
             redirect: HashMap::new(),
+            print: Print::default(),
         }
     }
 }
@@ -592,6 +595,25 @@ impl Default for Playground {
             copyable: true,
             copy_js: true,
             line_numbers: false,
+        }
+    }
+}
+
+/// Configuration for printing of HTML
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct Print {
+    /// Insert page breaks between chapters. Default: `false`.
+    pub page_break: bool,
+    /// Insert chapter name before each chapter. Default: `false`.
+    pub chapter_name: bool,
+}
+
+impl Default for Print {
+    fn default() -> Print {
+        Print {
+            page_break: false,
+            chapter_name: false,
         }
     }
 }
@@ -706,6 +728,10 @@ mod tests {
         "index.html" = "overview.html"
         "nexted/page.md" = "https://rust-lang.org/"
 
+        [output.html.print]
+        page-break = true
+        chapter-name = true
+
         [preprocessor.first]
 
         [preprocessor.second]
@@ -735,6 +761,10 @@ mod tests {
             copy_js: true,
             line_numbers: false,
         };
+        let print_should_be = Print {
+            page_break: true,
+            chapter_name: true,
+        };
         let html_should_be = HtmlConfig {
             curly_quotes: true,
             google_analytics: Some(String::from("123456")),
@@ -753,6 +783,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            print: print_should_be,
             ..Default::default()
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -605,16 +605,11 @@ impl Default for Playground {
 pub struct Print {
     /// Insert page breaks between chapters. Default: `true`.
     pub page_break: bool,
-    /// Insert chapter name before each chapter. Default: `false`.
-    pub chapter_name: bool,
 }
 
 impl Default for Print {
     fn default() -> Print {
-        Print {
-            page_break: true,
-            chapter_name: false,
-        }
+        Print { page_break: true }
     }
 }
 
@@ -730,7 +725,6 @@ mod tests {
 
         [output.html.print]
         page-break = true
-        chapter-name = true
 
         [preprocessor.first]
 
@@ -761,10 +755,7 @@ mod tests {
             copy_js: true,
             line_numbers: false,
         };
-        let print_should_be = Print {
-            page_break: true,
-            chapter_name: true,
-        };
+        let print_should_be = Print { page_break: true };
         let html_should_be = HtmlConfig {
             curly_quotes: true,
             google_analytics: Some(String::from("123456")),

--- a/src/config.rs
+++ b/src/config.rs
@@ -603,7 +603,7 @@ impl Default for Playground {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Print {
-    /// Insert page breaks between chapters. Default: `false`.
+    /// Insert page breaks between chapters. Default: `true`.
     pub page_break: bool,
     /// Insert chapter name before each chapter. Default: `false`.
     pub chapter_name: bool,
@@ -612,7 +612,7 @@ pub struct Print {
 impl Default for Print {
     fn default() -> Print {
         Print {
-            page_break: false,
+            page_break: true,
             chapter_name: false,
         }
     }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -51,11 +51,6 @@ impl HtmlHandlebars {
             // Add both two CSS properties because of the compatibility issue
             print_content.push_str(r#"<div id="chapter_begin" style="break-before: page; page-break-before: always;"></div>"#);
         }
-        let rendered_chapter_name = utils::render_markdown(&ch.name, ctx.html_config.curly_quotes);
-        if ctx.html_config.print.chapter_name {
-            // Insert chapter name before each chapter.
-            print_content.push_str(&format!("<h1>{}</h1>", rendered_chapter_name));
-        }
         print_content.push_str(&fixed_content);
 
         // Update the context with data for this file

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -45,6 +45,17 @@ impl HtmlHandlebars {
             ctx.html_config.curly_quotes,
             Some(&path),
         );
+        if !ctx.is_index && ctx.html_config.print.page_break {
+            // Add page break between chapters
+            // See https://developer.mozilla.org/en-US/docs/Web/CSS/break-before and https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-before
+            // Add both two CSS properties because of the compatibility issue
+            print_content.push_str(r#"<div id="chapter_begin" style="break-before: page; page-break-before: always;"></div>"#);
+        }
+        let rendered_chapter_name = utils::render_markdown(&ch.name, ctx.html_config.curly_quotes);
+        if ctx.html_config.print.chapter_name {
+            // Insert chapter name before each chapter.
+            print_content.push_str(&format!("<h1>{}</h1>", rendered_chapter_name));
+        }
         print_content.push_str(&fixed_content);
 
         // Update the context with data for this file


### PR DESCRIPTION
# Background

For now, the only way to export to PDF format is by exporting to HTML and click the print button. However, the printed version simply hide the sidebar and merge all the chapters into one. This can lead to the loss of chapter information.

For example:

Chapter1.md:

```markdown
This is chapter 1.
```

Chapter2.md:

```markdown
This is chapter 2.
```

The printed version is 

```html
<p>This is chapter 1.</p>
<p>This is chapter 2.</p>
```

We can't determine the paragraph is in which chapter, which may be important for some books.

# Solutions

I add two options to solve this problem:

In `book.toml`:

```toml
[output.html.print]
page-break = true
chapter-name = true
```

First, `page-break` inserts page breaks between chapters. This is a common practice in many markdown editors, such as Typora. To implement this feature, I use CSS property [break-before](https://developer.mozilla.org/en-US/docs/Web/CSS/break-before) (and [page-break- before](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-before) for compatibility).

Second, `chapter-name` inserts chapter name before each chapter.

The above two options only works for the printed version (PDF in most case), and will not affect the HTML version.