### PR TITLE
support google analytics 4 property

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -603,7 +603,13 @@ fn make_data(
 
     // Add google analytics tag
     if let Some(ref ga) = html_config.google_analytics {
-        data.insert("google_analytics".to_owned(), json!(ga));
+        if ga.starts_with("G-") {
+            // google analytics 4
+            data.insert("google_analytics_4".to_owned(), json!(ga));
+        } else {
+            // default to legacy Universal Analytics
+            data.insert("google_analytics".to_owned(), json!(ga));
+        }
     }
 
     if html_config.mathjax_support {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -53,6 +53,17 @@
         <!-- MathJax -->
         <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{/if}}
+
+        {{#if google_analytics_4}}
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{google_analytics_4}}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '{{google_analytics_4}}');
+        </script>
+        {{/if}}
     </head>
     <body>
         <!-- Provide site root to javascript -->


### PR DESCRIPTION
Google analytics 4 tags has `G-` prefix and needs to be installed
differently, see:

https://support.google.com/analytics/answer/10089681?hl=en
https://support.google.com/analytics/answer/9304153?hl=en