### PR TITLE
Test cargo install in CI and bump MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
       run: cargo test
     - name: Test no default
       run: cargo test --no-default-features
+    - name: Install mdbook
+      run: cargo install --path .
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
             rust: stable
           - build: msrv
             os: ubuntu-latest
-            rust: 1.39.0
+            rust: 1.40.0
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are multiple ways to install mdBook.
 
 2. **From Crates.io**
 
-   This requires at least [Rust] 1.39 and Cargo to be installed. Once you have installed
+   This requires at least [Rust] 1.40 and Cargo to be installed. Once you have installed
    Rust, type the following in the terminal:
 
    ```


### PR DESCRIPTION
Currently trying to `cargo install mdbook` on 1.39 [fails to compile](https://github.com/Alexendoo/mdBook/runs/1265268352?check_suite_focus=true#step:6:189), for some reason it builds/tests just fine but when using `cargo install` it ignores the Cargo.lock, compiling `remove_dir_all v0.5.3` instead of `0.5.2`

This bumps the MSRV to 1.40 where `remove_dir_all v0.5.3` does compile and adds a test to catch it in the future

Ideally the MRSV could stay at 1.39, but I don't know what's going on with Cargo.lock being sometimes ignored