### PR TITLE
Provide useful feedback if user executes command in different folder

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -14,7 +14,7 @@ pub fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> 
     let summary_md = src_dir.join("SUMMARY.md");
 
     let mut summary_content = String::new();
-    File::open(summary_md.clone())
+    File::open(&summary_md)
         .with_context(|| format!("Couldn't open SUMMARY.md in {:?} directory", src_dir))?
         .read_to_string(&mut summary_content)?;
 

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -14,11 +14,12 @@ pub fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> 
     let summary_md = src_dir.join("SUMMARY.md");
 
     let mut summary_content = String::new();
-    File::open(summary_md)
-        .with_context(|| "Couldn't open SUMMARY.md")?
+    File::open(summary_md.clone())
+        .with_context(|| format!("Couldn't open SUMMARY.md in {:?} directory", src_dir))?
         .read_to_string(&mut summary_content)?;
 
-    let summary = parse_summary(&summary_content).with_context(|| "Summary parsing failed")?;
+    let summary = parse_summary(&summary_content)
+        .with_context(|| format!("Summary parsing failed for file={:?}", summary_md))?;
 
     if cfg.create_missing {
         create_missing(&src_dir, &summary).with_context(|| "Unable to create missing chapters")?;


### PR DESCRIPTION
Provides better feedback if user executes in a different folder than what is expected by mdbook


After the changes `mdbook build`
```
2020-12-19 14:27:35 [ERROR] (mdbook::utils): Error: Couldn't open SUMMARY.md in "/Users/vicky/rust/source_codes/mdbook_testing/src/src" directory
2020-12-19 14:27:35 [ERROR] (mdbook::utils):    Caused By: No such file or directory (os error 2)
```

Previously: `mdbook build`
```
2020-12-19 14:28:46 [ERROR] (mdbook::utils): Error: Couldn't open SUMMARY.md
2020-12-19 14:28:46 [ERROR] (mdbook::utils):    Caused By: No such file or directory (os error 2)
```
