### PR TITLE
End .nojekyll file with newline

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -184,7 +184,7 @@ impl HtmlHandlebars {
         write_file(
             destination,
             ".nojekyll",
-            b"This file makes sure that Github Pages doesn't process mdBook's output.",
+            b"This file makes sure that Github Pages doesn't process mdBook's output.\n",
         )?;
 
         write_file(destination, "book.js", &theme.js)?;


### PR DESCRIPTION
See https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline.

Before:

```console
/path/to$  cat book/.nojekyll
This file makes sure that Github Pages doesn't process mdBook's output./path/to$  ▎
```

After:

```console
/path/to$  cat book/.nojekyll
This file makes sure that Github Pages doesn't process mdBook's output.
/path/to$  ▎
```