### PR TITLE
Change `init --theme` to place theme in root.

### DIFF
--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -110,10 +110,7 @@ impl BookBuilder {
         debug!("Copying theme");
 
         let html_config = self.config.html_config().unwrap_or_default();
-        let themedir = html_config
-            .theme
-            .unwrap_or_else(|| self.config.book.src.join("theme"));
-        let themedir = self.root.join(themedir);
+        let themedir = html_config.theme_dir(&self.root);
 
         if !themedir.exists() {
             debug!(
@@ -127,7 +124,9 @@ impl BookBuilder {
         index.write_all(theme::INDEX)?;
 
         let cssdir = themedir.join("css");
-        fs::create_dir(&cssdir)?;
+        if !cssdir.exists() {
+            fs::create_dir(&cssdir)?;
+        }
 
         let mut general_css = File::create(cssdir.join("general.css"))?;
         general_css.write_all(theme::GENERAL_CSS)?;

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -28,15 +28,11 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     // If flag `--theme` is present, copy theme to src
     if args.is_present("theme") {
-        config.set("output.html.theme", "src/theme")?;
+        let theme_dir = book_dir.join("theme");
+        println!();
+        println!("Copying the default theme to {}", theme_dir.display());
         // Skip this if `--force` is present
-        if !args.is_present("force") {
-            // Print warning
-            println!();
-            println!(
-                "Copying the default theme to {}",
-                builder.config().book.src.display()
-            );
+        if !args.is_present("force") && theme_dir.exists() {
             println!("This could potentially overwrite files already present in that directory.");
             print!("\nAre you sure you want to continue? (y/n) ");
 

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -108,3 +108,37 @@ fn book_toml_isnt_required() {
 
     md.build().unwrap();
 }
+
+#[test]
+fn copy_theme() {
+    let temp = TempFileBuilder::new().prefix("mdbook").tempdir().unwrap();
+    MDBook::init(temp.path()).copy_theme(true).build().unwrap();
+    let expected = vec![
+        "book.js",
+        "css/chrome.css",
+        "css/general.css",
+        "css/print.css",
+        "css/variables.css",
+        "favicon.png",
+        "favicon.svg",
+        "highlight.css",
+        "highlight.js",
+        "index.hbs",
+    ];
+    let theme_dir = temp.path().join("theme");
+    let mut actual: Vec<_> = walkdir::WalkDir::new(&theme_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| !e.file_type().is_dir())
+        .map(|e| {
+            e.path()
+                .strip_prefix(&theme_dir)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace('\\', "/")
+        })
+        .collect();
+    actual.sort();
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
A long time ago (#491, #696), the location of themes was changed from `src/theme` to `theme`.  However, `mdbook init --theme` was never updated to place the theme in the new location.  This updates the init command to place the `theme` directory in the root.

This also includes a few minor fixes:
* If the css directory exists, don't fail.
* Don't print the overwrite warning if it isn't actually going to overwrite anything.

Closes #1412
