### PR TITLE
Conditionally show compile warnings when running code

### DIFF
--- a/book-example/src/SUMMARY.md
+++ b/book-example/src/SUMMARY.md
@@ -14,7 +14,7 @@
     - [Configuration](format/config.md)
     - [Theme](format/theme/README.md)
         - [index.hbs](format/theme/index-hbs.md)
-        - [Syntax highlighting](format/theme/syntax-highlighting.md)
+        - [Code Blocks](format/theme/code-blocks.md)
         - [Editor](format/theme/editor.md)
     - [MathJax Support](format/mathjax.md)
     - [mdBook specific features](format/mdbook.md)

--- a/book-example/src/format/theme/code-blocks.md
+++ b/book-example/src/format/theme/code-blocks.md
@@ -1,16 +1,50 @@
-# Syntax Highlighting
+# Code Blocks
 
-For syntax highlighting I use [Highlight.js](https://highlightjs.org) with a
-custom theme.
-
+Syntax highlighted code blocks are supported using [Highlight.js](https://highlightjs.org)
+with a custom theme.  
 Automatic language detection has been turned off, so you will probably want to
 specify the programming language you use like this
-
 <pre><code class="language-markdown">```rust
 fn main() {
     // Some code
 }
 ```</code></pre>
+
+## Run Button
+Rust code blocks are runnable by default with a run button, for example:
+```rust
+fn main() {
+    println!("hello");
+}
+```
+Other languages are currently not supported.
+
+You can also diable the run button with `no_run`:
+<pre><code class="language-markdown">```rust,no_run
+fn main() {
+    println!("Not runnable.");
+}
+```</code></pre>
+
+```rust,no_run
+fn main() {
+    println!("Not runnable.");
+}
+```
+### Show Warnings
+
+It is possible to show warning when Rust code is run via adding `warn`:
+<pre><code class="language-markdown">```rust,warn
+fn main() {
+    let unused = 7;
+}
+```</code></pre>
+
+```rust,warn
+fn main() {
+    let unused = 7;
+}
+```
 
 ## Custom theme
 Like the rest of the theme, the files used for syntax highlighting can be

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -132,7 +132,7 @@ function playground_text(playground) {
             params.version = "nightly";
         }
 
-        result_stderr_block.classList.add("hidden")
+        result_stderr_block.classList.add("hidden");
         result_block.innerText = "Running...";
 
         fetch_with_timeout("https://play.rust-lang.org/execute", {
@@ -146,9 +146,10 @@ function playground_text(playground) {
         .then(response => response.json())
         .then(response => {
             result_block.innerText = response.stdout;
+            // show stderr block only if there is compile error or warning
             if (!response.success || response.stderr.includes("warning")) {
                 result_stderr_block.innerText = response.stderr;
-                result_stderr_block.classList.remove("hidden")
+                result_stderr_block.classList.remove("hidden");
             }
         })
         .catch(error => result_block.innerText = "Playground Communication: " + error.message);

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -116,6 +116,7 @@ function playground_text(playground) {
         let text = playground_text(code_block);
         let classes = code_block.querySelector('code').classList;
         let has_2018 = classes.contains("edition2018");
+        let should_warn = classes.contains("warn")
         let edition = has_2018 ? "2018" : "2015";
 
         var params = {
@@ -146,8 +147,9 @@ function playground_text(playground) {
         .then(response => response.json())
         .then(response => {
             result_block.innerText = response.stdout;
-            // show stderr block only if there is compile error or warning
-            if (!response.success || response.stderr.includes("warning")) {
+            var show_warnings = should_warn && response.stderr.includes("warning");
+            // show stderr block if there is compile error or warning
+            if (!response.success || show_warnings) {
                 result_stderr_block.innerText = response.stderr;
                 result_stderr_block.classList.remove("hidden");
             }

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -101,14 +101,14 @@ function playground_text(playground) {
         var result_stderr_block = code_block.querySelector(".result.stderr");
         if (!result_stderr_block) {
             result_stderr_block = document.createElement('code');
-            result_stderr_block.className = 'result stderr hljs language-bash';
+            result_stderr_block.className = 'result stderr hljs nohighlight';
 
             code_block.append(result_stderr_block);
         }
         var result_block = code_block.querySelector(".result.stdout");
         if (!result_block) {
             result_block = document.createElement('code');
-            result_block.className = 'result stdout hljs language-bash';
+            result_block.className = 'result stdout hljs nohighlight';
 
             code_block.append(result_block);
         }

--- a/tests/summary_md_files/example_book.md
+++ b/tests/summary_md_files/example_book.md
@@ -12,7 +12,7 @@
     - [Configuration](format/config.md)
     - [Theme](format/theme/theme.md)
         - [index.hbs](format/theme/index-hbs.md)
-        - [Syntax highlighting](format/theme/syntax-highlighting.md)
+        - [Code Blocks](format/theme/code-blocks.md)
     - [MathJax Support](format/mathjax.md)
     - [Rust code specific features](format/rust.md)
 - [Rust Library](lib/lib.md)


### PR DESCRIPTION
This PR makes it so that warnings are shown if a markdown code block is labelled with `warn` e.g.
<pre>
```rust,warn
fn main() {
    let unused = 7;
}
```
</pre>
This enables addressing issues like https://github.com/rust-lang/rust-by-example/issues/1328.

Here is a demo:
![example](https://user-images.githubusercontent.com/1718745/92331424-7afc0300-f044-11ea-9d1e-ed530da1231a.gif)
