### PR TITLE
Fix macOS CI deploy.

### DIFF
--- a/ci/make-release.sh
+++ b/ci/make-release.sh
@@ -17,6 +17,12 @@ cd target/release
 case $1 in
   ubuntu* | macos*)
     asset="mdbook-$TAG-$host.tar.gz"
+    # There is a bug with BSD tar on macOS where the first 8MB of the file are
+    # sometimes all NUL bytes. See https://github.com/actions/cache/issues/403
+    # and https://github.com/rust-lang/cargo/issues/8603 for some more
+    # information. An alternative solution here is to install GNU tar, but
+    # flushing the disk cache seems to work, too.
+    sudo /usr/sbin/purge
     tar czf ../../$asset mdbook
     ;;
   windows*)


### PR DESCRIPTION
There is a bug with BSD tar on macOS where the first 8MB of the file are sometimes all NUL bytes. See https://github.com/actions/cache/issues/403 and https://github.com/rust-lang/cargo/issues/8603 for some more information. An alternative solution here is to install GNU tar, but flushing the disk cache seems to work, too.
