### PR TITLE
Add chapter name to search result breadcrumbs

### DIFF
--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -95,6 +95,8 @@ fn render_item(
     let mut breadcrumbs = chapter.parent_names.clone();
     let mut footnote_numbers = HashMap::new();
 
+    breadcrumbs.push(chapter.name.clone());
+
     while let Some(event) = p.next() {
         match event {
             Event::Start(Tag::Heading(i)) if i <= max_section_depth => {

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -595,7 +595,10 @@ mod search {
             docs[&summary]["body"],
             "Dummy Book Introduction First Chapter Nested Chapter Includes Recursive Markdown Unicode Second Chapter Nested Chapter Conclusion"
         );
-        assert_eq!(docs[&summary]["breadcrumbs"], "First Chapter » Summary");
+        assert_eq!(
+            docs[&summary]["breadcrumbs"],
+            "First Chapter » Includes » Summary"
+        );
         assert_eq!(docs[&conclusion]["body"], "I put &lt;HTML&gt; in here!");
     }
 

--- a/tests/searchindex_fixture.json
+++ b/tests/searchindex_fixture.json
@@ -27,234 +27,234 @@
       "docInfo": {
         "0": {
           "body": 9,
-          "breadcrumbs": 2,
+          "breadcrumbs": 4,
           "title": 2
         },
         "1": {
           "body": 3,
-          "breadcrumbs": 1,
+          "breadcrumbs": 2,
           "title": 1
         },
         "10": {
           "body": 16,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         },
         "11": {
           "body": 3,
-          "breadcrumbs": 4,
+          "breadcrumbs": 5,
           "title": 2
         },
         "12": {
           "body": 4,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         },
         "13": {
           "body": 12,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         },
         "14": {
           "body": 2,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         },
         "15": {
           "body": 3,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         },
         "16": {
           "body": 29,
-          "breadcrumbs": 5,
+          "breadcrumbs": 6,
           "title": 3
         },
         "17": {
           "body": 20,
-          "breadcrumbs": 2,
+          "breadcrumbs": 4,
           "title": 2
         },
         "18": {
           "body": 18,
-          "breadcrumbs": 7,
+          "breadcrumbs": 9,
           "title": 5
         },
         "19": {
           "body": 0,
-          "breadcrumbs": 3,
+          "breadcrumbs": 5,
           "title": 1
         },
         "2": {
           "body": 2,
-          "breadcrumbs": 2,
+          "breadcrumbs": 4,
           "title": 2
         },
         "20": {
           "body": 3,
-          "breadcrumbs": 1,
+          "breadcrumbs": 2,
           "title": 1
         },
         "3": {
           "body": 0,
-          "breadcrumbs": 1,
+          "breadcrumbs": 3,
           "title": 1
         },
         "4": {
           "body": 4,
-          "breadcrumbs": 4,
+          "breadcrumbs": 6,
           "title": 2
         },
         "5": {
           "body": 1,
-          "breadcrumbs": 3,
+          "breadcrumbs": 5,
           "title": 1
         },
         "6": {
           "body": 21,
-          "breadcrumbs": 9,
+          "breadcrumbs": 11,
           "title": 7
         },
         "7": {
           "body": 6,
-          "breadcrumbs": 8,
+          "breadcrumbs": 10,
           "title": 6
         },
         "8": {
           "body": 6,
-          "breadcrumbs": 6,
+          "breadcrumbs": 8,
           "title": 4
         },
         "9": {
           "body": 0,
-          "breadcrumbs": 3,
+          "breadcrumbs": 4,
           "title": 1
         }
       },
       "docs": {
         "0": {
           "body": "This file is just here to cause the index preprocessor to run. Does a pretty good job, too.",
-          "breadcrumbs": "Dummy Book",
+          "breadcrumbs": "Dummy Book » Dummy Book",
           "id": "0",
           "title": "Dummy Book"
         },
         "1": {
           "body": "Here's some interesting text...",
-          "breadcrumbs": "Introduction",
+          "breadcrumbs": "Introduction » Introduction",
           "id": "1",
           "title": "Introduction"
         },
         "10": {
           "body": "Dummy Book Introduction First Chapter Nested Chapter Includes Recursive Markdown Unicode Second Chapter Nested Chapter Conclusion",
-          "breadcrumbs": "First Chapter » Summary",
+          "breadcrumbs": "First Chapter » Includes » Summary",
           "id": "10",
           "title": "Summary"
         },
         "11": {
           "body": "Tests for some markdown output.",
-          "breadcrumbs": "First Chapter » Markdown tests",
+          "breadcrumbs": "First Chapter » Markdown » Markdown tests",
           "id": "11",
           "title": "Markdown tests"
         },
         "12": {
           "body": "foo bar baz bim",
-          "breadcrumbs": "First Chapter » Tables",
+          "breadcrumbs": "First Chapter » Markdown » Tables",
           "id": "12",
           "title": "Tables"
         },
         "13": {
           "body": "Footnote example [1] , or with a word [2] . This is a footnote. A longer footnote. With multiple lines. Third line.",
-          "breadcrumbs": "First Chapter » Footnotes",
+          "breadcrumbs": "First Chapter » Markdown » Footnotes",
           "id": "13",
           "title": "Footnotes"
         },
         "14": {
           "body": "strikethrough example",
-          "breadcrumbs": "First Chapter » Strikethrough",
+          "breadcrumbs": "First Chapter » Markdown » Strikethrough",
           "id": "14",
           "title": "Strikethrough"
         },
         "15": {
           "body": "Apples Broccoli Carrots",
-          "breadcrumbs": "First Chapter » Tasklisks",
+          "breadcrumbs": "First Chapter » Markdown » Tasklisks",
           "id": "15",
           "title": "Tasklisks"
         },
         "16": {
           "body": "Please be careful editing, this contains carefully crafted characters. Two byte character: spatiëring Combining character: spatiëring Three byte character: 书こんにちは Four byte character: 𐌀‮𐌁‮𐌂‮𐌃‮𐌄‮𐌅‮𐌆‮𐌇‮𐌈‬ Right-to-left: مرحبا Emoticons: 🔊 😍 💜 1️⃣ right-to-left mark: hello באמת!‏ Zalgo: ǫ̛̖̱̗̝͈̋͒͋̏ͥͫ̒̆ͩ̏͌̾͊͐ͪ̾̚",
-          "breadcrumbs": "First Chapter » Unicode stress tests",
+          "breadcrumbs": "First Chapter » Unicode » Unicode stress tests",
           "id": "16",
           "title": "Unicode stress tests"
         },
         "17": {
           "body": "This makes sure you can insert runnable Rust files. fn main() { println!(\"Hello World!\");\n#\n# // You can even hide lines! :D\n# println!(\"I am hidden! Expand the code snippet to see me\");\n}",
-          "breadcrumbs": "Second Chapter",
+          "breadcrumbs": "Second Chapter » Second Chapter",
           "id": "17",
           "title": "Second Chapter"
         },
         "18": {
           "body": "When we link to the first section , it should work on both the print page and the non-print page. A fragment link should work. Link outside . Some image HTML Link",
-          "breadcrumbs": "Second Chapter » Testing relative links for the print page",
+          "breadcrumbs": "Second Chapter » Nested Chapter » Testing relative links for the print page",
           "id": "18",
           "title": "Testing relative links for the print page"
         },
         "19": {
           "body": "",
-          "breadcrumbs": "Second Chapter » Some section",
+          "breadcrumbs": "Second Chapter » Nested Chapter » Some section",
           "id": "19",
           "title": "Some section"
         },
         "2": {
           "body": "more text.",
-          "breadcrumbs": "First Chapter",
+          "breadcrumbs": "First Chapter » First Chapter",
           "id": "2",
           "title": "First Chapter"
         },
         "20": {
           "body": "I put &lt;HTML&gt; in here!",
-          "breadcrumbs": "Conclusion",
+          "breadcrumbs": "Conclusion » Conclusion",
           "id": "20",
           "title": "Conclusion"
         },
         "3": {
           "body": "",
-          "breadcrumbs": "Some Section",
+          "breadcrumbs": "First Chapter » Some Section",
           "id": "3",
           "title": "Some Section"
         },
         "4": {
           "body": "This file has some testable code. assert!(true);",
-          "breadcrumbs": "First Chapter » Nested Chapter",
+          "breadcrumbs": "First Chapter » Nested Chapter » Nested Chapter",
           "id": "4",
           "title": "Nested Chapter"
         },
         "5": {
           "body": "assert!(true);",
-          "breadcrumbs": "First Chapter » Some Section",
+          "breadcrumbs": "First Chapter » Nested Chapter » Some Section",
           "id": "5",
           "title": "Some Section"
         },
         "6": {
           "body": "// The next line will cause a `rendered_output` test to fail if the anchor feature is broken in\n// such a way that the content between anchors isn't included.\n// unique-string-for-anchor-test\nassert!(true);",
-          "breadcrumbs": "First Chapter » Anchors include the part of a file between special comments",
+          "breadcrumbs": "First Chapter » Nested Chapter » Anchors include the part of a file between special comments",
           "id": "6",
           "title": "Anchors include the part of a file between special comments"
         },
         "7": {
           "body": "# fn some_function() {\n# assert!(true);\n# }\n# fn main() { some_function();\n}",
-          "breadcrumbs": "First Chapter » Rustdoc include adds the rest of the file as hidden",
+          "breadcrumbs": "First Chapter » Nested Chapter » Rustdoc include adds the rest of the file as hidden",
           "id": "7",
           "title": "Rustdoc include adds the rest of the file as hidden"
         },
         "8": {
           "body": "# fn some_other_function() {\n# assert!(true);\n# }\n# fn main() { some_other_function();\n}",
-          "breadcrumbs": "First Chapter » Rustdoc include works with anchors too",
+          "breadcrumbs": "First Chapter » Nested Chapter » Rustdoc include works with anchors too",
           "id": "8",
           "title": "Rustdoc include works with anchors too"
         },
         "9": {
           "body": "",
-          "breadcrumbs": "First Chapter » Includes",
+          "breadcrumbs": "First Chapter » Includes » Includes",
           "id": "9",
           "title": "Includes"
         }
@@ -3048,7 +3048,7 @@
                   "df": 2,
                   "docs": {
                     "0": {
-                      "tf": 1.4142135623730951
+                      "tf": 1.7320508075688772
                     },
                     "10": {
                       "tf": 1.0
@@ -3222,7 +3222,7 @@
                       "df": 0,
                       "docs": {},
                       "r": {
-                        "df": 17,
+                        "df": 18,
                         "docs": {
                           "10": {
                             "tf": 2.23606797749979
@@ -3246,31 +3246,34 @@
                             "tf": 1.0
                           },
                           "17": {
-                            "tf": 1.4142135623730951
-                          },
-                          "18": {
-                            "tf": 1.0
-                          },
-                          "19": {
-                            "tf": 1.0
-                          },
-                          "2": {
-                            "tf": 1.4142135623730951
-                          },
-                          "4": {
                             "tf": 1.7320508075688772
                           },
-                          "5": {
+                          "18": {
+                            "tf": 1.4142135623730951
+                          },
+                          "19": {
+                            "tf": 1.4142135623730951
+                          },
+                          "2": {
+                            "tf": 1.7320508075688772
+                          },
+                          "3": {
                             "tf": 1.0
+                          },
+                          "4": {
+                            "tf": 2.0
+                          },
+                          "5": {
+                            "tf": 1.4142135623730951
                           },
                           "6": {
-                            "tf": 1.0
+                            "tf": 1.4142135623730951
                           },
                           "7": {
-                            "tf": 1.0
+                            "tf": 1.4142135623730951
                           },
                           "8": {
-                            "tf": 1.0
+                            "tf": 1.4142135623730951
                           },
                           "9": {
                             "tf": 1.0
@@ -3379,7 +3382,7 @@
                             "tf": 1.0
                           },
                           "20": {
-                            "tf": 1.4142135623730951
+                            "tf": 1.7320508075688772
                           }
                         }
                       }
@@ -3467,7 +3470,7 @@
                     "df": 2,
                     "docs": {
                       "0": {
-                        "tf": 1.4142135623730951
+                        "tf": 1.7320508075688772
                       },
                       "10": {
                         "tf": 1.0
@@ -3672,7 +3675,7 @@
                   "df": 0,
                   "docs": {},
                   "t": {
-                    "df": 15,
+                    "df": 16,
                     "docs": {
                       "10": {
                         "tf": 1.4142135623730951
@@ -3699,7 +3702,10 @@
                         "tf": 1.0
                       },
                       "2": {
-                        "tf": 1.4142135623730951
+                        "tf": 1.7320508075688772
+                      },
+                      "3": {
+                        "tf": 1.0
                       },
                       "4": {
                         "tf": 1.0
@@ -3964,7 +3970,7 @@
                       "df": 5,
                       "docs": {
                         "10": {
-                          "tf": 1.0
+                          "tf": 1.4142135623730951
                         },
                         "6": {
                           "tf": 1.7320508075688772
@@ -3976,7 +3982,7 @@
                           "tf": 1.4142135623730951
                         },
                         "9": {
-                          "tf": 1.4142135623730951
+                          "tf": 1.7320508075688772
                         }
                       }
                     },
@@ -4065,7 +4071,7 @@
                             "df": 2,
                             "docs": {
                               "1": {
-                                "tf": 1.4142135623730951
+                                "tf": 1.7320508075688772
                               },
                               "10": {
                                 "tf": 1.0
@@ -4282,13 +4288,25 @@
                         "df": 0,
                         "docs": {},
                         "n": {
-                          "df": 2,
+                          "df": 6,
                           "docs": {
                             "10": {
                               "tf": 1.0
                             },
                             "11": {
-                              "tf": 1.7320508075688772
+                              "tf": 2.0
+                            },
+                            "12": {
+                              "tf": 1.0
+                            },
+                            "13": {
+                              "tf": 1.0
+                            },
+                            "14": {
+                              "tf": 1.0
+                            },
+                            "15": {
+                              "tf": 1.0
                             }
                           }
                         }
@@ -4361,13 +4379,31 @@
                 "df": 0,
                 "docs": {},
                 "t": {
-                  "df": 2,
+                  "df": 8,
                   "docs": {
                     "10": {
                       "tf": 1.4142135623730951
                     },
+                    "18": {
+                      "tf": 1.0
+                    },
+                    "19": {
+                      "tf": 1.0
+                    },
                     "4": {
-                      "tf": 1.4142135623730951
+                      "tf": 1.7320508075688772
+                    },
+                    "5": {
+                      "tf": 1.0
+                    },
+                    "6": {
+                      "tf": 1.0
+                    },
+                    "7": {
+                      "tf": 1.0
+                    },
+                    "8": {
+                      "tf": 1.0
                     }
                   }
                 }
@@ -4843,7 +4879,7 @@
                           "tf": 1.0
                         },
                         "17": {
-                          "tf": 1.4142135623730951
+                          "tf": 1.7320508075688772
                         },
                         "18": {
                           "tf": 1.0
@@ -5385,7 +5421,7 @@
                           "tf": 1.0
                         },
                         "16": {
-                          "tf": 1.4142135623730951
+                          "tf": 1.7320508075688772
                         }
                       }
                     },


### PR DESCRIPTION
Currently the search result breadcrumbs only contain the chapter's parents, and not the chapter name itself.
This PR adds the chapter name to the breadcrumbs for improved searchability.
