### PR TITLE
Upgrade to shlex 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ regex = "1.0.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-shlex = "0.1"
+shlex = "1"
 tempfile = "3.0"
 toml = "0.5.1"
 


### PR DESCRIPTION
This upgrades the [shlex](https://docs.rs/shlex) dependency from version 0.1 to 1. The breaking change in shlex 1 is a fix for [a correctness bug](https://github.com/comex/rust-shlex/issues/6). I haven't looked closely at how shlex is used in mdbook so it should probably be made sure that this doesn't break anything that relied on the incorrect behavior.