### PR TITLE
Remove leading $, > and # chars from clipboard of console snippets

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -569,10 +569,23 @@ function playground_text(playground) {
         elem.className = 'fa fa-copy tooltipped';
     }
 
+    // this will remove '$', '>' and '#' leading characters
+    // from clipboard of console snippets
+    function removeLeadingChars(str) {
+        var leading_chars_expr = /^(\$|\>|\#)\s/gm;
+        return str.replace(leading_chars_expr, '');
+    }
+
     var clipboardSnippets = new ClipboardJS('.clip-button', {
         text: function (trigger) {
             hideTooltip(trigger);
             let playground = trigger.closest("pre");
+            
+            // evaluates if the code block is of type console
+            let isConsole = playground.querySelector("code").classList.contains("language-console");
+            if (isConsole === true)
+                return removeLeadingChars(playground_text(playground));
+             
             return playground_text(playground);
         }
     });


### PR DESCRIPTION
This PR aims to add a function to remove leading `$`, `>`, and `#` characters from the clipboard of console snippets.

Related PR: https://github.com/rust-lang/mdBook/pull/1110
Related issues: https://github.com/rust-lang/mdBook/issues/864, https://github.com/rust-lang/book/issues/1756, https://github.com/rust-lang/book/issues/2420, https://github.com/rust-lang/book/issues/2179, 