### PR TITLE
Feature/suggest an edit link

### DIFF
--- a/guide/book.toml
+++ b/guide/book.toml
@@ -11,7 +11,7 @@ edition = "2018"
 mathjax-support = true
 site-url = "/mdBook/"
 git-repository-url = "https://github.com/rust-lang/mdBook/tree/master/guide"
-git-repository-edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
+edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
 
 [output.html.playground]
 editable = true

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -11,6 +11,7 @@ edition = "2018"
 mathjax-support = true
 site-url = "/mdBook/"
 git-repository-url = "https://github.com/rust-lang/mdBook/tree/master/guide"
+git-repository-edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
 
 [output.html.playground]
 editable = true

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -295,6 +295,7 @@ additional-js = ["custom.js"]
 no-section-label = false
 git-repository-url = "https://github.com/rust-lang/mdBook"
 git-repository-icon = "fa-github"
+git-repository-edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
 site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -201,12 +201,15 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-- **git-repository-edit-baseurl:** The base url for suggesting an edit
-  to individual pages/chapters of the book. If **git-repository-url** is defined,
-  defaults to **git-repository-url**/blob/master which works for e.g. GitHub.
-  The page source path is appended to this url, e.g. `/src/SUMMARY.md`. So when
-  this or **git-repository-url** is configured an icon link will be output in
-  the menu bar of the book.
+- **git-repository-edit-url-template:** Git repository file edit url
+  template, when provided shows an "Suggest an edit" button for
+  directly jumping to editing the currently viewed page in the git
+  repository. For e.g. GitHub projects set this to
+  `https://github.com/<owner>/<repo>/edit/master/{path}` or for
+  Bitbucket projects set it to
+  `https://bitbucket.org/<owner>/<repo>/src/master/{path}?mode=edit`
+  where {path} will be replaced with the full path of the file in the
+  repository.
 - **redirect:** A subtable used for generating redirects when a page is moved.
   The table contains key-value pairs where the key is where the redirect file
   needs to be created, as an absolute path from the build directory, (e.g.

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -201,6 +201,12 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
+- **git-repository-edit-baseurl:** The base url for suggesting an edit
+  to individual pages/chapters of the book. If **git-repository-url** is defined,
+  defaults to **git-repository-url**/blob/master which works for e.g. GitHub.
+  The page source path is appended to this url, e.g. `/src/SUMMARY.md`. So when
+  this or **git-repository-url** is configured an icon link will be output in
+  the menu bar of the book.
 - **redirect:** A subtable used for generating redirects when a page is moved.
   The table contains key-value pairs where the key is where the redirect file
   needs to be created, as an absolute path from the build directory, (e.g.

--- a/guide/src/format/config.md
+++ b/guide/src/format/config.md
@@ -201,10 +201,9 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
-- **git-repository-edit-url-template:** Git repository file edit url
-  template, when provided shows an "Suggest an edit" button for
-  directly jumping to editing the currently viewed page in the git
-  repository. For e.g. GitHub projects set this to
+- **edit-url-template:** Edit url template, when provided shows a
+  "Suggest an edit" button for directly jumping to editing the currently
+  viewed page. For e.g. GitHub projects set this to
   `https://github.com/<owner>/<repo>/edit/master/{path}` or for
   Bitbucket projects set it to
   `https://bitbucket.org/<owner>/<repo>/src/master/{path}?mode=edit`
@@ -295,7 +294,7 @@ additional-js = ["custom.js"]
 no-section-label = false
 git-repository-url = "https://github.com/rust-lang/mdBook"
 git-repository-icon = "fa-github"
-git-repository-edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
+edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
 site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -160,6 +160,8 @@ pub struct Chapter {
     pub sub_items: Vec<BookItem>,
     /// The chapter's location, relative to the `SUMMARY.md` file.
     pub path: Option<PathBuf>,
+    /// The chapter's source file, relative to the `SUMMARY.md` file.
+    pub source_path: Option<PathBuf>,
     /// An ordered list of the names of each chapter above this one in the hierarchy.
     pub parent_names: Vec<String>,
 }
@@ -169,13 +171,15 @@ impl Chapter {
     pub fn new<P: Into<PathBuf>>(
         name: &str,
         content: String,
-        path: P,
+        p: P,
         parent_names: Vec<String>,
     ) -> Chapter {
+        let path: PathBuf = p.into();
         Chapter {
             name: name.to_string(),
             content,
-            path: Some(path.into()),
+            path: Some(path.clone()),
+            source_path: Some(path),
             parent_names,
             ..Default::default()
         }
@@ -188,6 +192,7 @@ impl Chapter {
             name: name.to_string(),
             content: String::new(),
             path: None,
+            source_path: None,
             parent_names,
             ..Default::default()
         }
@@ -438,6 +443,7 @@ And here is some \
             content: String::from("Hello World!"),
             number: Some(SectionNumber(vec![1, 2])),
             path: Some(PathBuf::from("second.md")),
+            source_path: Some(PathBuf::from("second.md")),
             parent_names: vec![String::from("Chapter 1")],
             sub_items: Vec::new(),
         };
@@ -446,6 +452,7 @@ And here is some \
             content: String::from(DUMMY_SRC),
             number: None,
             path: Some(PathBuf::from("chapter_1.md")),
+            source_path: Some(PathBuf::from("chapter_1.md")),
             parent_names: Vec::new(),
             sub_items: vec![
                 BookItem::Chapter(nested.clone()),
@@ -470,6 +477,7 @@ And here is some \
                 name: String::from("Chapter 1"),
                 content: String::from(DUMMY_SRC),
                 path: Some(PathBuf::from("chapter_1.md")),
+                source_path: Some(PathBuf::from("chapter_1.md")),
                 ..Default::default()
             })],
             ..Default::default()
@@ -510,6 +518,7 @@ And here is some \
                     content: String::from(DUMMY_SRC),
                     number: None,
                     path: Some(PathBuf::from("Chapter_1/index.md")),
+                    source_path: Some(PathBuf::from("Chapter_1/index.md")),
                     parent_names: Vec::new(),
                     sub_items: vec![
                         BookItem::Chapter(Chapter::new(
@@ -562,6 +571,7 @@ And here is some \
                     content: String::from(DUMMY_SRC),
                     number: None,
                     path: Some(PathBuf::from("Chapter_1/index.md")),
+                    source_path: Some(PathBuf::from("Chapter_1/index.md")),
                     parent_names: Vec::new(),
                     sub_items: vec![
                         BookItem::Chapter(Chapter::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -522,11 +522,10 @@ pub struct HtmlConfig {
     ///
     /// [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
     pub cname: Option<String>,
-    /// Git repository file edit url template, when set shows an
-    /// "Suggest an edit" button for directly jumping to editing the
-    /// currently viewed page in the git repository. Contains {path}
-    /// that is replaced with chapter source file path
-    pub git_repository_edit_url_template: Option<String>,
+    /// Edit url template, when set shows a "Suggest an edit" button for
+    /// directly jumping to editing the currently viewed page.
+    /// Contains {path} that is replaced with chapter source file path
+    pub edit_url_template: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where
@@ -559,7 +558,7 @@ impl Default for HtmlConfig {
             search: None,
             git_repository_url: None,
             git_repository_icon: None,
-            git_repository_edit_url_template: None,
+            edit_url_template: None,
             input_404: None,
             site_url: None,
             cname: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -522,6 +522,11 @@ pub struct HtmlConfig {
     ///
     /// [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
     pub cname: Option<String>,
+    /// Git repository file edit baseurl, below which e.g. src/SUMMARY.md can
+    /// be viewed/edited
+    /// Defaults to git_repository_url + `/blob/master` if `None` and
+    /// git_repository_url is not `None` - works for e.g. GitHub master branch
+    pub git_repository_edit_baseurl: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where

--- a/src/config.rs
+++ b/src/config.rs
@@ -522,11 +522,11 @@ pub struct HtmlConfig {
     ///
     /// [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
     pub cname: Option<String>,
-    /// Git repository file edit baseurl, below which e.g. src/SUMMARY.md can
-    /// be viewed/edited
-    /// Defaults to git_repository_url + `/blob/master` if `None` and
-    /// git_repository_url is not `None` - works for e.g. GitHub master branch
-    pub git_repository_edit_baseurl: Option<String>,
+    /// Git repository file edit url template, when set shows an
+    /// "Suggest an edit" button for directly jumping to editing the
+    /// currently viewed page in the git repository. Contains {path}
+    /// that is replaced with chapter source file path
+    pub git_repository_edit_url_template: Option<String>,
     /// This is used as a bit of a workaround for the `mdbook serve` command.
     /// Basically, because you set the websocket port from the command line, the
     /// `mdbook serve` command needs a way to let the HTML renderer know where

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,6 +559,7 @@ impl Default for HtmlConfig {
             search: None,
             git_repository_url: None,
             git_repository_icon: None,
+            git_repository_edit_url_template: None,
             input_404: None,
             site_url: None,
             cname: None,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -685,10 +685,16 @@ fn make_data(
             Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
             None => &default_edit_baseurl,
         };
-        data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+        data.insert(
+            "git_repository_edit_baseurl".to_owned(),
+            json!(git_repository_edit_baseurl),
+        );
     } else {
         if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
-            data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+            data.insert(
+                "git_repository_edit_baseurl".to_owned(),
+                json!(git_repository_edit_baseurl),
+            );
         }
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -680,10 +680,10 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
-        let defaultEditBaseUrl = git_repository_url.to_owned() + "/blob/master";
+        let default_edit_baseurl = git_repository_url.to_owned() + "/blob/master";
         let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
             Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
-            None => &defaultEditBaseUrl,
+            None => &default_edit_baseurl,
         };
         data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
     } else {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -40,7 +40,12 @@ impl HtmlHandlebars {
         if let Some(ref git_repository_edit_url_template) =
             ctx.html_config.git_repository_edit_url_template
         {
-            let full_path = "src/".to_owned() + path.to_str().unwrap();
+            let full_path = "src/".to_owned()
+                + ch.source_path
+                    .clone()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
             let edit_url = git_repository_edit_url_template.replace("{path}", &full_path);
             ctx.data
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -680,6 +680,16 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
+        let defaultEditBaseUrl = git_repository_url.to_owned() + "/blob/master";
+        let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
+            Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
+            None => &defaultEditBaseUrl,
+        };
+        data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+    } else {
+        if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
+            data.insert("git_repository_edit_baseurl".to_owned(), json!(git_repository_edit_baseurl));
+        }
     }
 
     let git_repository_icon = match html_config.git_repository_icon {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -37,16 +37,14 @@ impl HtmlHandlebars {
             _ => return Ok(()),
         };
 
-        if let Some(ref git_repository_edit_url_template) =
-            ctx.html_config.git_repository_edit_url_template
-        {
+        if let Some(ref edit_url_template) = ctx.html_config.edit_url_template {
             let full_path = "src/".to_owned()
                 + ch.source_path
                     .clone()
                     .unwrap_or_default()
                     .to_str()
                     .unwrap_or_default();
-            let edit_url = git_repository_edit_url_template.replace("{path}", &full_path);
+            let edit_url = edit_url_template.replace("{path}", &full_path);
             ctx.data
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));
         }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -37,6 +37,15 @@ impl HtmlHandlebars {
             _ => return Ok(()),
         };
 
+        if let Some(ref git_repository_edit_url_template) =
+            ctx.html_config.git_repository_edit_url_template
+        {
+            let full_path = "src/".to_owned() + path.to_str().unwrap();
+            let edit_url = git_repository_edit_url_template.replace("{path}", &full_path);
+            ctx.data
+                .insert("git_repository_edit_url".to_owned(), json!(edit_url));
+        }
+
         let content = ch.content.clone();
         let content = utils::render_markdown(&content, ctx.html_config.curly_quotes);
 
@@ -680,22 +689,6 @@ fn make_data(
 
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
-        let default_edit_baseurl = git_repository_url.to_owned() + "/blob/master";
-        let git_repository_edit_baseurl = match html_config.git_repository_edit_baseurl {
-            Some(ref git_repository_edit_baseurl) => git_repository_edit_baseurl,
-            None => &default_edit_baseurl,
-        };
-        data.insert(
-            "git_repository_edit_baseurl".to_owned(),
-            json!(git_repository_edit_baseurl),
-        );
-    } else {
-        if let Some(ref git_repository_edit_baseurl) = html_config.git_repository_edit_baseurl {
-            data.insert(
-                "git_repository_edit_baseurl".to_owned(),
-                json!(git_repository_edit_baseurl),
-            );
-        }
     }
 
     let git_repository_icon = match html_config.git_repository_icon {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -148,6 +148,12 @@
                             <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                         </a>
                         {{/if}}
+                        {{#if git_repository_edit_baseurl}}
+                        <a href="{{git_repository_edit_baseurl}}/src/{{path}}" title="Suggest an edit" aria-label="Suggest an edit">
+                            <i id="git-edit-button" class="fa fa-edit"></i>
+                        </a>
+                        {{/if}}
+
                     </div>
                 </div>
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -148,8 +148,8 @@
                             <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                         </a>
                         {{/if}}
-                        {{#if git_repository_edit_baseurl}}
-                        <a href="{{git_repository_edit_baseurl}}/src/{{path}}" title="Suggest an edit" aria-label="Suggest an edit">
+                        {{#if git_repository_edit_url}}
+                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
                         {{/if}}


### PR DESCRIPTION
This PR is based on https://github.com/rust-lang/mdBook/pull/1148 and supersedes it.

Compared to the originating PR, this one rebases the code against the current `master` branch and, most important of all, fixes the broken links reported by the early testers of this feature. I'm referring to the broken links to pages that were named `README.md`.

I've successfully tested this feature against a complex mdbook hosted on GitHub, Bitbucket and Gitea