### PR TITLE
Fix some issues with fragment scrolling and linking.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -756,7 +756,7 @@ fn insert_link_into_header(
     *id_count += 1;
 
     format!(
-        r##"<h{level}><a class="header" href="#{id}" id="{id}">{text}</a></h{level}>"##,
+        r##"<h{level} id="{id}"><a class="header" href="#{id}">{text}</a></h{level}>"##,
         level = level,
         id = id,
         text = content
@@ -927,27 +927,27 @@ mod tests {
         let inputs = vec![
             (
                 "blah blah <h1>Foo</h1>",
-                r##"blah blah <h1><a class="header" href="#foo" id="foo">Foo</a></h1>"##,
+                r##"blah blah <h1 id="foo"><a class="header" href="#foo">Foo</a></h1>"##,
             ),
             (
                 "<h1>Foo</h1>",
-                r##"<h1><a class="header" href="#foo" id="foo">Foo</a></h1>"##,
+                r##"<h1 id="foo"><a class="header" href="#foo">Foo</a></h1>"##,
             ),
             (
                 "<h3>Foo^bar</h3>",
-                r##"<h3><a class="header" href="#foobar" id="foobar">Foo^bar</a></h3>"##,
+                r##"<h3 id="foobar"><a class="header" href="#foobar">Foo^bar</a></h3>"##,
             ),
             (
                 "<h4></h4>",
-                r##"<h4><a class="header" href="#" id=""></a></h4>"##,
+                r##"<h4 id=""><a class="header" href="#"></a></h4>"##,
             ),
             (
                 "<h4><em>Hï</em></h4>",
-                r##"<h4><a class="header" href="#hï" id="hï"><em>Hï</em></a></h4>"##,
+                r##"<h4 id="hï"><a class="header" href="#hï"><em>Hï</em></a></h4>"##,
             ),
             (
                 "<h1>Foo</h1><h3>Foo</h3>",
-                r##"<h1><a class="header" href="#foo" id="foo">Foo</a></h1><h3><a class="header" href="#foo-1" id="foo-1">Foo</a></h3>"##,
+                r##"<h1 id="foo"><a class="header" href="#foo">Foo</a></h1><h3 id="foo-1"><a class="header" href="#foo-1">Foo</a></h3>"##,
             ),
         ];
 

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -45,20 +45,23 @@ h4, h5 { margin-top: 2em; }
     margin-top: 1em;
 }
 
-h1 a.header:target::before,
-h2 a.header:target::before,
-h3 a.header:target::before,
-h4 a.header:target::before {
+h1:target::before,
+h2:target::before,
+h3:target::before,
+h4:target::before,
+h5:target::before,
+h6:target::before {
     display: inline-block;
     content: "»";
     margin-left: -30px;
     width: 30px;
 }
 
-h1 a.header:target,
-h2 a.header:target,
-h3 a.header:target,
-h4 a.header:target {
+/* This is broken on Safari as of version 14, but is fixed
+   in Safari Technology Preview 117 which I think will be Safari 14.2.
+   https://bugs.webkit.org/show_bug.cgi?id=218076
+*/
+:target {
     scroll-margin-top: calc(var(--menu-bar-height) + 0.5em);
 }
 

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -104,12 +104,12 @@ fn check_correct_cross_links_in_nested_dir() {
 
     assert_contains_strings(
         first.join("index.html"),
-        &[r##"href="#some-section" id="some-section""##],
+        &[r##"<h2 id="some-section"><a class="header" href="#some-section">"##],
     );
 
     assert_contains_strings(
         first.join("nested.html"),
-        &[r##"href="#some-section" id="some-section""##],
+        &[r##"<h2 id="some-section"><a class="header" href="#some-section">"##],
     );
 }
 
@@ -373,7 +373,7 @@ fn able_to_include_files_in_chapters() {
     let includes = temp.path().join("book/first/includes.html");
 
     let summary_strings = &[
-        r##"<h1><a class="header" href="#summary" id="summary">Summary</a></h1>"##,
+        r##"<h1 id="summary"><a class="header" href="#summary">Summary</a></h1>"##,
         ">First Chapter</a>",
     ];
     assert_contains_strings(&includes, summary_strings);


### PR DESCRIPTION
This fixes some issues with how `#` fragment scrolling works, and how headers are highlighted:

* h5 and h6 now show a chevron to the side.
* All `:target` elements now scroll into view with a top margin so that they aren't covered by the menu bar. This affected anything that wasn't h1-h4 (like h5, h6, footnotes, custom anchors, etc.).  I didn't see an obvious reason to restrict this to just header tags, so it now selects all `:target` elements.

Note that the margin scrolling does not work on Safari, but has been fixed in Technology Preview 117 (which I think is Safari 14.2).  This required moving the `id` from the `<a>` tag to the header tag, which I think should be fine (Safari didn't seem to like id's on `<a>` tags).

Fixes #1198
Fixes #1357
