### PR TITLE
Support right-to-left languages

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -432,7 +432,7 @@ function playground_text(playground) {
 })();
 
 (function sidebar() {
-    var html = document.querySelector("html");
+    var body = document.querySelector("body");
     var sidebar = document.getElementById("sidebar");
     var sidebarLinks = document.querySelectorAll('#sidebar a');
     var sidebarToggleButton = document.getElementById("sidebar-toggle");
@@ -440,8 +440,8 @@ function playground_text(playground) {
     var firstContact = null;
 
     function showSidebar() {
-        html.classList.remove('sidebar-hidden')
-        html.classList.add('sidebar-visible');
+        body.classList.remove('sidebar-hidden')
+        body.classList.add('sidebar-visible');
         Array.from(sidebarLinks).forEach(function (link) {
             link.setAttribute('tabIndex', 0);
         });
@@ -462,8 +462,8 @@ function playground_text(playground) {
     });
 
     function hideSidebar() {
-        html.classList.remove('sidebar-visible')
-        html.classList.add('sidebar-hidden');
+        body.classList.remove('sidebar-visible')
+        body.classList.add('sidebar-hidden');
         Array.from(sidebarLinks).forEach(function (link) {
             link.setAttribute('tabIndex', -1);
         });
@@ -474,14 +474,14 @@ function playground_text(playground) {
 
     // Toggle sidebar
     sidebarToggleButton.addEventListener('click', function sidebarToggle() {
-        if (html.classList.contains("sidebar-hidden")) {
+        if (body.classList.contains("sidebar-hidden")) {
             var current_width = parseInt(
                 document.documentElement.style.getPropertyValue('--sidebar-width'), 10);
             if (current_width < 150) {
                 document.documentElement.style.setProperty('--sidebar-width', '150px');
             }
             showSidebar();
-        } else if (html.classList.contains("sidebar-visible")) {
+        } else if (body.classList.contains("sidebar-visible")) {
             hideSidebar();
         } else {
             if (getComputedStyle(sidebar)['transform'] === 'none') {
@@ -497,14 +497,14 @@ function playground_text(playground) {
     function initResize(e) {
         window.addEventListener('mousemove', resize, false);
         window.addEventListener('mouseup', stopResize, false);
-        html.classList.add('sidebar-resizing');
+        body.classList.add('sidebar-resizing');
     }
     function resize(e) {
         var pos = (e.clientX - sidebar.offsetLeft);
         if (pos < 20) {
             hideSidebar();
         } else {
-            if (html.classList.contains("sidebar-hidden")) {
+            if (body.classList.contains("sidebar-hidden")) {
                 showSidebar();
             }
             pos = Math.min(pos, window.innerWidth - 100);
@@ -513,7 +513,7 @@ function playground_text(playground) {
     }
     //on mouseup remove windows functions mousemove & mouseup
     function stopResize(e) {
-        html.classList.remove('sidebar-resizing');
+        body.classList.remove('sidebar-resizing');
         window.removeEventListener('mousemove', resize, false);
         window.removeEventListener('mouseup', stopResize, false);
     }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -30,9 +30,9 @@ a > .hljs {
     display: flex;
     flex-wrap: wrap;
     background-color: var(--bg);
-    border-bottom-color: var(--bg);
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
+    border-block-end-color: var(--bg);
+    border-block-end-width: 1px;
+    border-block-end-style: solid;
 }
 #menu-bar.sticky,
 .js #menu-bar-hover-placeholder:hover + #menu-bar,
@@ -49,7 +49,7 @@ a > .hljs {
     height: var(--menu-bar-height);
 }
 #menu-bar.bordered {
-    border-bottom-color: var(--table-border-color);
+    border-block-end-color: var(--table-border-color);
 }
 #menu-bar i, #menu-bar .icon-button {
     position: relative;
@@ -153,7 +153,7 @@ a > .hljs {
 }
 
 .nav-wrapper {
-    margin-top: 50px;
+    margin-block-start: 50px;
     display: none;
 }
 
@@ -167,10 +167,12 @@ a > .hljs {
 }
 
 .previous {
+    /* Only Firefox supports flow-relative values */
     float: left;
 }
 
 .next {
+    /* Only Firefox supports flow-relative values */
     float: right;
     right: var(--page-padding);
 }
@@ -218,7 +220,7 @@ pre > .buttons :hover {
     color: var(--sidebar-active);
 }
 pre > .buttons i {
-    margin-left: 8px;
+    margin-inline-start: 8px;
 }
 pre > .buttons button {
     color: inherit;
@@ -227,7 +229,7 @@ pre > .buttons button {
     cursor: inherit;
 }
 pre > .result {
-    margin-top: 10px;
+    margin-block-start: 10px;
 }
 
 /* Search */
@@ -238,8 +240,14 @@ pre > .result {
 
 mark {
     border-radius: 2px;
-    padding: 0 3px 1px 3px;
-    margin: 0 -3px -1px -3px;
+    padding-block-start: 0;
+    padding-block-end: 1px;
+    padding-inline-start: 3px;
+    padding-inline-end: 3px;
+    margin-block-start: 0;
+    margin-block-end: -1px;
+    margin-inline-start: -3px;
+    margin-inline-end: -3px;
     background-color: var(--search-mark-bg);
     transition: background-color 300ms linear;
     cursor: pointer;
@@ -251,14 +259,17 @@ mark.fade-out {
 }
 
 .searchbar-outer {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     max-width: var(--content-max-width);
 }
 
 #searchbar {
     width: 100%;
-    margin: 5px auto 0px auto;
+    margin-block-start: 5px;
+    margin-block-end: 0;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     padding: 10px 16px;
     transition: box-shadow 300ms ease-in-out;
     border: 1px solid var(--searchbar-border-color);
@@ -274,20 +285,23 @@ mark.fade-out {
 .searchresults-header {
     font-weight: bold;
     font-size: 1em;
-    padding: 18px 0 0 5px;
+    padding-block-start: 18px;
+    padding-block-end: 0;
+    padding-inline-start: 5px;
+    padding-inline-end: 0;
     color: var(--searchresults-header-fg);
 }
 
 .searchresults-outer {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     max-width: var(--content-max-width);
-    border-bottom: 1px dashed var(--searchresults-border-color);
+    border-block-end: 1px dashed var(--searchresults-border-color);
 }
 
 ul#searchresults {
     list-style: none;
-    padding-left: 20px;
+    padding-inline-start: 20px;
 }
 ul#searchresults li {
     margin: 10px 0px;
@@ -300,7 +314,10 @@ ul#searchresults li.focus {
 ul#searchresults span.teaser {
     display: block;
     clear: both;
-    margin: 5px 0 0 20px;
+    margin-block-start: 5px;
+    margin-block-end: 0;
+    margin-inline-start: 20px;
+    margin-inline-end: 0;
     font-size: 0.8em;
 }
 ul#searchresults span.teaser em {
@@ -372,13 +389,13 @@ ul#searchresults span.teaser em {
 @media only screen and (min-width: 620px) {
     .sidebar-visible .page-wrapper {
         transform: none;
-        margin-left: var(--sidebar-width);
+        margin-inline-start: var(--sidebar-width);
     }
 }
 
 .chapter {
     list-style: none outside none;
-    padding-left: 0;
+    padding-inline-start: 0;
     line-height: 2.2em;
 }
 
@@ -408,7 +425,7 @@ ul#searchresults span.teaser em {
 .chapter li > a.toggle {
     cursor: pointer;
     display: block;
-    margin-left: auto;
+    margin-inline-start: auto;
     padding: 0 10px;
     user-select: none;
     opacity: 0.68;
@@ -425,7 +442,7 @@ ul#searchresults span.teaser em {
 
 .chapter li.chapter-item {
     line-height: 1.5em;
-    margin-top: 0.6em;
+    margin-block-start: 0.6em;
 }
 
 .chapter li.expanded > a.toggle div {
@@ -448,7 +465,7 @@ ul#searchresults span.teaser em {
 
 .section {
     list-style: none outside none;
-    padding-left: 20px;
+    padding-inline-start: 20px;
     line-height: 1.9em;
 }
 
@@ -479,7 +496,7 @@ ul#searchresults span.teaser em {
     padding: 2px 10px;
     line-height: 25px;
     white-space: nowrap;
-    text-align: left;
+    text-align: start;
     cursor: pointer;
     color: inherit;
     background: inherit;
@@ -490,6 +507,6 @@ ul#searchresults span.teaser em {
 }
 .theme-popup .theme:hover:first-child,
 .theme-popup .theme:hover:last-child {
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
+    border-start-start-radius: inherit;
+    border-start-end-radius: inherit;
 }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -166,15 +166,19 @@ a > .hljs {
     background-color: var(--sidebar-bg);
 }
 
-.previous {
-    /* Only Firefox supports flow-relative values */
-    float: left;
-}
+/* Only Firefox supports flow-relative values */
+.previous { float: left; }
+[dir=rtl] .previous { float: right; }
 
+/* Only Firefox supports flow-relative values */
 .next {
-    /* Only Firefox supports flow-relative values */
     float: right;
     right: var(--page-padding);
+}
+[dir=rtl] .next {
+    float: left;
+    right: unset;
+    left: var(--page-padding);
 }
 
 @media only screen and (max-width: 1080px) {
@@ -340,6 +344,7 @@ ul#searchresults span.teaser em {
     background-color: var(--sidebar-bg);
     color: var(--sidebar-fg);
 }
+[dir=rtl] .sidebar { left: unset; right: 0; }
 .sidebar-resizing {
     -moz-user-select: none;
     -webkit-user-select: none;
@@ -369,12 +374,16 @@ ul#searchresults span.teaser em {
     top: 0;
     bottom: 0;
 }
+[dir=rtl] .sidebar .sidebar-resize-handle { right:  unset; left: 0; }
 .js .sidebar .sidebar-resize-handle {
     cursor: col-resize;
     width: 5px;
 }
 .sidebar-hidden .sidebar {
     transform: translateX(calc(0px - var(--sidebar-width)));
+}
+[dir=rtl] .sidebar-hidden .sidebar {
+    transform: translateX(var(--sidebar-width));
 }
 .sidebar::-webkit-scrollbar {
     background: var(--sidebar-bg);
@@ -486,6 +495,7 @@ ul#searchresults span.teaser em {
     list-style: none;
     display: none;
 }
+[dir=rtl] .theme-popup { left: unset;  right: 10px; }
 .theme-popup .default {
     color: var(--icons);
 }

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -37,13 +37,13 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
 .hide-boring .boring { display: none; }
 .hidden { display: none !important; }
 
-h2, h3 { margin-top: 2.5em; }
-h4, h5 { margin-top: 2em; }
+h2, h3 { margin-block-start: 2.5em; }
+h4, h5 { margin-block-start: 2em; }
 
 .header + .header h3,
 .header + .header h4,
 .header + .header h5 {
-    margin-top: 1em;
+    margin-block-start: 1em;
 }
 
 h1:target::before,
@@ -54,7 +54,7 @@ h5:target::before,
 h6:target::before {
     display: inline-block;
     content: "»";
-    margin-left: -30px;
+    margin-inline-start: -30px;
     width: 30px;
 }
 
@@ -63,13 +63,14 @@ h6:target::before {
    https://bugs.webkit.org/show_bug.cgi?id=218076
 */
 :target {
+    /* Safari does not support logical properties */
     scroll-margin-top: calc(var(--menu-bar-height) + 0.5em);
 }
 
 .page {
     outline: 0;
     padding: 0 var(--page-padding);
-    margin-top: calc(0px - var(--menu-bar-height)); /* Compensate for the #menu-bar-hover-placeholder */
+    margin-block-start: calc(0px - var(--menu-bar-height)); /* Compensate for the #menu-bar-hover-placeholder */
 }
 .page-wrapper {
     box-sizing: border-box;
@@ -81,11 +82,11 @@ h6:target::before {
 .content {
     overflow-y: auto;
     padding: 0 15px;
-    padding-bottom: 50px;
+    padding-block-end: 50px;
 }
 .content main {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     max-width: var(--content-max-width);
 }
 .content p { line-height: 1.45em; }
@@ -135,14 +136,14 @@ blockquote {
     padding: 0 20px;
     color: var(--fg);
     background-color: var(--quote-bg);
-    border-top: .1em solid var(--quote-border);
-    border-bottom: .1em solid var(--quote-border);
+    border-block-start: .1em solid var(--quote-border);
+    border-block-end: .1em solid var(--quote-border);
 }
 
 
 :not(.footnote-definition) + .footnote-definition,
 .footnote-definition + :not(.footnote-definition) {
-    margin-top: 2em;
+    margin-block-start: 2em;
 }
 .footnote-definition {
     font-size: 0.9em;

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -78,6 +78,9 @@ h6:target::before {
 .js:not(.sidebar-resizing) .page-wrapper {
     transition: margin-left 0.3s ease, transform 0.3s ease; /* Animation: slide away */
 }
+[dir=rtl] .js:not(.sidebar-resizing) .page-wrapper {
+    transition: margin-right 0.3s ease, transform 0.3s ease; /* Animation: slide away */
+}
 
 .content {
     overflow-y: auto;

--- a/src/theme/css/print.css
+++ b/src/theme/css/print.css
@@ -8,7 +8,7 @@
 
 #page-wrapper.page-wrapper {
     transform: none;
-    margin-left: 0px;
+    margin-inline-start: 0px;
     overflow-y: initial;
 }
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="{{ language }}" class="sidebar-visible no-js {{ default_theme }}">
+<html lang="{{ language }}" class="{{ default_theme }}">
     <head>
         <!-- Book generated using mdBook -->
         <meta charset="UTF-8">
@@ -54,7 +54,7 @@
         <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{/if}}
     </head>
-    <body>
+    <body class="sidebar-visible no-js">
         <!-- Provide site root to javascript -->
         <script type="text/javascript">
             var path_to_root = "{{ path_to_root }}";
@@ -83,22 +83,23 @@
             try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
             if (theme === null || theme === undefined) { theme = default_theme; }
             var html = document.querySelector('html');
-            html.classList.remove('no-js')
             html.classList.remove('{{ default_theme }}')
             html.classList.add(theme);
-            html.classList.add('js');
+            var body = document.querySelector('body');
+            body.classList.remove('no-js')
+            body.classList.add('js');
         </script>
 
         <!-- Hide / unhide sidebar before it is displayed -->
         <script type="text/javascript">
-            var html = document.querySelector('html');
+            var body = document.querySelector('body');
             var sidebar = 'hidden';
             if (document.body.clientWidth >= 1080) {
                 try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';
             }
-            html.classList.remove('sidebar-visible');
-            html.classList.add("sidebar-" + sidebar);
+            body.classList.remove('sidebar-visible');
+            body.classList.add("sidebar-" + sidebar);
         </script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">


### PR DESCRIPTION
Use CSS logical properties where feasible and CSS selectors elsewhere to fix behavior of RTL pages.  Moves  `js`/`no-js` and `sidebar-hidden`/`sidebar-visible` classes from the root `html` element to `body` so that selectors function correctly when page direction is flipped.

TODO:

- [ ] Set `dir="rtl"` explicitly?
  - New config? Determine by language?
- [ ] Fix prev/next arrow direction?
  - Will FontAwesome ever support RTL themselves?
- [ ] Fix resizing sidebar

Resolves: #1486