### PR TITLE
Lower the width below which a screen is considered small

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -175,7 +175,7 @@ a > .hljs {
     right: var(--page-padding);
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 900px) {
     .nav-wide-wrapper { display: none; }
     .nav-wrapper { display: block; }
 }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -93,7 +93,7 @@
         <script type="text/javascript">
             var html = document.querySelector('html');
             var sidebar = 'hidden';
-            if (document.body.clientWidth >= 1080) {
+            if (document.body.clientWidth >= 900) {
                 try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';
             }


### PR DESCRIPTION
I've noticed that the point at which mdBook starts considering a screen as small (i.e. force-hides the sidebar after a reload) feel unnecessarily small. In my opinion, this makes mdBooks much more difficult to navigate on small screens or in small browser windows, given that after every click on a link the sidebar is hidden and has to be re-opened.

The original 1080px width seems to stem from 71689da6b151c922f0bb69c54f0bc6545d585652 which states that this is because of the sum of side bar width plus content width. This suggests the underlying assumption that the content becomes less readable once it shrinks below the default width.

In my opinion, this is not the case: at the proposed breakpoint of 900px, the reader still sees around 70 characters per line at default zoom level. According to [this thread](https://ux.stackexchange.com/a/108803/30751), that is still a good line width for reading on a screen.

This may also be related to #850, though I'm not entirely sure.