### PR TITLE
allow to serialize the "build" section

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,11 @@ impl Serialize for Config {
         let book_config = Value::try_from(&self.book).expect("should always be serializable");
         table.insert("book", book_config);
 
+        if self.build != BuildConfig::default() {
+            let build_config = Value::try_from(&self.build).expect("should always be serializable");
+            table.insert("build", build_config);
+        }
+
         if self.rust != RustConfig::default() {
             let rust_config = Value::try_from(&self.rust).expect("should always be serializable");
             table.insert("rust", rust_config);

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -91,6 +91,12 @@ fn run_mdbook_init_with_custom_book_and_src_locations() {
             file
         );
     }
+
+    let contents = fs::read_to_string(temp.path().join("book.toml")).unwrap();
+    assert_eq!(
+        contents,
+        "[book]\nauthors = []\nlanguage = \"en\"\nmultilingual = false\nsrc = \"in\"\n\n[build]\nbuild-dir = \"out\"\ncreate-missing = true\nuse-default-preprocessors = true\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Without this change it's impossible to setup build parameters through API like that:

```rust
use mdbook::MDBook;
use mdbook::config::Config;

let root_dir = "/path/to/book/root";

let mut cfg = Config::default();
cfg.book.title = Some("My Book".to_string());
cfg.book.authors.push("Michael-F-Bryan".to_string());

cfg.build.build_dir = PathBuf::from("output"); <---------------- we can set it, but it won't be serialized

MDBook::init(root_dir)
    .create_gitignore(true)
    .with_config(cfg)
    .build()
    .expect("Book generation failed");
```