### PR TITLE
Adds an example of git-repository-url in book.toml

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -23,6 +23,7 @@ create-missing = false
 
 [output.html]
 additional-css = ["custom.css"]
+git-repository-url = "https://github.com/rust-lang/mdBook"
 
 [output.html.search]
 limit-results = 15


### PR DESCRIPTION
#802 seemingly didn't remember to update the docs with this option, this PR address it.