### PR TITLE
Create a chapter_config for chapter specific properties to be exposed to the handlebars template.

### DIFF
--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -105,6 +105,25 @@ The following preprocessors are available and included by default:
 - `index`: Convert all chapter files named `README.md` into `index.md`. That is
   to say, all `README.md` would be rendered to an index file `index.html` in the
   rendered book.
+- `metadata`: Reads an optional TOML header from the markdown chapter sources
+  to provide chapter specific information. This data is then made available to
+  handlebars.js. The supported fields are `author`, `title`, `description`, `keywords`,
+  `date` and `modified`.
+
+**Sample Chapter**
+```toml
+---
+author = "Jane Doe" # this is written to the author meta tag
+title = "Blog Post #1" # this overwrites the default title handlebar
+date = "2021/02/14"
+keywords = [
+  "Rust",
+  "Blog",
+] # this sets the keywords meta tag
+description = "A blog about rust-lang" # this sets the description meta tag
+---
+This is my blog about rust.
+```
 
 
 **book.toml**
@@ -116,6 +135,8 @@ create-missing = false
 [preprocessor.links]
 
 [preprocessor.index]
+
+[preprocessor.metadata]
 ```
 
 ### Custom Preprocessor Configuration

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -83,14 +83,14 @@ This controls the build process of your book.
   will be created when the book is built (i.e. `create-missing = true`). If this
   is `false` then the build process will instead exit with an error if any files
   do not exist.
-- **use-default-preprocessors:** Disable the default preprocessors of (`links` &
-  `index`) by setting this option to `false`.
+- **use-default-preprocessors:** Disable the default preprocessors of (`links`,
+  `index` & `metadata`) by setting this option to `false`.
 
   If you have the same, and/or other preprocessors declared via their table
   of configuration, they will run instead.
 
-  - For clarity, with no preprocessor configuration, the default `links` and
-    `index` will run.
+  - For clarity, with no preprocessor configuration, the default `links`,
+    `index` and `metadata` will run.
   - Setting `use-default-preprocessors = false` will disable these
     default preprocessors from running.
   - Adding `[preprocessor.links]`, for example, will ensure, regardless of
@@ -105,24 +105,23 @@ The following preprocessors are available and included by default:
 - `index`: Convert all chapter files named `README.md` into `index.md`. That is
   to say, all `README.md` would be rendered to an index file `index.html` in the
   rendered book.
-- `metadata`: Reads an optional TOML header from the markdown chapter sources
+- `metadata`: Strips an optional TOML header from the markdown chapter sources
   to provide chapter specific information. This data is then made available to
-  handlebars.js. The supported fields are `author`, `title`, `description`, `keywords`,
-  `date` and `modified`.
+  handlebars.js as a collection of properties.
 
-**Sample Chapter**
+**Sample Chapter With Default "index.hbs"**
 ```toml
 ---
-author = "Jane Doe" # this is written to the author meta tag
-title = "Blog Post #1" # this overwrites the default title handlebar
-date = "2021/02/14"
+author = "Jane Doe"     # this is written to the author meta tag
+title = "Blog Post #1"  # this overwrites the default title handlebar
 keywords = [
   "Rust",
   "Blog",
-] # this sets the keywords meta tag
+]                       # this sets the keywords meta tag
 description = "A blog about rust-lang" # this sets the description meta tag
+date = "2021/02/14"     # this exposes date as a property for use in the handlebars template
 ---
-This is my blog about rust.
+This is my blog about rust. # only from this point on remains after preprocessing
 ```
 
 

--- a/guide/src/format/theme/index-hbs.md
+++ b/guide/src/format/theme/index-hbs.md
@@ -19,7 +19,7 @@ Here is a list of the properties that are exposed:
 
 - ***language*** Language of the book in the form `en`, as specified in `book.toml` (if not specified, defaults to `en`). To use in <code
   class="language-html">\<html lang="{{ language }}"></code> for example.
-- ***title*** Title used for the current page. This is identical to `{{ chapter_title }} - {{ book_title }}` unless `book_title` is not set in which case it just defaults to the `chapter_title`.
+- ***title*** Title used for the current page. This is identical to `{{ chapter_title }} - {{ book_title }}` unless `book_title` is not set in which case it just defaults to the `chapter_title`. This property can be overwritten by the TOML front matter of a chapter's source.
 - ***book_title*** Title of the book, as specified in `book.toml`
 - ***chapter_title*** Title of the current chapter, as listed in `SUMMARY.md`
 

--- a/guide/src/format/theme/index-hbs.md
+++ b/guide/src/format/theme/index-hbs.md
@@ -38,6 +38,8 @@ Here is a list of the properties that are exposed:
   containing all the chapters of the book. It is used for example to construct
   the table of contents (sidebar).
 
+Further properties can be exposed through the `chapter_config` field of a `Chapter` which is accessible to preprocessors.
+
 ## Handlebars Helpers
 
 In addition to the properties you can access, there are some handlebars helpers

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -152,6 +152,8 @@ impl From<Chapter> for BookItem {
 pub struct Chapter {
     /// The chapter's name.
     pub name: String,
+    /// A collection of key, value pairs for handlebars.js templates.
+    pub chapter_config: serde_json::Map<String, serde_json::Value>,
     /// The chapter's contents.
     pub content: String,
     /// The chapter's section number, if it has one.
@@ -174,6 +176,7 @@ impl Chapter {
     ) -> Chapter {
         Chapter {
             name: name.to_string(),
+            chapter_config: serde_json::Map::with_capacity(0),
             content,
             path: Some(path.into()),
             parent_names,
@@ -186,6 +189,7 @@ impl Chapter {
     pub fn new_draft(name: &str, parent_names: Vec<String>) -> Self {
         Chapter {
             name: name.to_string(),
+            chapter_config: serde_json::Map::with_capacity(0),
             content: String::new(),
             path: None,
             parent_names,
@@ -435,6 +439,7 @@ And here is some \
 
         let nested = Chapter {
             name: String::from("Nested Chapter 1"),
+            chapter_config: serde_json::Map::with_capacity(0),
             content: String::from("Hello World!"),
             number: Some(SectionNumber(vec![1, 2])),
             path: Some(PathBuf::from("second.md")),
@@ -443,6 +448,7 @@ And here is some \
         };
         let should_be = BookItem::Chapter(Chapter {
             name: String::from("Chapter 1"),
+            chapter_config: serde_json::Map::with_capacity(0),
             content: String::from(DUMMY_SRC),
             number: None,
             path: Some(PathBuf::from("chapter_1.md")),
@@ -507,6 +513,7 @@ And here is some \
             sections: vec![
                 BookItem::Chapter(Chapter {
                     name: String::from("Chapter 1"),
+                    chapter_config: serde_json::Map::with_capacity(0),
                     content: String::from(DUMMY_SRC),
                     number: None,
                     path: Some(PathBuf::from("Chapter_1/index.md")),
@@ -559,6 +566,7 @@ And here is some \
             sections: vec![
                 BookItem::Chapter(Chapter {
                     name: String::from("Chapter 1"),
+                    chapter_config: serde_json::Map::with_capacity(0),
                     content: String::from(DUMMY_SRC),
                     number: None,
                     path: Some(PathBuf::from("Chapter_1/index.md")),

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -23,7 +23,8 @@ use toml::Value;
 
 use crate::errors::*;
 use crate::preprocess::{
-    CmdPreprocessor, IndexPreprocessor, LinkPreprocessor, Preprocessor, PreprocessorContext,
+    CmdPreprocessor, IndexPreprocessor, LinkPreprocessor, MetadataPreprocessor, Preprocessor,
+    PreprocessorContext,
 };
 use crate::renderer::{CmdRenderer, HtmlHandlebars, MarkdownRenderer, RenderContext, Renderer};
 use crate::utils;
@@ -375,12 +376,15 @@ fn default_preprocessors() -> Vec<Box<dyn Preprocessor>> {
     vec![
         Box::new(LinkPreprocessor::new()),
         Box::new(IndexPreprocessor::new()),
+        Box::new(MetadataPreprocessor::new()),
     ]
 }
 
 fn is_default_preprocessor(pre: &dyn Preprocessor) -> bool {
     let name = pre.name();
-    name == LinkPreprocessor::NAME || name == IndexPreprocessor::NAME
+    name == LinkPreprocessor::NAME
+        || name == IndexPreprocessor::NAME
+        || name == MetadataPreprocessor::NAME
 }
 
 /// Look at the `MDBook` and try to figure out what preprocessors to run.
@@ -396,6 +400,7 @@ fn determine_preprocessors(config: &Config) -> Result<Vec<Box<dyn Preprocessor>>
             match key.as_ref() {
                 "links" => preprocessors.push(Box::new(LinkPreprocessor::new())),
                 "index" => preprocessors.push(Box::new(IndexPreprocessor::new())),
+                "metadata" => preprocessors.push(Box::new(MetadataPreprocessor::new())),
                 name => preprocessors.push(interpret_custom_preprocessor(
                     name,
                     &preprocessor_table[name],
@@ -513,9 +518,10 @@ mod tests {
         let got = determine_preprocessors(&cfg);
 
         assert!(got.is_ok());
-        assert_eq!(got.as_ref().unwrap().len(), 2);
+        assert_eq!(got.as_ref().unwrap().len(), 3);
         assert_eq!(got.as_ref().unwrap()[0].name(), "links");
         assert_eq!(got.as_ref().unwrap()[1].name(), "index");
+        assert_eq!(got.as_ref().unwrap()[2].name(), "metadata");
     }
 
     #[test]

--- a/src/preprocess/metadata.rs
+++ b/src/preprocess/metadata.rs
@@ -66,7 +66,7 @@ impl Match {
         if let Some(mat) = RE.captures(contents) {
             // safe to unwrap as we know there is a match
             let metadata = mat.name("metadata").unwrap();
-            Some( Match {
+            Some(Match {
                 range: metadata.start()..metadata.end(),
                 end: mat.get(0).unwrap().end(),
             })
@@ -161,7 +161,9 @@ mod tests {
             \"Blog\",
         ]
         date = \"2021/02/15\"
-        ").unwrap();
+        ",
+        )
+        .unwrap();
         let mut map = serde_json::Map::<String, serde_json::Value>::new();
         map.insert("author".to_string(), json!("Adam"));
         map.insert("title".to_string(), json!("Blog Post #1"));

--- a/src/preprocess/metadata.rs
+++ b/src/preprocess/metadata.rs
@@ -1,0 +1,277 @@
+use crate::errors::*;
+use regex::{CaptureMatches, Captures, Regex};
+
+use super::{Preprocessor, PreprocessorContext};
+use crate::book::{Book, BookItem};
+
+/// A preprocessor for reading TOML front matter from a markdown file. The supported
+/// fields are:
+/// - `author` - For setting the author meta tag.
+/// - `title` - For overwritting the title tag.
+/// - `description` - For setting the description meta tag.
+/// - `keywords` - For setting the keywords meta tag.
+/// - `date` - The date the file was created, creates a handlebar.js vairable {{date}}.
+/// - `modified` - The date the file was modified, creates a handlebar.js vairable {{modified}}.
+#[derive(Default)]
+pub struct MetadataPreprocessor;
+
+impl MetadataPreprocessor {
+    pub(crate) const NAME: &'static str = "metadata";
+
+    /// Create a new `MetadataPreprocessor`.
+    pub fn new() -> Self {
+        MetadataPreprocessor
+    }
+}
+
+impl Preprocessor for MetadataPreprocessor {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {
+        book.for_each_mut(|section: &mut BookItem| {
+            if let BookItem::Chapter(ref mut ch) = *section {
+                let (metadata, content) = collect(&ch.content);
+                ch.content = content;
+                ch.chapter_config.append(&mut metadata.to_map());
+            }
+        });
+        Ok(book)
+    }
+}
+
+fn collect(s: &str) -> (Metadata, String) {
+    let mut end_index = 0;
+    let mut replaced = String::new();
+
+    let metadata: Metadata = if let Some(metadata) = find_metadata(s).next() {
+        match toml::from_str(metadata.text) {
+            Ok(meta) => {
+                end_index += metadata.end_index;
+                meta
+            }
+            _ => Metadata::default(),
+        }
+    } else {
+        Metadata::default()
+    };
+
+    replaced.push_str(&s[end_index..]);
+    (metadata, replaced)
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+struct Metadata {
+    author: Option<String>,
+    title: Option<String>,
+    date: Option<String>,
+    keywords: Option<Vec<String>>,
+    description: Option<String>,
+    modified: Option<String>,
+}
+
+impl Metadata {
+    fn to_map(self) -> serde_json::Map<String, serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        if let Some(author) = self.author {
+            map.insert("author".to_string(), json!(author));
+        }
+        if let Some(title) = self.title {
+            map.insert("title".to_string(), json!(title));
+        }
+        if let Some(date) = self.date {
+            map.insert("date".to_string(), json!(date));
+        }
+        if let Some(keywords) = self.keywords {
+            map.insert("keywords".to_string(), json!(keywords));
+        }
+        if let Some(modified) = self.modified {
+            map.insert("modified".to_string(), json!(modified));
+        }
+        if let Some(description) = self.description {
+            map.insert("description".to_string(), json!(description));
+        }
+        map
+    }
+}
+
+impl Default for Metadata {
+    fn default() -> Metadata {
+        Metadata {
+            author: None,
+            title: None,
+            date: None,
+            keywords: None,
+            modified: None,
+            description: None,
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+struct MetadataItem<'a> {
+    end_index: usize,
+    text: &'a str,
+}
+
+impl<'a> MetadataItem<'a> {
+    fn from_capture(cap: Captures<'a>) -> Option<MetadataItem<'a>> {
+        if let Some(mat) = cap.name("metadata") {
+            let full_match = cap.get(0).unwrap();
+            if full_match.start() == 0 {
+                return Some(MetadataItem {
+                    end_index: full_match.end(),
+                    text: mat.as_str(),
+                });
+            }
+        }
+        None
+    }
+}
+
+struct MetadataIter<'a>(CaptureMatches<'a, 'a>);
+
+impl<'a> Iterator for MetadataIter<'a> {
+    type Item = MetadataItem<'a>;
+    fn next(&mut self) -> Option<MetadataItem<'a>> {
+        for cap in &mut self.0 {
+            if let Some(inc) = MetadataItem::from_capture(cap) {
+                return Some(inc);
+            }
+        }
+        None
+    }
+}
+
+fn find_metadata(contents: &str) -> MetadataIter<'_> {
+    // lazily compute following regex
+    // r"^-{3,}\n(?P<metadata>.*?)^{3,}\n"
+    lazy_static! {
+        static ref RE: Regex = Regex::new(
+            r"(?xms)          # insignificant whitespace mode and multiline
+            ^-{3,}\n          # match a horizontal rule
+            (?P<metadata>.*?) # name the match between horizontal rules metadata
+            ^-{3,}\n          # match a horizontal rule
+            "
+        )
+        .unwrap();
+    }
+    MetadataIter(RE.captures_iter(contents))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_not_at_start() {
+        let start = "\
+        content\n\
+        ---
+        author = \"Adam\"
+        title = \"Blog Post #1\"
+        keywords = [
+            \"rust\",
+            \"blog\",
+        ]
+        date = \"2021/02/15\"
+        modified = \"2021/02/16\"\n\
+        ---
+        content
+        ";
+        assert_eq!(collect(start).1, start);
+    }
+
+    #[test]
+    fn test_collect_at_start() {
+        let start = "\
+        ---
+        author = \"Adam\"
+        title = \"Blog Post #1\"
+        keywords = [
+            \"rust\",
+            \"blog\",
+        ]
+        date = \"2021/02/15\"
+        description = \"My rust blog.\"
+        modified = \"2021/02/16\"\n\
+        ---\n\
+        content
+        ";
+        let end = "\
+        content
+        ";
+        assert_eq!(collect(start).1, end);
+    }
+
+    #[test]
+    fn test_collect_partial_metadata() {
+        let start = "\
+        ---
+        author = \"Adam\"\n\
+        ---\n\
+        content
+        ";
+        let end = "\
+        content
+        ";
+        assert_eq!(collect(start).1, end);
+        assert_eq!(
+            collect(start).0,
+            Metadata {
+                author: Some("Adam".to_string()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_collect_unsupported_metadata() {
+        let start = "\
+        ---
+        author: \"Adam\"
+        unsupported_field: \"text\"\n\
+        ---
+        followed by more content
+        ";
+        assert_eq!(collect(start).1, start);
+    }
+
+    #[test]
+    fn test_collect_not_metadata() {
+        let start = "\
+        ---
+        This is just standard content that happens to start with a line break
+        and has a second line break in the text.\n\
+        ---
+        followed by more content
+        ";
+        assert_eq!(collect(start).1, start);
+    }
+
+    #[test]
+    fn test_metadata_to_map() {
+        let metadata: Metadata = toml::from_str(
+            "author = \"Adam\"
+        title = \"Blog Post #1\"
+        keywords = [
+            \"Rust\",
+            \"Blog\",
+        ]
+        date = \"2021/02/15\"
+        description = \"My rust blog.\"
+        modified = \"2021/02/16\" ",
+        )
+        .unwrap();
+        let mut map = serde_json::Map::new();
+        map.insert("author".to_string(), json!("Adam"));
+        map.insert("title".to_string(), json!("Blog Post #1"));
+        map.insert("keywords".to_string(), json!(vec!["Rust", "Blog"]));
+        map.insert("date".to_string(), json!("2021/02/15"));
+        map.insert("description".to_string(), json!("My rust blog."));
+        map.insert("modified".to_string(), json!("2021/02/16"));
+        assert_eq!(metadata.to_map(), map)
+    }
+}

--- a/src/preprocess/metadata.rs
+++ b/src/preprocess/metadata.rs
@@ -1,17 +1,17 @@
 use crate::errors::*;
-use regex::{CaptureMatches, Captures, Regex};
+use regex::Regex;
+use std::ops::Range;
 
 use super::{Preprocessor, PreprocessorContext};
 use crate::book::{Book, BookItem};
 
-/// A preprocessor for reading TOML front matter from a markdown file. The supported
-/// fields are:
+/// A preprocessor for reading TOML front matter from a markdown file. Special
+/// fields are included in the `index.hbs` file for handlebars.js templating and
+/// are:
 /// - `author` - For setting the author meta tag.
 /// - `title` - For overwritting the title tag.
 /// - `description` - For setting the description meta tag.
 /// - `keywords` - For setting the keywords meta tag.
-/// - `date` - The date the file was created, creates a handlebar.js vairable {{date}}.
-/// - `modified` - The date the file was modified, creates a handlebar.js vairable {{modified}}.
 #[derive(Default)]
 pub struct MetadataPreprocessor;
 
@@ -32,133 +32,48 @@ impl Preprocessor for MetadataPreprocessor {
     fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {
         book.for_each_mut(|section: &mut BookItem| {
             if let BookItem::Chapter(ref mut ch) = *section {
-                let (metadata, content) = collect(&ch.content);
-                ch.content = content;
-                ch.chapter_config.append(&mut metadata.to_map());
+                if let Some(m) = Match::find_metadata(&ch.content) {
+                    if let Ok(mut meta) = toml::from_str(&ch.content[m.range]) {
+                        ch.chapter_config.append(&mut meta);
+                        ch.content = String::from(&ch.content[m.end..]);
+                    };
+                }
             }
         });
         Ok(book)
     }
 }
 
-fn collect(s: &str) -> (Metadata, String) {
-    let mut end_index = 0;
-    let mut replaced = String::new();
-
-    let metadata: Metadata = if let Some(metadata) = find_metadata(s).next() {
-        match toml::from_str(metadata.text) {
-            Ok(meta) => {
-                end_index += metadata.end_index;
-                meta
-            }
-            _ => Metadata::default(),
-        }
-    } else {
-        Metadata::default()
-    };
-
-    replaced.push_str(&s[end_index..]);
-    (metadata, replaced)
+struct Match {
+    range: Range<usize>,
+    end: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
-struct Metadata {
-    author: Option<String>,
-    title: Option<String>,
-    date: Option<String>,
-    keywords: Option<Vec<String>>,
-    description: Option<String>,
-    modified: Option<String>,
-}
-
-impl Metadata {
-    fn to_map(self) -> serde_json::Map<String, serde_json::Value> {
-        let mut map = serde_json::Map::new();
-        if let Some(author) = self.author {
-            map.insert("author".to_string(), json!(author));
-        }
-        if let Some(title) = self.title {
-            map.insert("title".to_string(), json!(title));
-        }
-        if let Some(date) = self.date {
-            map.insert("date".to_string(), json!(date));
-        }
-        if let Some(keywords) = self.keywords {
-            map.insert("keywords".to_string(), json!(keywords));
-        }
-        if let Some(modified) = self.modified {
-            map.insert("modified".to_string(), json!(modified));
-        }
-        if let Some(description) = self.description {
-            map.insert("description".to_string(), json!(description));
-        }
-        map
-    }
-}
-
-impl Default for Metadata {
-    fn default() -> Metadata {
-        Metadata {
-            author: None,
-            title: None,
-            date: None,
-            keywords: None,
-            modified: None,
-            description: None,
+impl Match {
+    fn find_metadata(contents: &str) -> Option<Match> {
+        // lazily compute following regex
+        // r"\A-{3,}\n(?P<metadata>.*?)^{3,}\n"
+        lazy_static! {
+            static ref RE: Regex = Regex::new(
+                r"(?xms)          # insignificant whitespace mode and multiline
+                \A-{3,}\n         # match a horizontal rule at the start of the content
+                (?P<metadata>.*?) # name the match between horizontal rules metadata
+                ^-{3,}\n          # match a horizontal rule
+                "
+            )
+            .unwrap();
+        };
+        if let Some(mat) = RE.captures(contents) {
+            // safe to unwrap as we know there is a match
+            let metadata = mat.name("metadata").unwrap();
+            Some( Match {
+                range: metadata.start()..metadata.end(),
+                end: mat.get(0).unwrap().end(),
+            })
+        } else {
+            None
         }
     }
-}
-
-#[derive(PartialEq, Debug, Clone)]
-struct MetadataItem<'a> {
-    end_index: usize,
-    text: &'a str,
-}
-
-impl<'a> MetadataItem<'a> {
-    fn from_capture(cap: Captures<'a>) -> Option<MetadataItem<'a>> {
-        if let Some(mat) = cap.name("metadata") {
-            let full_match = cap.get(0).unwrap();
-            if full_match.start() == 0 {
-                return Some(MetadataItem {
-                    end_index: full_match.end(),
-                    text: mat.as_str(),
-                });
-            }
-        }
-        None
-    }
-}
-
-struct MetadataIter<'a>(CaptureMatches<'a, 'a>);
-
-impl<'a> Iterator for MetadataIter<'a> {
-    type Item = MetadataItem<'a>;
-    fn next(&mut self) -> Option<MetadataItem<'a>> {
-        for cap in &mut self.0 {
-            if let Some(inc) = MetadataItem::from_capture(cap) {
-                return Some(inc);
-            }
-        }
-        None
-    }
-}
-
-fn find_metadata(contents: &str) -> MetadataIter<'_> {
-    // lazily compute following regex
-    // r"^-{3,}\n(?P<metadata>.*?)^{3,}\n"
-    lazy_static! {
-        static ref RE: Regex = Regex::new(
-            r"(?xms)          # insignificant whitespace mode and multiline
-            ^-{3,}\n          # match a horizontal rule
-            (?P<metadata>.*?) # name the match between horizontal rules metadata
-            ^-{3,}\n          # match a horizontal rule
-            "
-        )
-        .unwrap();
-    }
-    MetadataIter(RE.captures_iter(contents))
 }
 
 #[cfg(test)]
@@ -166,8 +81,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_collect_not_at_start() {
-        let start = "\
+    fn test_find_metadata_not_at_start() {
+        let s = "\
         content\n\
         ---
         author = \"Adam\"
@@ -181,12 +96,14 @@ mod tests {
         ---
         content
         ";
-        assert_eq!(collect(start).1, start);
+        if let Some(_) = Match::find_metadata(s) {
+            panic!()
+        }
     }
 
     #[test]
-    fn test_collect_at_start() {
-        let start = "\
+    fn test_find_metadata_at_start() {
+        let s = "\
         ---
         author = \"Adam\"
         title = \"Blog Post #1\"
@@ -200,60 +117,43 @@ mod tests {
         ---\n\
         content
         ";
-        let end = "\
-        content
-        ";
-        assert_eq!(collect(start).1, end);
+        if let None = Match::find_metadata(s) {
+            panic!()
+        }
     }
 
     #[test]
-    fn test_collect_partial_metadata() {
-        let start = "\
+    fn test_find_metadata_partial_metadata() {
+        let s = "\
         ---
-        author = \"Adam\"\n\
-        ---\n\
+        author = \"Adam\n\
         content
         ";
-        let end = "\
-        content
-        ";
-        assert_eq!(collect(start).1, end);
-        assert_eq!(
-            collect(start).0,
-            Metadata {
-                author: Some("Adam".to_string()),
-                ..Default::default()
-            }
-        );
+        if let Some(_) = Match::find_metadata(s) {
+            panic!()
+        }
     }
 
     #[test]
-    fn test_collect_unsupported_metadata() {
-        let start = "\
-        ---
-        author: \"Adam\"
-        unsupported_field: \"text\"\n\
-        ---
-        followed by more content
-        ";
-        assert_eq!(collect(start).1, start);
-    }
-
-    #[test]
-    fn test_collect_not_metadata() {
-        let start = "\
+    fn test_find_metadata_not_metadata() {
+        type Map = serde_json::Map<String, serde_json::Value>;
+        let s = "\
         ---
         This is just standard content that happens to start with a line break
         and has a second line break in the text.\n\
         ---
         followed by more content
         ";
-        assert_eq!(collect(start).1, start);
+        if let Some(m) = Match::find_metadata(s) {
+            if let Ok(_) = toml::from_str::<Map>(&s[m.range]) {
+                panic!()
+            }
+        }
     }
 
     #[test]
-    fn test_metadata_to_map() {
-        let metadata: Metadata = toml::from_str(
+    fn test_parse_metadata() {
+        let metadata: serde_json::Map<String, serde_json::Value> = toml::from_str(
             "author = \"Adam\"
         title = \"Blog Post #1\"
         keywords = [
@@ -261,17 +161,12 @@ mod tests {
             \"Blog\",
         ]
         date = \"2021/02/15\"
-        description = \"My rust blog.\"
-        modified = \"2021/02/16\" ",
-        )
-        .unwrap();
-        let mut map = serde_json::Map::new();
+        ").unwrap();
+        let mut map = serde_json::Map::<String, serde_json::Value>::new();
         map.insert("author".to_string(), json!("Adam"));
         map.insert("title".to_string(), json!("Blog Post #1"));
         map.insert("keywords".to_string(), json!(vec!["Rust", "Blog"]));
         map.insert("date".to_string(), json!("2021/02/15"));
-        map.insert("description".to_string(), json!("My rust blog."));
-        map.insert("modified".to_string(), json!("2021/02/16"));
-        assert_eq!(metadata.to_map(), map)
+        assert_eq!(metadata, map)
     }
 }

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -3,10 +3,12 @@
 pub use self::cmd::CmdPreprocessor;
 pub use self::index::IndexPreprocessor;
 pub use self::links::LinkPreprocessor;
+pub use self::metadata::MetadataPreprocessor;
 
 mod cmd;
 mod index;
 mod links;
+mod metadata;
 
 use crate::book::Book;
 use crate::config::Config;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -72,7 +72,9 @@ impl HtmlHandlebars {
         ctx.data.insert("path".to_owned(), json!(path));
         ctx.data.insert("content".to_owned(), json!(content));
         ctx.data.insert("chapter_title".to_owned(), json!(ch.name));
-        ctx.data.insert("title".to_owned(), json!(title));
+        if let Some(title) = ctx.data.insert("title".to_owned(), json!(title)) {
+            ctx.data.insert("title".to_string(), title);
+        }
         ctx.data.insert(
             "path_to_root".to_owned(),
             json!(utils::fs::path_to_root(&path)),
@@ -494,10 +496,19 @@ impl Renderer for HtmlHandlebars {
 
         let mut is_index = true;
         for item in book.iter() {
+            let item_data = if let BookItem::Chapter(ref ch) = item {
+                let mut chapter_data = data.clone();
+                for (key, value) in ch.chapter_config.iter() {
+                    let _ = chapter_data.insert(key.to_string(), json!(value));
+                }
+                chapter_data
+            } else {
+                data.clone()
+            };
             let ctx = RenderItemContext {
                 handlebars: &handlebars,
                 destination: destination.to_path_buf(),
-                data: data.clone(),
+                data: item_data,
                 is_index,
                 html_config: html_config.clone(),
                 edition: ctx.config.rust.edition,

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -16,7 +16,9 @@
         {{> head}}
 
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-        <meta name="description" content="{{ description }}">
+        {{#if description}}<meta name="description" content="{{ description }}">{{/if}}
+        {{#if keywords}}<meta name="keywords" content="{{#each keywords}}{{lookup ../keywords @index}}, {{/each}}">{{/if}}
+        {{#if author}}<meta name="author" content="{{ author }}">{{/if}}
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />
 


### PR DESCRIPTION
I wanted to expose my own properties to the handlebars.js template so added a config field to Chapter that is merged with the book ctx.data when rendered. As a use case I wrote a preprocessor that strips TOML front matter from a markdown file into this config so that meta tags can be populated and things like the date of creation for a file can be tracked. I think this should solve #277 and also achieve the same goal as #1381. I hope you like the idea/implementation and welcome any feedback.