### PR TITLE
feat(navigation): add support for vi bindings (h = left and l = right)

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -539,6 +539,7 @@ function playground_text(playground) {
 
         switch (e.key) {
             case 'ArrowRight':
+            case 'l':
                 e.preventDefault();
                 var nextButton = document.querySelector('.nav-chapters.next');
                 if (nextButton) {
@@ -546,6 +547,7 @@ function playground_text(playground) {
                 }
                 break;
             case 'ArrowLeft':
+            case 'h':
                 e.preventDefault();
                 var previousButton = document.querySelector('.nav-chapters.previous');
                 if (previousButton) {


### PR DESCRIPTION
This PR replaces #608 because it seems to be that the original author is gone.

Also, I propose to only handle the keys for rightArrow (l) and leftArrow (h) here, for the key bindings to navigate back and forth for whole sections in the sidebar I am planning to bring up a new PR.