### PR TITLE
Add MDBook::load_with_config_file

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -47,7 +47,7 @@ pub struct MDBook {
 }
 
 impl MDBook {
-  /// Load a book from its root directory on disk. If a `book.toml` file is present in the
+    /// Load a book from its root directory on disk. If a `book.toml` file is present in the
     /// root directory, the configuration is loaded from that. Otherwise, the
     /// default `Config` is used.
     ///

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -30,6 +30,8 @@ use crate::utils;
 
 use crate::config::{Config, RustEdition};
 
+const DEFAULT_CONFIG_FILE_NAME: &str = "book.toml";
+
 /// The object used to manage and build a book.
 pub struct MDBook {
     /// The book's root directory.
@@ -45,10 +47,38 @@ pub struct MDBook {
 }
 
 impl MDBook {
-    /// Load a book from its root directory on disk.
+  /// Load a book from its root directory on disk. If a `book.toml` file is present in the
+    /// root directory, the configuration is loaded from that. Otherwise, the
+    /// default `Config` is used.
+    ///
+    /// ```no_run
+    /// # use mdbook::MDBook;
+    /// let root_dir = "/path/to/book/root";
+    ///
+    /// let mut md = MDBook::load(root_dir)
+    ///   .expect("Unable to load the book");
+    /// ```
     pub fn load<P: Into<PathBuf>>(book_root: P) -> Result<MDBook> {
+        MDBook::load_book(book_root, None)
+    }
+
+    /// Load a book from its root directory on disk, specifying a configuration file explicitly. If
+    /// the supplied configuration file is not found, an error is returned.
+    ///
+    /// ```no_run
+    /// # use mdbook::MDBook;
+    /// let root_dir = "/path/to/book/root";
+    /// let alternate_config_file = "/path/to/alternate-config.toml";
+    ///
+    /// let mut md = MDBook::load_with_config_file(root_dir, alternate_config_file)
+    ///   .expect("Unable to load the book");
+    /// ```
+    pub fn load_with_config_file<P: Into<PathBuf>>(book_root: P, config_file: P) -> Result<MDBook> {
+        MDBook::load_book(book_root, Some(config_file))
+    }
+
+    fn load_book<P: Into<PathBuf>>(book_root: P, config_file: Option<P>) -> Result<MDBook> {
         let book_root = book_root.into();
-        let config_location = book_root.join("book.toml");
 
         // the book.json file is no longer used, so we should emit a warning to
         // let people know to migrate to book.toml
@@ -60,11 +90,28 @@ impl MDBook {
             warn!("\thttps://rust-lang.github.io/mdBook/format/config.html");
         }
 
-        let mut config = if config_location.exists() {
-            debug!("Loading config from {}", config_location.display());
-            Config::from_disk(&config_location)?
-        } else {
-            Config::default()
+        let mut config = match config_file {
+            // the config file was explicitly supplied. if it doesn't exist, bail with an error
+            Some(config_file) => {
+                let config_file = config_file.into();
+                if config_file.exists() {
+                    debug!("Loading config from {}", config_file.display());
+                    Config::from_disk(&config_file)?
+                } else {
+                    bail!("Configuration file {} not found", config_file.display());
+                }
+            }
+            // no config file was supplied, look for a book.toml, or fall back to the default
+            _ => {
+                let config_file = book_root.join(DEFAULT_CONFIG_FILE_NAME);
+                if config_file.exists() {
+                    debug!("Loading config from {}", DEFAULT_CONFIG_FILE_NAME);
+                    Config::from_disk(&config_file)?
+                } else {
+                    debug!("Loading config from Config::default()");
+                    Config::default()
+                }
+            }
         };
 
         config.update_from_env();

--- a/tests/load.rs
+++ b/tests/load.rs
@@ -1,0 +1,176 @@
+mod dummy_book;
+
+use crate::dummy_book::{assert_contains_strings, DummyBook};
+use mdbook::book::parse_summary;
+use mdbook::book::{Summary, SummaryItem};
+use mdbook::config::Config;
+use mdbook::utils::fs::write_file;
+use mdbook::MDBook;
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+
+#[test]
+fn load_with_default_config() {
+    let temp = DummyBook::new().build().unwrap();
+    assert!(!temp.path().join("book.toml").exists());
+
+    let md = MDBook::load(temp.path()).unwrap();
+
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book</title>"#]);
+}
+
+#[test]
+fn load_with_book_toml_implicit() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let book_toml = r#"
+[book]
+title = "implicit"
+    "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    assert!(temp.path().join("book.toml").exists());
+
+    let md = MDBook::load(temp.path()).unwrap();
+
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book - implicit</title>"#]);
+}
+
+#[test]
+fn load_with_book_toml_explicit() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let book_toml = r#"
+[book]
+title = "explicit"
+    "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    assert!(temp.path().join("book.toml").exists());
+
+    let md = MDBook::load_with_config_file(temp.path(), &temp.path().join("book.toml")).unwrap();
+
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book - explicit</title>"#]);
+}
+
+#[test]
+fn load_with_alternate_toml() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let alternate_toml = r#"
+[book]
+title = "alternate"
+    "#;
+
+    write_file(&temp.path(), "not-book.toml", alternate_toml.as_bytes()).unwrap();
+
+    assert!(!temp.path().join("book.toml").exists());
+    assert!(temp.path().join("not-book.toml").exists());
+
+    let md =
+        MDBook::load_with_config_file(temp.path(), &temp.path().join("not-book.toml")).unwrap();
+
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(
+        index_html,
+        &vec![r#"<title>Dummy Book - alternate</title>"#],
+    );
+}
+
+#[test]
+fn load_with_alternate_toml_with_book_toml_present() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let book_toml = r#"
+[book]
+title = "book"
+    "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    let alternate_toml = r#"
+[book]
+title = "not book"
+    "#;
+
+    write_file(&temp.path(), "not-book.toml", alternate_toml.as_bytes()).unwrap();
+
+    assert!(temp.path().join("book.toml").exists());
+    assert!(temp.path().join("not-book.toml").exists());
+
+    let md =
+        MDBook::load_with_config_file(temp.path(), &temp.path().join("not-book.toml")).unwrap();
+
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book - not book</title>"#]);
+}
+
+#[test]
+fn load_with_config_default() {
+    let temp = DummyBook::new().build().unwrap();
+    let cfg = Config::default();
+
+    let md = MDBook::load_with_config(temp.path(), cfg).unwrap();
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book</title>"#]);
+}
+
+#[test]
+fn load_with_config_from_disk() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let book_toml = r#"
+[book]
+title = "book"
+    "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    let cfg = Config::from_disk(&temp.path().join("book.toml")).unwrap();
+
+    let md = MDBook::load_with_config(temp.path(), cfg).unwrap();
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book - book</title>"#]);
+}
+
+#[test]
+fn load_with_config_and_summary() {
+    let temp = DummyBook::new().build().unwrap();
+
+    let cfg = Config::default();
+    let summary = fs::read_to_string(temp.path().join("src").join("SUMMARY.md")).unwrap();
+    let summary = parse_summary(&summary).unwrap();
+
+    let md = MDBook::load_with_config_and_summary(temp.path(), cfg, summary).unwrap();
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(index_html, &vec![r#"<title>Dummy Book</title>"#]);
+}
+
+#[test]
+#[should_panic]
+fn try_load_with_missing_file() {
+    let temp = DummyBook::new().build().unwrap();
+    MDBook::load_with_config_file(temp.path(), &temp.path().join("not-there.toml")).unwrap();
+}

--- a/tests/load.rs
+++ b/tests/load.rs
@@ -2,13 +2,10 @@ mod dummy_book;
 
 use crate::dummy_book::{assert_contains_strings, DummyBook};
 use mdbook::book::parse_summary;
-use mdbook::book::{Summary, SummaryItem};
 use mdbook::config::Config;
 use mdbook::utils::fs::write_file;
 use mdbook::MDBook;
 use std::fs;
-use std::fs::File;
-use std::io::Read;
 
 #[test]
 fn load_with_default_config() {


### PR DESCRIPTION
Adds `MDBook::load_with_config_file` to load a book from its root and explicitly specify a configuration file to use. This is already possible with multiple steps; this just wraps up the work of loading the `Config` first and then loading the book with `MDBook::load_with_config`. A subsequent PR will add the ability to optionally specify a configuration explicitly on the command line using `mdbook`.

Also adds a dedicated test namespace for explicitly testing the various methods of loading a book and configuration.