### PR TITLE
List supported Highlight.js languages in guide

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -17,7 +17,7 @@
         - [Syntax highlighting](format/theme/syntax-highlighting.md)
         - [Editor](format/theme/editor.md)
     - [MathJax Support](format/mathjax.md)
-    - [mdBook specific features](format/mdbook.md)
+    - [mdBook-specific features](format/mdbook.md)
 - [Continuous Integration](continuous-integration.md)
 - [For Developers](for_developers/README.md)
     - [Preprocessors](for_developers/preprocessors.md)

--- a/guide/src/format/mdbook.md
+++ b/guide/src/format/mdbook.md
@@ -1,9 +1,9 @@
-# mdBook-specific markdown
+# mdBook-specific features
 
 ## Hiding code lines
 
 There is a feature in mdBook that lets you hide code lines by prepending them
-with a `#` [in the same way that Rustdoc does][rustdoc-hide].
+with a `#` [like you would with Rustdoc][rustdoc-hide].
 
 [rustdoc-hide]: https://doc.rust-lang.org/stable/rustdoc/documentation-tests.html#hiding-portions-of-the-example
 
@@ -37,7 +37,7 @@ With the following syntax, you can include files into your book:
 
 The path to the file has to be relative from the current source file.
 
-mdBook will interpret included files as markdown. Since the include command
+mdBook will interpret included files as Markdown. Since the include command
 is usually used for inserting code snippets and examples, you will often
 wrap the command with ```` ``` ```` to display the file contents without
 interpretting them.

--- a/guide/src/format/theme/syntax-highlighting.md
+++ b/guide/src/format/theme/syntax-highlighting.md
@@ -1,7 +1,7 @@
 # Syntax Highlighting
 
-For syntax highlighting we use [Highlight.js](https://highlightjs.org) with a
-custom theme.
+mdBook uses [Highlight.js](https://highlightjs.org) with a custom theme
+for syntax highlighting.
 
 Automatic language detection has been turned off, so you will probably want to
 specify the programming language you use like this:

--- a/guide/src/format/theme/syntax-highlighting.md
+++ b/guide/src/format/theme/syntax-highlighting.md
@@ -1,16 +1,67 @@
 # Syntax Highlighting
 
-For syntax highlighting I use [Highlight.js](https://highlightjs.org) with a
+For syntax highlighting we use [Highlight.js](https://highlightjs.org) with a
 custom theme.
 
 Automatic language detection has been turned off, so you will probably want to
-specify the programming language you use like this
+specify the programming language you use like this:
 
-<pre><code class="language-markdown">```rust
+~~~markdown
+```rust
 fn main() {
     // Some code
 }
-```</code></pre>
+```
+~~~
+
+## Supported languages
+
+These languages are supported by default, but you can add more by supplying
+your own `highlight.js` file:
+
+- apache
+- armasm
+- bash
+- c
+- coffeescript
+- cpp
+- csharp
+- css
+- d
+- diff
+- go
+- handlebars
+- haskell
+- http
+- ini
+- java
+- javascript
+- json
+- julia
+- kotlin
+- less
+- lua
+- makefile
+- markdown
+- nginx
+- objectivec
+- perl
+- php
+- plaintext
+- properties
+- python
+- r
+- ruby
+- rust
+- scala
+- scss
+- shell
+- sql
+- swift
+- typescript
+- x86asm
+- xml
+- yaml
 
 ## Custom theme
 Like the rest of the theme, the files used for syntax highlighting can be


### PR DESCRIPTION
Generated using the technique described in https://github.com/rust-lang/mdBook/issues/1275#issuecomment-655903967.
