### PR TITLE
Fix stray spacing after #playground code

### DIFF
--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -335,7 +335,7 @@ impl<'a> Link<'a> {
             LinkType::Playground(ref pat, ref attrs) => {
                 let target = base.join(pat);
 
-                let contents = fs::read_to_string(&target).with_context(|| {
+                let mut contents = fs::read_to_string(&target).with_context(|| {
                     format!(
                         "Could not read file for link {} ({})",
                         self.link_text,
@@ -343,8 +343,11 @@ impl<'a> Link<'a> {
                     )
                 })?;
                 let ftype = if !attrs.is_empty() { "rust," } else { "rust" };
+                if !contents.ends_with('\n') {
+                    contents.push('\n');
+                }
                 Ok(format!(
-                    "```{}{}\n{}\n```\n",
+                    "```{}{}\n{}```\n",
                     ftype,
                     attrs.join(","),
                     contents


### PR DESCRIPTION
Taken from https://rust-lang.github.io/mdBook/format/mdbook.html#inserting-runnable-rust-files:

```markdown
Here is what a rendered code snippet looks like:

{{#playground example.rs}}
```

<br>

### Before:

![Screenshot from 2020-11-05 21-49-05](https://user-images.githubusercontent.com/1940490/98331136-c97c3e00-1fb0-11eb-8deb-f76b1f244a7c.png)

<br>

### After:

![Screenshot from 2020-11-05 21-49-18](https://user-images.githubusercontent.com/1940490/98331143-cda85b80-1fb0-11eb-8d47-000d61613f67.png)