### PR TITLE
Show path in the error message (#1396)

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -110,7 +110,10 @@ pub fn copy_files_except_ext(
 
     for entry in fs::read_dir(from)? {
         let entry = entry?;
-        let metadata = entry.path().metadata()?;
+        let metadata = entry
+            .path()
+            .metadata()
+            .with_context(|| format!("Failed to read {:?}", entry.path()))?;
 
         // If the entry is a dir and the recursive option is enabled, call itself
         if metadata.is_dir() && recursive {


### PR DESCRIPTION
With this pull request, in the case of the example in #1396, the error message will look like this:

```
2020-12-14 15:31:55 [INFO] (mdbook::book): Book building has started
2020-12-14 15:31:55 [INFO] (mdbook::book): Running the html backend
2020-12-14 15:31:55 [ERROR] (mdbook::utils): Error: Rendering failed
2020-12-14 15:31:55 [ERROR] (mdbook::utils):    Caused By: Failed to read "/home/u7693/Workspace/book/src/not-found"
2020-12-14 15:31:55 [ERROR] (mdbook::utils):    Caused By: No such file or directory (os error 2)
```

Fixes #1396