### PR TITLE
Enhanced contrast theme, for users with visual restrictions etc.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -207,6 +207,11 @@ impl HtmlHandlebars {
         write_file(destination, "highlight.css", &theme.highlight_css)?;
         write_file(destination, "tomorrow-night.css", &theme.tomorrow_night_css)?;
         write_file(destination, "ayu-highlight.css", &theme.ayu_highlight_css)?;
+        write_file(
+            destination,
+            "contrast-highlight.css",
+            &theme.contrast_highlight_css,
+        )?;
         write_file(destination, "highlight.js", &theme.highlight_js)?;
         write_file(destination, "clipboard.min.js", &theme.clipboard_js)?;
         write_file(

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -278,6 +278,7 @@ function playground_text(playground) {
     var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
     var stylesheets = {
         ayuHighlight: document.querySelector("[href$='ayu-highlight.css']"),
+        contrastHighlight: document.querySelector("[href$='contrast-highlight.css']"),
         tomorrowNight: document.querySelector("[href$='tomorrow-night.css']"),
         highlight: document.querySelector("[href$='highlight.css']"),
     };
@@ -310,17 +311,26 @@ function playground_text(playground) {
         if (theme == 'coal' || theme == 'navy') {
             stylesheets.ayuHighlight.disabled = true;
             stylesheets.tomorrowNight.disabled = false;
+            stylesheets.contrastHighlight.disabled = true;
             stylesheets.highlight.disabled = true;
 
             ace_theme = "ace/theme/tomorrow_night";
         } else if (theme == 'ayu') {
             stylesheets.ayuHighlight.disabled = false;
             stylesheets.tomorrowNight.disabled = true;
+            stylesheets.contrastHighlight.disabled = true;
             stylesheets.highlight.disabled = true;
             ace_theme = "ace/theme/tomorrow_night";
+        } else if (theme == 'contrast') {
+            stylesheets.ayuHighlight.disabled = true;
+            stylesheets.tomorrowNight.disabled = true;
+            stylesheets.contrastHighlight.disabled = false;
+            stylesheets.highlight.disabled = true;
+            ace_theme = "ace/theme/dawn";
         } else {
             stylesheets.ayuHighlight.disabled = true;
             stylesheets.tomorrowNight.disabled = true;
+            stylesheets.contrastHighlight.disabled = true;
             stylesheets.highlight.disabled = false;
             ace_theme = "ace/theme/dawn";
         }

--- a/src/theme/contrast-highlight.css
+++ b/src/theme/contrast-highlight.css
@@ -1,0 +1,84 @@
+/*
+ * An increased contrast highlighting scheme loosely based on the mdbook
+ * "light" highlight scheme, itself a subset of Base16 Atelier Dune Light -
+ * Theme by Bram de Haan
+ * (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+ * Original Base16 color scheme by Chris Kempson
+ * (https://github.com/chriskempson/base16)
+ */
+
+/* Comment */
+.hljs-comment,
+.hljs-quote {
+  color: #575757;
+}
+
+/* Red */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-tag,
+.hljs-name,
+.hljs-regexp,
+.hljs-link,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #d70025;
+}
+
+/* Dark Orange */
+.hljs-number,
+.hljs-meta,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params {
+  color: #a61900;
+}
+
+/* Green */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet {
+  color: #008200;
+}
+
+/* Blue */
+.hljs-title,
+.hljs-section {
+  color: #0030f2;
+}
+
+/* Purple */
+.hljs-keyword,
+.hljs-selector-tag {
+  color: #9d00ec;
+}
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  background: #f5f6f6;
+  color: #000;
+  padding: 0.5em;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-addition {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.hljs-deletion {
+  color: #b31d28;
+  background-color: #ffeef0;
+}

--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -130,6 +130,46 @@
     --search-mark-bg: #a2cff5;
 }
 
+.contrast {
+    --bg: hsl(0, 0%, 100%);
+    --fg: hsl(0, 0%, 0%);
+
+    --sidebar-bg: #fafafa;
+    --sidebar-fg: hsl(0, 0%, 0%);
+    --sidebar-non-existant: #aaaaaa;
+    --sidebar-active: #1f1fff;
+    --sidebar-spacer: #f4f4f4;
+
+    --scrollbar: #747474;
+
+    --icons: #747474;
+    --icons-hover: #000000;
+
+    --links: #20609f;
+
+    --inline-code-color: #3c1900;
+
+    --theme-popup-bg: #fafafa;
+    --theme-popup-border: #cccccc;
+    --theme-hover: #e6e6e6;
+
+    --quote-bg: hsl(197, 37%, 96%);
+    --quote-border: hsl(197, 37%, 91%);
+
+    --table-border-color: hsl(0, 0%, 95%);
+    --table-header-bg: hsl(0, 0%, 80%);
+    --table-alternate-bg: hsl(0, 0%, 97%);
+
+    --searchbar-border-color: #aaa;
+    --searchbar-bg: #fafafa;
+    --searchbar-fg: #000;
+    --searchbar-shadow-color: #aaa;
+    --searchresults-header-fg: #666;
+    --searchresults-border-color: #888;
+    --searchresults-li-bg: #e4f2fe;
+    --search-mark-bg: #a2cff5;
+}
+
 .navy {
     --bg: hsl(226, 23%, 11%);
     --fg: #bcbdd0;

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -43,6 +43,7 @@
         <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
         <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
         <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}contrast-highlight.css">
 
         <!-- Custom theme stylesheets -->
         {{#each additional_css}}
@@ -123,6 +124,7 @@
                         </button>
                         <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
                             <li role="none"><button role="menuitem" class="theme" id="light">{{ theme_option "Light" }}</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="contrast">{{ theme_option "Contrast" }}</button></li>
                             <li role="none"><button role="menuitem" class="theme" id="rust">{{ theme_option "Rust" }}</button></li>
                             <li role="none"><button role="menuitem" class="theme" id="coal">{{ theme_option "Coal" }}</button></li>
                             <li role="none"><button role="menuitem" class="theme" id="navy">{{ theme_option "Navy" }}</button></li>

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -28,6 +28,7 @@ pub static HIGHLIGHT_JS: &[u8] = include_bytes!("highlight.js");
 pub static TOMORROW_NIGHT_CSS: &[u8] = include_bytes!("tomorrow-night.css");
 pub static HIGHLIGHT_CSS: &[u8] = include_bytes!("highlight.css");
 pub static AYU_HIGHLIGHT_CSS: &[u8] = include_bytes!("ayu-highlight.css");
+pub static CONTRAST_HIGHLIGHT_CSS: &[u8] = include_bytes!("contrast-highlight.css");
 pub static CLIPBOARD_JS: &[u8] = include_bytes!("clipboard.min.js");
 pub static FONT_AWESOME: &[u8] = include_bytes!("FontAwesome/css/font-awesome.min.css");
 pub static FONT_AWESOME_EOT: &[u8] = include_bytes!("FontAwesome/fonts/fontawesome-webfont.eot");
@@ -60,6 +61,7 @@ pub struct Theme {
     pub highlight_css: Vec<u8>,
     pub tomorrow_night_css: Vec<u8>,
     pub ayu_highlight_css: Vec<u8>,
+    pub contrast_highlight_css: Vec<u8>,
     pub highlight_js: Vec<u8>,
     pub clipboard_js: Vec<u8>,
 }
@@ -101,6 +103,10 @@ impl Theme {
                 (
                     theme_dir.join("ayu-highlight.css"),
                     &mut theme.ayu_highlight_css,
+                ),
+                (
+                    theme_dir.join("contrast-highlight.css"),
+                    &mut theme.contrast_highlight_css,
                 ),
             ];
 
@@ -159,6 +165,7 @@ impl Default for Theme {
             highlight_css: HIGHLIGHT_CSS.to_owned(),
             tomorrow_night_css: TOMORROW_NIGHT_CSS.to_owned(),
             ayu_highlight_css: AYU_HIGHLIGHT_CSS.to_owned(),
+            contrast_highlight_css: CONTRAST_HIGHLIGHT_CSS.to_owned(),
             highlight_js: HIGHLIGHT_JS.to_owned(),
             clipboard_js: CLIPBOARD_JS.to_owned(),
         }
@@ -218,6 +225,7 @@ mod tests {
             "tomorrow-night.css",
             "highlight.css",
             "ayu-highlight.css",
+            "contrast-highlight.css",
             "clipboard.min.js",
         ];
 
@@ -246,6 +254,7 @@ mod tests {
             highlight_css: Vec::new(),
             tomorrow_night_css: Vec::new(),
             ayu_highlight_css: Vec::new(),
+            contrast_highlight_css: Vec::new(),
             highlight_js: Vec::new(),
             clipboard_js: Vec::new(),
         };


### PR DESCRIPTION
Now that I'm half way through my fifth decade, I find the default 'light' theme quite tiring for more than a few minutes.

Whilst reading mdBook material, I often find myself physically moving my face closer to the screen and/or zooming in more than I do on other similar material rendered with other frameworks.

I often use browser extensions to increase text contrast, but these don't cope well with mdBook's output (in particular, I haven't found one which works well with mdBook's syntax highlighting).

For my own use, I've created an enhanced contrast theme, based on the 'light' theme.  I've also asked the opinions of others whilst viewing, and have received universally positive feedback, so I hope you will consider this addition to mdBook.

Any feedback welcome!