### PR TITLE
Skip HTML nodes in SUMMARY.md

### DIFF
--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -365,6 +365,8 @@ impl<'a> SummaryParser<'a> {
         let mut first = true;
 
         loop {
+            let mut html_node = false;
+
             match self.next_event() {
                 Some(ev @ Event::Start(Tag::Paragraph)) => {
                     if !first {
@@ -405,6 +407,12 @@ impl<'a> SummaryParser<'a> {
                     items.push(SummaryItem::Separator);
                 }
 
+                // A HTML node, such as a comment line... ignore, but set the html_node flag.
+                Some(Event::Html(html)) => {
+                    trace!("Skipping a HTML node of {:?}", html);
+                    html_node = true;
+                }
+
                 // something else... ignore
                 Some(_) => {}
 
@@ -414,8 +422,10 @@ impl<'a> SummaryParser<'a> {
                 }
             }
 
-            // From now on, we cannot accept any new paragraph opening tags.
-            first = false;
+            // If the event was not a HTML node, we no longer accept any new paragraph opening tags.
+            if !html_node {
+                first = false;
+            }
         }
 
         Ok(items)
@@ -525,14 +535,19 @@ impl<'a> SummaryParser<'a> {
 
     /// Try to parse the title line.
     fn parse_title(&mut self) -> Option<String> {
-        match self.next_event() {
-            Some(Event::Start(Tag::Heading(1))) => {
-                debug!("Found a h1 in the SUMMARY");
+        loop {
+            match self.next_event() {
+                Some(Event::Start(Tag::Heading(1))) => {
+                    debug!("Found a h1 in the SUMMARY");
 
-                let tags = collect_events!(self.stream, end Tag::Heading(1));
-                Some(stringify_events(tags))
+                    let tags = collect_events!(self.stream, end Tag::Heading(1));
+                    return Some(stringify_events(tags));
+                }
+                // Skip a HTML element such as a comment line.
+                Some(Event::Html(_)) => {}
+                // Otherwise, no title.
+                _ => return None,
             }
-            _ => None,
         }
     }
 }
@@ -971,6 +986,105 @@ mod tests {
             .parse_numbered(&mut 0, &mut SectionNumber::default())
             .unwrap();
 
+        assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn skip_html_comments() {
+        let src = r#"<!--
+# Title - En
+-->
+# Title - Local
+
+<!--
+[Prefix 00-01 - En](ch00-01.md)
+[Prefix 00-02 - En](ch00-02.md)
+-->
+[Prefix 00-01 - Local](ch00-01.md)
+[Prefix 00-02 - Local](ch00-02.md)
+
+<!--
+## Section Title - En
+-->
+## Section Title - Localized
+
+<!--
+- [Ch 01-00 - En](ch01-00.md)
+    - [Ch 01-01 - En](ch01-01.md)
+    - [Ch 01-02 - En](ch01-02.md)
+-->
+- [Ch 01-00 - Local](ch01-00.md)
+    - [Ch 01-01 - Local](ch01-01.md)
+    - [Ch 01-02 - Local](ch01-02.md)
+
+<!--
+- [Ch 02-00 - En](ch02-00.md)
+-->
+- [Ch 02-00 - Local](ch02-00.md)
+
+<!--
+[Appendix A - En](appendix-01.md)
+[Appendix B - En](appendix-02.md)
+-->`
+[Appendix A - Local](appendix-01.md)
+[Appendix B - Local](appendix-02.md)
+"#;
+
+        let mut parser = SummaryParser::new(src);
+
+        // ---- Title ----
+        let title = parser.parse_title();
+        assert_eq!(title, Some(String::from("Title - Local")));
+
+        // ---- Prefix Chapters ----
+
+        let new_affix_item = |name, location| {
+            SummaryItem::Link(Link {
+                name: String::from(name),
+                location: Some(PathBuf::from(location)),
+                ..Default::default()
+            })
+        };
+
+        let should_be = vec![
+            new_affix_item("Prefix 00-01 - Local", "ch00-01.md"),
+            new_affix_item("Prefix 00-02 - Local", "ch00-02.md"),
+        ];
+
+        let got = parser.parse_affix(true).unwrap();
+        assert_eq!(got, should_be);
+
+        // ---- Numbered Chapters ----
+
+        let new_numbered_item = |name, location, numbers: &[u32], nested_items| {
+            SummaryItem::Link(Link {
+                name: String::from(name),
+                location: Some(PathBuf::from(location)),
+                number: Some(SectionNumber(numbers.to_vec())),
+                nested_items,
+            })
+        };
+
+        let ch01_nested = vec![
+            new_numbered_item("Ch 01-01 - Local", "ch01-01.md", &[1, 1], vec![]),
+            new_numbered_item("Ch 01-02 - Local", "ch01-02.md", &[1, 2], vec![]),
+        ];
+
+        let should_be = vec![
+            new_numbered_item("Ch 01-00 - Local", "ch01-00.md", &[1], ch01_nested),
+            new_numbered_item("Ch 02-00 - Local", "ch02-00.md", &[2], vec![]),
+        ];
+        let got = parser.parse_parts().unwrap();
+        assert_eq!(got, should_be);
+
+        // ---- Suffix Chapters ----
+
+        let should_be = vec![
+            new_affix_item("Appendix A - Local", "appendix-01.md"),
+            new_affix_item("Appendix B - Local", "appendix-02.md"),
+        ];
+
+        let got = parser.parse_affix(false).unwrap();
         assert_eq!(got, should_be);
     }
 }

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -365,8 +365,6 @@ impl<'a> SummaryParser<'a> {
         let mut first = true;
 
         loop {
-            let mut html_node = false;
-
             match self.next_event() {
                 Some(ev @ Event::Start(Tag::Paragraph)) => {
                     if !first {
@@ -407,12 +405,6 @@ impl<'a> SummaryParser<'a> {
                     items.push(SummaryItem::Separator);
                 }
 
-                // A HTML node, such as a comment line... ignore, but set the html_node flag.
-                Some(Event::Html(html)) => {
-                    trace!("Skipping a HTML node of {:?}", html);
-                    html_node = true;
-                }
-
                 // something else... ignore
                 Some(_) => {}
 
@@ -422,10 +414,8 @@ impl<'a> SummaryParser<'a> {
                 }
             }
 
-            // If the event was not a HTML node, we no longer accept any new paragraph opening tags.
-            if !html_node {
-                first = false;
-            }
+            // From now on, we cannot accept any new paragraph opening tags.
+            first = false;
         }
 
         Ok(items)


### PR DESCRIPTION
This pull request changes mdBook 0.4.x to skip any HTML node (such as HTML comment) in `SUMMARY.md`.

Here is an example [`SUMMARY.md`](https://raw.githubusercontent.com/rust-lang-ja/book-ja/3cdfb484693765c4386ad1a227f741e66a7b924b/src/SUMMARY.md) from [rust-lang-ja/book-ja](https://github.com/rust-lang-ja/book-ja) repository. This repository is for a Japanese translation of "The Rust Programming Language" book.

```markdown
 1: <!--
 2: # The Rust Programming Language
 3: -->
 4: # Rustプログラミング言語
 5:
 6: <!--
 7: [The Rust Programming Language](title-page.md)
 8: [Foreword](foreword.md)
 9: [Introduction](ch00-00-introduction.md)
10: -->
11: [The Rust Programming Language 日本語版](title-page.md)
12: [まえがき](foreword.md)
13: [導入](ch00-00-introduction.md)
14:
15: <!--
16: ## Getting started
17: -->
18: ## 事始め
19: 
20: <!--
21: - [Getting Started](ch01-00-getting-started.md)
22:     - [Installation](ch01-01-installation.md)
23:     - [Hello, World!](ch01-02-hello-world.md)
24:     - [Hello, Cargo!](ch01-03-hello-cargo.md)
25: -->
26: - [事始め](ch01-00-getting-started.md)
27:     - [インストール](ch01-01-installation.md)
...
```

(We are keeping the original English texts in HTML comments to track future updates in the original)

Without this change, mdBook 0.4.x will fail as the followings:

```console
$ mdbook build
[ERROR] (mdbook::utils): Error: Summary parsing failed
[ERROR] (mdbook::utils): 	Caused By: There was an error parsing the suffix chapters
[ERROR] (mdbook::utils): 	Caused By: failed to parse SUMMARY.md line 26, column 1: 
Suffix chapters cannot be followed by a list
```

Note that mdBook 0.3.7 can parse the same `SUMMARY.md` without problem.
