### PR TITLE
collect all test failures before failing

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -250,6 +250,7 @@ impl MDBook {
         // Index Preprocessor is disabled so that chapter paths continue to point to the
         // actual markdown files.
 
+        let mut failed = false;
         for item in book.iter() {
             if let BookItem::Chapter(ref ch) = *item {
                 let chapter_path = match ch.path {
@@ -282,7 +283,8 @@ impl MDBook {
                 let output = cmd.output()?;
 
                 if !output.status.success() {
-                    bail!(
+                    failed = true;
+                    error!(
                         "rustdoc returned an error:\n\
                         \n--- stdout\n{}\n--- stderr\n{}",
                         String::from_utf8_lossy(&output.stdout),
@@ -290,6 +292,9 @@ impl MDBook {
                     );
                 }
             }
+        }
+        if failed {
+            bail!("One of more tests failed");
         }
         Ok(())
     }

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -294,7 +294,7 @@ impl MDBook {
             }
         }
         if failed {
-            bail!("One of more tests failed");
+            bail!("One or more tests failed");
         }
         Ok(())
     }


### PR DESCRIPTION
I found that iterating on `mdbook` test is fairly slow as any failure in any file halts the process
This prints the error with `error~`, marks a failure, and then moves on

I tested that the return code is 0 on a passing book (i had a working local version of the cargo book) and that its non-0 on a non-passing book (`dummy_book` in `tests` is good for this)