### PR TITLE
Add options to resolve markdown symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "memchr",
  "notify",
  "open",
+ "pathdiff",
  "pretty_assertions",
  "pulldown-cmark",
  "regex",
@@ -896,6 +897,12 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0"
 shlex = "0.1"
 tempfile = "3.0"
 toml = "0.5.1"
+pathdiff = "0.2.0"
 
 # Watch feature
 notify = { version = "4.0", optional = true }

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -217,6 +217,9 @@ The following configuration options are available:
   This string will be written to a file named CNAME in the root of your site, as
   required by GitHub Pages (see [*Managing a custom domain for your GitHub Pages
   site*][custom domain]).
+- **resolve-md-symlink** Resolve the symlink between markdown files. Enable this option
+  may lead to large cost since many syscalls are used. If your markdown source file does
+  not contain symlinks, do not enable this option. This option is disabled by default.
 
 [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
 
@@ -289,6 +292,7 @@ git-repository-icon = "fa-github"
 site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"
+resolve-md-symlink = true
 
 [output.html.print]
 enable = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -533,6 +533,8 @@ pub struct HtmlConfig {
     /// The mapping from old pages to new pages/URLs to use when generating
     /// redirects.
     pub redirect: HashMap<String, String>,
+    /// Resolve symlink between markdown files.
+    pub resolve_md_symlink: bool,
 }
 
 impl Default for HtmlConfig {
@@ -559,6 +561,7 @@ impl Default for HtmlConfig {
             cname: None,
             livereload_url: None,
             redirect: HashMap::new(),
+            resolve_md_symlink: false,
         }
     }
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -520,12 +520,16 @@ impl Renderer for HtmlHandlebars {
                             };
                             let md_location = fs::canonicalize(md_location).ok();
                             let html_path = md_path.with_extension("html");
-                            let html_location = Some(if html_path.is_absolute() {
+                            let html_location = if html_path.is_absolute() {
                                 html_path.clone()
                             } else {
                                 ctx.destination.join(&html_path)
-                            });
-                            md_location.zip(html_location)
+                            };
+                            if let Some(md_location) = md_location {
+                                Some((md_location, html_location))
+                            } else {
+                                None
+                            }
                         }
                         _ => None,
                     })

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -513,11 +513,18 @@ impl Renderer for HtmlHandlebars {
                     .filter_map(|book_item| match book_item {
                         BookItem::Chapter(ch) if !ch.is_draft_chapter() => {
                             let md_path = ch.path.as_ref().unwrap();
-                            let md_location = if md_path.is_absolute() {
+                            let mut md_location = if md_path.is_absolute() {
                                 md_path.clone()
                             } else {
                                 src_dir.join(md_path)
                             };
+                            if md_location.ends_with("index.md") {
+                                if let Some(parent) = md_location.parent() {
+                                    if let Some(readme_path) = utils::find_readme_path(&parent) {
+                                        md_location = readme_path;
+                                    }
+                                }
+                            }
                             let md_location = fs::canonicalize(md_location).ok();
                             let html_path = md_path.with_extension("html");
                             let html_location = if html_path.is_absolute() {


### PR DESCRIPTION
# Background

Since it is recommended that we put all markdown source files in a single directory `src`, problem occurs when I want to make a table of contents in the top-level `README.md` and `src/README.md` at same time.

My `src/` dir contains `README.md`, `a.md`, `b.md`, `SUMMARY.md`, and to avoid duplicating, the `README.md` is soft linked to top-level `README.md`. If I write

```markdown
My table of contents:

- [a](src/a.md)
- [b](src/b.md)
```

then the links in `src/README.md` is invalid; If I write

```markdown
My table of contents:

- [a](./a.md)
- [b](./b.md)
```

then the links in top-level `README.md` is invalid.

I know changing directory layout to be flat can handle this problem, but it is more acceptable if I organize all docs in a single directory. So I can

```shell
ln -s src src/src
```

then use `src/a.md` for markdown links. For top-level `README.md`, it links to real markdown files in `README.md`, and for `src/README.md`, it links to `a.md` in soft-linked `src` dir.

However, mdbook does not support soft-linked markdown files.

# Simplified problem

In `src/`, we have `SUMMARY.md`, `a.md`, `b.md`, `c.md`, where `c.md` is soft linked to `b.md`. In `SUMMARY.md`, we include `a.md` and `b.md`, so the generated html should be `a.html` and `b.html`. In `a.md`, we have a link to `c.md`. But in generated `a.html`, the link breaks.

# Solution

Before rendering files, we calculate a map, whose key is the canonicalized absolute path of markdown file, and value is the absolute path of generated html file.

When adjusting links, we get the path of generated html file of current markdown file, and of the link's target markdown file, from the pre-calculated map. Then we get the diffs of the two absolute path to get a relative path, then use this relative html path to replace the link's target markdown path.

However, this may lead a lot cost when calculating canonicalized absolute path, and the original link-adjust method (simply replace `.md` to `.html`) can work for most situations unless symlinks are involved. So I introduce an option `resolve-md-symlink` in the HTML config, and disable it by default.