### PR TITLE
[README] Add optional directory parameter for the init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ explanation, check out the [User Guide].
 
     The init command will create a directory with the minimal boilerplate to
     start with. If the `<directory>` parameter is omitted, the current 
-    directory will me used.
+    directory will be used.
 
     ```
     book-test/

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ all its functionality as a Rust crate for integration in other projects.
 Here are the main commands you will want to run. For a more exhaustive
 explanation, check out the [User Guide].
 
-- `mdbook init`
+- `mdbook init <directory>`
 
     The init command will create a directory with the minimal boilerplate to
-    start with.
+    start with. If the `<directory>` parameter is omitted, the current 
+    directory will me used.
 
     ```
     book-test/


### PR DESCRIPTION
With the current description of the command, I was expecting to get a directory named with the project name, but the files were created in the current directory.
I think a more precise description would help first-time users.