### PR TITLE
Fix search highlighting with multiple words.

### DIFF
--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -296,7 +296,7 @@ window.search = window.search || {};
         }
 
         if (url.params.hasOwnProperty(URL_MARK_PARAM)) {
-            var words = url.params[URL_MARK_PARAM].split(' ');
+            var words = decodeURIComponent(url.params[URL_MARK_PARAM]).split(' ');
             marker.mark(words, {
                 exclude: mark_exclude
             });


### PR DESCRIPTION
If you click on a search result after entering multiple words, the target page will not have any highlighting.  The marking code was not unescaping the highlight words, thus the split on space doesn't work.