### PR TITLE
Docs: CI guide update

### DIFF
--- a/guide/src/continuous-integration.md
+++ b/guide/src/continuous-integration.md
@@ -12,8 +12,7 @@ run.
 
 ```yaml
 language: rust
-os: linux
-dist: xenial
+sudo: false
 
 cache:
   - cargo
@@ -49,6 +48,39 @@ Then, append this snippet to your `.travis.yml` and update the path to the
 ```yaml
 deploy:
   provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  local-dir: path/to/mybook/book
+  keep-history: false
+  on:
+    branch: master
+```
+
+That's it!
+
+Note: Travis has a new [dplv2](https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release) configuration that is currently in beta. To use this new format, update your `.travis.yml` file to:
+
+```yaml
+language: rust
+os: linux
+dist: xenial
+
+cache:
+  - cargo
+
+rust:
+  - stable
+
+before_script:
+  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.3" mdbook)
+  - cargo install-update -a
+
+script:
+  - mdbook build path/to/mybook && mdbook test path/to/mybook
+  
+deploy:
+  provider: pages
   strategy: git
   edge: true
   cleanup: false
@@ -59,8 +91,6 @@ deploy:
     branch: master
   target_branch: gh-pages
 ```
-
-That's it!
 
 ### Deploying to GitHub Pages manually
 

--- a/guide/src/continuous-integration.md
+++ b/guide/src/continuous-integration.md
@@ -12,7 +12,8 @@ run.
 
 ```yaml
 language: rust
-sudo: false
+os: linux
+dist: xenial
 
 cache:
   - cargo
@@ -39,18 +40,24 @@ permissions (or "repo" for private repositories). Go to your repository's Travis
 CI settings page and add an environment variable named `GITHUB_TOKEN` that is
 marked secure and *not* shown in the logs.
 
+Whilst still in your repository's settings page, navigate to Options and change the 
+Source on GitHub pages to `gh-pages`.
+
 Then, append this snippet to your `.travis.yml` and update the path to the
 `book` directory:
 
 ```yaml
 deploy:
   provider: pages
-  skip-cleanup: true
+  strategy: git
+  edge: true
+  cleanup: false
   github-token: $GITHUB_TOKEN
   local-dir: path/to/mybook/book
   keep-history: false
   on:
     branch: master
+  target_branch: gh-pages
 ```
 
 That's it!

--- a/guide/src/misc/contributors.md
+++ b/guide/src/misc/contributors.md
@@ -16,5 +16,6 @@ shout-out to them!
 - [Phaiax](https://github.com/Phaiax)
 - Matt Ickstadt ([mattico](https://github.com/mattico))
 - Weihang Lo ([@weihanglo](https://github.com/weihanglo))
+- Avision Ho ([@avisionh](https://github.com/avisionh))
 
 If you feel you're missing from this list, feel free to add yourself in a PR.


### PR DESCRIPTION
# Summary
This branch updates the [mdBook](https://rust-lang.github.io/mdBook/index.html) guidance on [Continuous Integration](https://rust-lang.github.io/mdBook/continuous-integration.html) to comply with travis-ci's upcoming use of [dpl v2](https://docs.travis-ci.com/user/deployment-v2).

It also updates it so that it guides the reader on GitHub Pages deployments via the `gh-pages` branch, which is the approach taken with the GitHub repo (I think).

Lastly, it removes the `sudo: false` command as per travis-ci recommendations in this [blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

Let me know what you think! 🙂 

## Context
I couldn't get the current instructions to work when setting this up for my [training-git](https://github.com/avisionh/training-git) repo, thus I made small tweaks to get it working. Note, I also migrated my repo from travis-ci.org to travis-ci.com as per the recommendations on the [travis blog](https://docs.travis-ci.com/user/migrate/open-source-repository-migration).

## Check
- [ ] These suggestions are appropriate to the guide.
- [ ] These suggestions work when setting up a CI-CD pipeline to deploy to GitHub Pages.
- [ ] There are no errors.

### Note
This possibly "fixes #1165".