### PR TITLE
Serve on 127.0.0.1 rather than localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ explanation, check out the [User Guide].
 - `mdbook serve`
 
     Does the same thing as `mdbook watch` but additionally serves the book at
-    `http://localhost:3000` (port is changeable) and reloads the browser when a
+    `http://127.0.0.1:3000` (port is changeable) and reloads the browser when a
     change occurs.
 
 - `mdbook clean`

--- a/guide/src/cli/serve.md
+++ b/guide/src/cli/serve.md
@@ -1,7 +1,7 @@
 # The serve command
 
 The serve command is used to preview a book by serving it over HTTP at
-`localhost:3000` by default. Additionally it watches the book's directory for
+`127.0.0.1:3000` by default. Additionally it watches the book's directory for
 changes, rebuilding the book and refreshing clients for each change. A websocket
 connection is used to trigger the client-side refresh.
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -20,7 +20,7 @@ const LIVE_RELOAD_ENDPOINT: &str = "__livereload";
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("serve")
-        .about("Serves a book at http://localhost:3000, and rebuilds it on changes")
+        .about("Serves a book at http://127.0.0.1:3000, and rebuilds it on changes")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
              Relative paths are interpreted relative to the book's root directory.{n}\
@@ -35,7 +35,7 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
                 .short("n")
                 .long("hostname")
                 .takes_value(true)
-                .default_value("localhost")
+                .default_value("127.0.0.1")
                 .empty_values(false)
                 .help("Hostname to listen on for HTTP connections"),
         )


### PR DESCRIPTION
This allows 127.1 and 127.0.0.1 to work but still having localhost
working, previously only localhost was allowed.

Fix #1434