### PR TITLE
Prefer bundled version of Source Code Pro

### DIFF
--- a/src/theme/fonts/fonts.css
+++ b/src/theme/fonts/fonts.css
@@ -96,6 +96,5 @@
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 500;
-  src: url('source-code-pro-v11-all-charsets-500.woff2') format('woff2'),
-       local('Source Code Pro Medium'), local('SourceCodePro-Medium');
+  src: url('source-code-pro-v11-all-charsets-500.woff2') format('woff2');
 }

--- a/src/theme/fonts/fonts.css
+++ b/src/theme/fonts/fonts.css
@@ -96,6 +96,6 @@
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 500;
-  src: local('Source Code Pro Medium'), local('SourceCodePro-Medium'),
-       url('source-code-pro-v11-all-charsets-500.woff2') format('woff2');
+  src: url('source-code-pro-v11-all-charsets-500.woff2') format('woff2'),
+       local('Source Code Pro Medium'), local('SourceCodePro-Medium');
 }


### PR DESCRIPTION
Fixes #1304.

This prevents an issue with Firefox 80 on macOS that prevents syntax
highlighting from working.