### PR TITLE
Missing chapters Error Reporting: Add file name

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -49,7 +49,9 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
                     }
                     debug!("Creating missing file {}", filename.display());
 
-                    let mut f = File::create(&filename).with_context(|| format!("Unable to create missing file: {}", filename.display()))?;
+                    let mut f = File::create(&filename).with_context(|| {
+                        format!("Unable to create missing file: {}", filename.display())
+                    })?;
                     writeln!(f, "# {}", link.name)?;
                 }
             }

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -49,7 +49,7 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
                     }
                     debug!("Creating missing file {}", filename.display());
 
-                    let mut f = File::create(&filename)?;
+                    let mut f = File::create(&filename).with_context(|| format!("Unable to create missing file: {}", filename.display()))?;
                     writeln!(f, "# {}", link.name)?;
                 }
             }


### PR DESCRIPTION
This patch adds more contextual information regarding the file name which failed due an underlying issue.


Before the changes

````
2020-12-05 20:06:01 [ERROR] (mdbook::utils): Error: Unable to create missing chapters
2020-12-05 20:06:01 [ERROR] (mdbook::utils):    Caused By: Permission denied (os error 13)
````

After the changes
```
2020-12-05 20:12:08 [ERROR] (mdbook::utils): Error: Unable to create missing chapters
2020-12-05 20:12:08 [ERROR] (mdbook::utils):    Caused By: Unable to create missing file: /Users/vicky/tmp/issue_testing/sample/src/./chapter_3.md
2020-12-05 20:12:08 [ERROR] (mdbook::utils):    Caused By: Permission denied (os error 13)
```