### PR TITLE
Add hidelines code class to enable hiding in non-Rust blocks

### DIFF
--- a/guide/src/format/theme/syntax-highlighting.md
+++ b/guide/src/format/theme/syntax-highlighting.md
@@ -103,11 +103,14 @@ Will render as
 # }
 ```
 
-**At the moment, this only works for code examples that are annotated with
-`rust`. Because it would collide with semantics of some programming languages.
-In the future, we want to make this configurable through the `book.toml` so that
-everyone can benefit from it.**
+Hiding is only enabled by default for code examples with the language `rust`,
+since it collides with ordinary use of `#` in some other programming languages.
+To enable code hiding for a specific non-Rust code block, append `,hidelines`
+after the language selector:
 
+~~~markdown
+```haskell,hidelines
+~~~
 
 ## Improve default theme
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -848,6 +848,8 @@ fn add_playground_pre(
                 } else {
                     format!("<code class=\"{}\">{}</code>", classes, hide_lines(code))
                 }
+            } else if classes.contains("hidelines") {
+                format!("<code class=\"{}\">{}</code>", classes, hide_lines(code))
             } else {
                 // not language-rust, so no-op
                 text.to_owned()

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -166,7 +166,7 @@ function playground_text(playground) {
     // even if highlighting doesn't apply
     code_nodes.forEach(function (block) { block.classList.add('hljs'); });
 
-    Array.from(document.querySelectorAll("code.language-rust")).forEach(function (block) {
+    Array.from(document.querySelectorAll("code.language-rust, code.hidelines")).forEach(function (block) {
 
         var lines = Array.from(block.querySelectorAll('.boring'));
         // If no lines were hidden, return


### PR DESCRIPTION
<img alt="```toml,hidelines" src="https://user-images.githubusercontent.com/1940490/98905392-3475bb00-2470-11eb-878d-fdcabe28c1f1.png" width="300">

---

![Screenshot from 2020-11-11 22-49-31](https://user-images.githubusercontent.com/1940490/98905401-3770ab80-2470-11eb-946e-45b69fda8641.png)

---

![Screenshot from 2020-11-11 22-49-44](https://user-images.githubusercontent.com/1940490/98905411-393a6f00-2470-11eb-91cc-20b7632cda96.png)
