### PR TITLE
Update deprecated GitHub Actions commands.

### DIFF
--- a/ci/install-hub.sh
+++ b/ci/install-hub.sh
@@ -21,4 +21,4 @@ case $1 in
     ;;
 esac
 
-echo "##[add-path]$PWD/hub/bin"
+echo "$PWD/hub/bin" >> $GITHUB_PATH


### PR DESCRIPTION
The old method of using `::set-env` and `::add-path` have been deprecated, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.
