### PR TITLE
[guide/format/theme/index-hbs] `chapter_title` and `book_title` are inverted

### DIFF
--- a/guide/src/format/theme/index-hbs.md
+++ b/guide/src/format/theme/index-hbs.md
@@ -19,7 +19,7 @@ Here is a list of the properties that are exposed:
 
 - ***language*** Language of the book in the form `en`, as specified in `book.toml` (if not specified, defaults to `en`). To use in <code
   class="language-html">\<html lang="{{ language }}"></code> for example.
-- ***title*** Title used for the current page. This is identical to `{{ book_title }} - {{ chapter_title }}` unless `book_title` is not set in which case it just defaults to the `chapter_title`.
+- ***title*** Title used for the current page. This is identical to `{{ chapter_title }} - {{ book_title }}` unless `book_title` is not set in which case it just defaults to the `chapter_title`.
 - ***book_title*** Title of the book, as specified in `book.toml`
 - ***chapter_title*** Title of the current chapter, as listed in `SUMMARY.md`
 


### PR DESCRIPTION
Looking into the code, we can confirm that the implementation is `{{ chapter_title }} - {{ book_title }}` and not `{{ book_title }} - {{ chapter_title }}` as written in the guide:
https://github.com/rust-lang/mdBook/blob/4c951d530d7cf225fcca18d6e9146b28bf8dcf10/src/renderer/html_handlebars/hbs_renderer.rs#L69