### PR TITLE
Fix a wrong version 0.4.4 in Cargo.toml (Should be 0.4.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mdbook"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     "Mathieu David <mathieudavid@mathieudavid.org>",
     "Michael-F-Bryan <michaelfbryan@gmail.com>",


### PR DESCRIPTION
This pull request updates the version in [Cargo.toml](https://github.com/rust-lang/mdBook/blob/a76557a678aeded8344acba2f929edb5b5ac8f3e/Cargo.toml#L3) from 0.4.4 to 0.4.5, so that it matches to the one published to crate.io.

**Problem Description**

v0.4.5 has been published to crates.io, but Cargo.toml in this repository left unchanged as 0.4.4.

```console
$ git clone git@github.com:rust-lang-ja/mdBook.git
$ cd mdBook/

$ git show  
commit 09e7bb76dc1d1f565a0678a9f8d3caa0164631cb (HEAD -> master, origin/master, origin/HEAD)
Author: ...
Date:   Tue Jan 5 10:31:16 2021 -0800

$ cargo run -- --version
...
mdbook v0.4.4    # <== Wrong version. Should be v0.4.5

$ rg 'version =' Cargo.toml | head -1
version = "0.4.4"
```

The one published to crate.io has the correct version.

```console
$ curl -L https://static.crates.io/crates/mdbook/mdbook-0.4.5.crate -o mdbook-0.4.5.tar.gz
$ tar xf mdbook-0.4.5.tar.gz
$ cd mdbook-0.4.5/
$ rg 'version =' Cargo.toml | head -1
version = "0.4.5"
```
