### PR TITLE
Support wasm-pack frontend in mdBook

### DIFF
--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -156,13 +156,13 @@ impl BookBuilder {
 
         let mut highlight_js = File::create(themedir.join("highlight.js"))?;
         highlight_js.write_all(theme::HIGHLIGHT_JS)?;
-        
+
         let mut iframe = File::create(themedir.join("iframe.html"))?;
         iframe.write_all(theme::IFRAME)?;
 
         let mut wasm_entry_js = File::create(themedir.join("wasm-entry.mjs"))?;
         wasm_entry_js.write_all(theme::WASM_ENTRY_MJS)?;
-        
+
         Ok(())
     }
 

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -156,7 +156,13 @@ impl BookBuilder {
 
         let mut highlight_js = File::create(themedir.join("highlight.js"))?;
         highlight_js.write_all(theme::HIGHLIGHT_JS)?;
+        
+        let mut iframe = File::create(themedir.join("iframe.html"))?;
+        iframe.write_all(theme::IFRAME)?;
 
+        let mut wasm_entry_js = File::create(themedir.join("wasm-entry.mjs"))?;
+        wasm_entry_js.write_all(theme::WASM_ENTRY_MJS)?;
+        
         Ok(())
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -197,6 +197,8 @@ impl HtmlHandlebars {
             write_file(destination, "CNAME", format!("{}\n", cname).as_bytes())?;
         }
 
+        write_file(destination, "iframe.html", &theme.iframe_html)?;
+        write_file(destination, "wasm-entry.mjs", &theme.wasm_entry_mjs)?;
         write_file(destination, "book.js", &theme.js)?;
         write_file(destination, "css/general.css", &theme.general_css)?;
         write_file(destination, "css/chrome.css", &theme.chrome_css)?;

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -144,23 +144,20 @@ function playground_text(playground) {
             .then(response => {
                 result_block.innerText = "";
                 var iframe = result_block.appendChild(document.createElement('iframe')),
-                    doc = iframe.contentWindow.document,
-                    options = {
-                        objid: 152,
-                        key: 316541321
-                    },
-                    //src = "host/widget.js",
-                    uri = encodeURIComponent(JSON.stringify(options));
-                doc.someVar = "Hello World!";
-                iframe.id = "iframewidget";
-                iframe.width = result_block.width;
-                iframe.height = result_block.height;
-
-                var html = '<body onload="var d=document;' +
-                    'var script=d.createElement(\'script\');script.type=\'module\';script.src=\'wasm-test.js\';' +
-                    'd.getElementsByTagName(\'head\')[0].appendChild(script);"><div id="button_click"></div></body>';
-                doc.open().write(html);
-                doc.close();
+                    doc = iframe.contentWindow.document;
+                iframe.id = "wasm-rendering";
+                iframe.style.width = "100%";
+                iframe.style.height = "100%";
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', 'iframe.html', true);
+                xhr.onreadystatechange = function () {
+                    if (this.readyState !== 4) return;
+                    if (this.status !== 200) return; // or whatever error handling you want
+                    var html = this.responseText;
+                    doc.open().write(html);
+                    doc.close();
+                };
+                xhr.send();
             })
             .catch(error => result_block.innerText = "Playground Communication: " + error.message);
 

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -172,7 +172,7 @@ function playground_text(playground) {
 
     // Greatly inspired from WebAssemblyStudio
     async function prepareSandbox(params) {
-        var wasmResult = fetch_with_timeout("http://127.0.0.1:9999/wasm-pack", {
+        var wasmResult = fetch_with_timeout("https://playground.titaneric.com/wasm-pack", {
             headers: {
                 'Content-Type': "application/json",
             },

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -32,12 +32,12 @@ function playground_text(playground) {
             method: 'POST',
             mode: 'cors',
         })
-        .then(response => response.json())
-        .then(response => {
-            // get list of crates available in the rust playground
-            let playground_crates = response.crates.map(item => item["id"]);
-            playgrounds.forEach(block => handle_crate_list_update(block, playground_crates));
-        });
+            .then(response => response.json())
+            .then(response => {
+                // get list of crates available in the rust playground
+                let playground_crates = response.crates.map(item => item["id"]);
+                playgrounds.forEach(block => handle_crate_list_update(block, playground_crates));
+            });
     }
 
     function handle_crate_list_update(playground_block, playground_crates) {
@@ -124,17 +124,46 @@ function playground_text(playground) {
 
         result_block.innerText = "Running...";
 
-        fetch_with_timeout("https://play.rust-lang.org/evaluate.json", {
-            headers: {
-                'Content-Type': "application/json",
-            },
-            method: 'POST',
-            mode: 'cors',
-            body: JSON.stringify(params)
+        // fetch_with_timeout("https://play.rust-lang.org/evaluate.json", {
+        //     headers: {
+        //         'Content-Type': "application/json",
+        //     },
+        //     method: 'POST',
+        //     mode: 'cors',
+        //     body: JSON.stringify(params)
+        // })
+        new Promise((resolve, reject) => {
+            setTimeout(() => {
+                resolve("foo");
+            }, 200)
         })
-        .then(response => response.json())
-        .then(response => result_block.innerText = response.result)
-        .catch(error => result_block.innerText = "Playground Communication: " + error.message);
+            // .then(response => response.json())
+            // .then(response => result_block.innerText = response.result)
+            // .then(response => result_block.innerHTML = "<div style=\"height: 300px;background-color: red;\"></div>")
+            // .then(response => result_block.innerHTML = "        <div id=\"button_click\"></div><script type=\"module\" src=\"wasm-test.js\"></script>")
+            .then(response => {
+                result_block.innerText = "";
+                var iframe = result_block.appendChild(document.createElement('iframe')),
+                    doc = iframe.contentWindow.document,
+                    options = {
+                        objid: 152,
+                        key: 316541321
+                    },
+                    //src = "host/widget.js",
+                    uri = encodeURIComponent(JSON.stringify(options));
+                doc.someVar = "Hello World!";
+                iframe.id = "iframewidget";
+                iframe.width = result_block.width;
+                iframe.height = result_block.height;
+
+                var html = '<body onload="var d=document;' +
+                    'var script=d.createElement(\'script\');script.type=\'module\';script.src=\'wasm-test.js\';' +
+                    'd.getElementsByTagName(\'head\')[0].appendChild(script);"><div id="button_click"></div></body>';
+                doc.open().write(html);
+                doc.close();
+            })
+            .catch(error => result_block.innerText = "Playground Communication: " + error.message);
+
     }
 
     // Syntax highlighting Configuration
@@ -146,7 +175,7 @@ function playground_text(playground) {
     let code_nodes = Array
         .from(document.querySelectorAll('code'))
         // Don't highlight `inline code` blocks in headers.
-        .filter(function (node) {return !node.parentElement.classList.contains("header"); });
+        .filter(function (node) { return !node.parentElement.classList.contains("header"); });
 
     if (window.ace) {
         // language-rust class needs to be removed for editable
@@ -363,7 +392,7 @@ function playground_text(playground) {
         set_theme(theme);
     });
 
-    themePopup.addEventListener('focusout', function(e) {
+    themePopup.addEventListener('focusout', function (e) {
         // e.relatedTarget is null in Safari and Firefox on macOS (see workaround below)
         if (!!e.relatedTarget && !themeToggleButton.contains(e.relatedTarget) && !themePopup.contains(e.relatedTarget)) {
             hideThemes();
@@ -371,7 +400,7 @@ function playground_text(playground) {
     });
 
     // Should not be needed, but it works around an issue on macOS & iOS: https://github.com/rust-lang/mdBook/issues/628
-    document.addEventListener('click', function(e) {
+    document.addEventListener('click', function (e) {
         if (themePopup.style.display === 'block' && !themeToggleButton.contains(e.target) && !themePopup.contains(e.target)) {
             hideThemes();
         }
@@ -593,7 +622,7 @@ function playground_text(playground) {
     });
 })();
 
-(function scrollToTop () {
+(function scrollToTop() {
     var menuTitle = document.querySelector('.menu-title');
 
     menuTitle.addEventListener('click', function () {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -181,9 +181,9 @@ function playground_text(playground) {
             body: JSON.stringify(params)
         })
             .then(response => response.json())
-            .then(({ wasm_js, wasm_bg, error }) => {
-                if (error) {
-                    throw new Error(error);
+            .then(({ wasm_js, wasm_bg, success, stderr }) => {
+                if (!success) {
+                    throw new Error(stderr);
                 }
 
                 return {
@@ -238,11 +238,13 @@ function playground_text(playground) {
 
     function createIFrame(src) {
         var iframe = document.createElement('iframe');
+        iframe.scrolling = 'no';
         iframe.style.height = "100%";
         iframe.style.width = "100%";
         iframe.style.padding = 0;
         iframe.style.margin = 0;
         iframe.style.border = 0;
+        iframe.style.overflow = "hidden";
         iframe.src = createObjectURL(src, "text/html");
         return iframe
     }

--- a/src/theme/iframe.html
+++ b/src/theme/iframe.html
@@ -1,18 +1,18 @@
-<!-- Code injected from iframe.html -->
+<!DOCTYPE html>
+<html>
+
 <head>
-    <script>
-        // dynamically create script element and append to head
-        // call wasm-entry to load the built wasm.js
-        function body_onload() {
-            var d = document;
-            var script = d.createElement('script');
-            script.type = 'module';
-            script.src = 'wasm-entry.mjs';
-            d.getElementsByTagName('head')[0].appendChild(script);
+    <meta charset="utf-8">
+    <style>
+        body {
+            background-color: rgb(255, 255, 255);
         }
-    </script>
+    </style>
 </head>
 
-<body onload="body_onload();">
-    <div id="_start"></div>
+<body>
+    <span id="container"></span>
+    <script src="wasm-entry.mjs" type="module"></script>
 </body>
+
+</html>

--- a/src/theme/iframe.html
+++ b/src/theme/iframe.html
@@ -1,0 +1,18 @@
+<!-- Code injected from iframe.html -->
+<head>
+    <script>
+        // dynamically create script element and append to head
+        // call wasm-entry to load the built wasm.js
+        function body_onload() {
+            var d = document;
+            var script = d.createElement('script');
+            script.type = 'module';
+            script.src = 'wasm-entry.mjs';
+            d.getElementsByTagName('head')[0].appendChild(script);
+        }
+    </script>
+</head>
+
+<body onload="body_onload();">
+    <div id="_start"></div>
+</body>

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -13,6 +13,8 @@ use std::path::Path;
 
 use crate::errors::*;
 
+pub static IFRAME: &[u8] = include_bytes!("iframe.html");
+pub static WASM_ENTRY_MJS: &[u8] = include_bytes!("wasm-entry.mjs");
 pub static INDEX: &[u8] = include_bytes!("index.hbs");
 pub static HEAD: &[u8] = include_bytes!("head.hbs");
 pub static REDIRECT: &[u8] = include_bytes!("redirect.hbs");
@@ -62,6 +64,8 @@ pub struct Theme {
     pub ayu_highlight_css: Vec<u8>,
     pub highlight_js: Vec<u8>,
     pub clipboard_js: Vec<u8>,
+    pub iframe_html: Vec<u8>,
+    pub wasm_entry_mjs: Vec<u8>,
 }
 
 impl Theme {
@@ -79,6 +83,8 @@ impl Theme {
         // Check for individual files, if they exist copy them across
         {
             let files = vec![
+                (theme_dir.join("iframe.html"), &mut theme.iframe_html),
+                (theme_dir.join("wasm-entry.mjs"), &mut theme.wasm_entry_mjs),
                 (theme_dir.join("index.hbs"), &mut theme.index),
                 (theme_dir.join("head.hbs"), &mut theme.head),
                 (theme_dir.join("redirect.hbs"), &mut theme.redirect),
@@ -161,6 +167,8 @@ impl Default for Theme {
             ayu_highlight_css: AYU_HIGHLIGHT_CSS.to_owned(),
             highlight_js: HIGHLIGHT_JS.to_owned(),
             clipboard_js: CLIPBOARD_JS.to_owned(),
+            iframe_html: IFRAME.to_owned(),
+            wasm_entry_mjs: WASM_ENTRY_MJS.to_owned(),
         }
     }
 }
@@ -248,6 +256,8 @@ mod tests {
             ayu_highlight_css: Vec::new(),
             highlight_js: Vec::new(),
             clipboard_js: Vec::new(),
+            iframe_html: Vec::new(),
+            wasm_entry_mjs: Vec::new(),
         };
 
         assert_eq!(got, empty);

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -227,6 +227,8 @@ mod tests {
             "highlight.css",
             "ayu-highlight.css",
             "clipboard.min.js",
+            "iframe.html",
+            "wasm-entry.mjs",
         ];
 
         let temp = TempFileBuilder::new().prefix("mdbook-").tempdir().unwrap();

--- a/src/theme/wasm-entry.mjs
+++ b/src/theme/wasm-entry.mjs
@@ -1,0 +1,3 @@
+import init from './wasm.js';
+
+init();

--- a/src/theme/wasm-entry.mjs
+++ b/src/theme/wasm-entry.mjs
@@ -1,3 +1,3 @@
 import init from './wasm.js';
 
-init();
+await init("WASM_URL");

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -123,7 +123,9 @@ fn copy_theme() {
         "favicon.svg",
         "highlight.css",
         "highlight.js",
+        "iframe.html",
         "index.hbs",
+        "wasm-entry.mjs",
     ];
     let theme_dir = temp.path().join("theme");
     let mut actual: Vec<_> = walkdir::WalkDir::new(&theme_dir)


### PR DESCRIPTION
This PR aim to solve #1500.

## Change of code

- Add new `run_wasm_pack_code` function in `theme/book.js` to fetch `wasm-pack` results and rendering them in Iframe
- Support `wasm` className in `theme/book.js` to differentiate the normal Rust and Wasm code
- Add new `theme/iframe.html` and `theme/wasm-entry.mjs` for Iframe
- Move `iframe.html` and `wasm-entry.mjs` to built directory by Rust

## Note

- This implementation is different than integer32llc/rust-playground#707
- It's possible to avoid new `iframe.html` and `wasm-entry.mjs` if we adapt their method, but the real implementation needs to be discussed.

## Demo

https://user-images.githubusercontent.com/12388235/114810242-3b697680-9dde-11eb-85f3-a6e746aaa0c1.mp4

## P.S.

This implementation is more like prototype than production, feel free to point out where I could do better or rewrite suitibly.