### PR TITLE
Remove mark from URL on escape.

### DIFF
--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -427,6 +427,7 @@ window.search = window.search || {};
             delete url.params[URL_MARK_PARAM];
             url.hash = "";
         } else {
+            delete url.params[URL_MARK_PARAM];
             delete url.params[URL_SEARCH_PARAM];
         }
         // A new search will also add a new history item, so the user can go back


### PR DESCRIPTION
When clicking on a search result, the page will highlight the search terms.  Pressing escape will remove the highlight.  However, the `?highlight=...` would remain in the URL.  This can be annoying if you want to copy and paste the URL to use elsewhere.  This changes it so that hitting escape will also remove the `?highlight=...` from the URL when hitting escape.
