### PR TITLE
Resolve full file paths when copying files

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -110,7 +110,7 @@ pub fn copy_files_except_ext(
 
     for entry in fs::read_dir(from)? {
         let entry = entry?;
-        let metadata = entry.metadata()?;
+        let metadata = entry.path().metadata()?;
 
         // If the entry is a dir and the recursive option is enabled, call itself
         if metadata.is_dir() && recursive {
@@ -187,7 +187,17 @@ pub fn get_404_output_file(input_404: &Option<String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::copy_files_except_ext;
-    use std::fs;
+    use std::{fs, io::Result, path::Path};
+
+    #[cfg(target_os = "windows")]
+    fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()> {
+        std::os::window::fs::symlink_file(src, dst)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()> {
+        std::os::unix::fs::symlink(src, dst)
+    }
 
     #[test]
     fn copy_files_except_ext_test() {
@@ -217,6 +227,12 @@ mod tests {
         }
         if let Err(err) = fs::File::create(&tmp.path().join("sub_dir_exists/file.txt")) {
             panic!("Could not create sub_dir_exists/file.txt: {}", err);
+        }
+        if let Err(err) = symlink(
+            &tmp.path().join("file.png"),
+            &tmp.path().join("symlink.png"),
+        ) {
+            panic!("Could not symlink file.png: {}", err);
         }
 
         // Create output dir
@@ -248,6 +264,9 @@ mod tests {
         }
         if !(&tmp.path().join("output/sub_dir_exists/file.txt")).exists() {
             panic!("output/sub_dir/file.png should exist")
+        }
+        if !(&tmp.path().join("output/symlink.png")).exists() {
+            panic!("output/symlink.png should exist")
         }
     }
 }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -191,7 +191,7 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()> {
-        std::os::window::fs::symlink_file(src, dst)
+        std::os::windows::fs::symlink_file(src, dst)
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Currently, the `copy_files` function doesn't support symlink files due to
its use of `DirEntry::metadata` - To avoid this issue, this patch
resolves the file path first before checking for metadata.

Fixes #1157
Fixes #1209