### PR TITLE
Update serve documentation in the guide

### DIFF
--- a/guide/src/cli/serve.md
+++ b/guide/src/cli/serve.md
@@ -51,5 +51,5 @@ contain file patterns described in the [gitignore
 documentation](https://git-scm.com/docs/gitignore). This can be useful for
 ignoring temporary files created by some editors.
 
-_Note: Only `.gitignore` from book root directory is used. Global
-`$HOME/.gitignore` or `.gitignore` files in parent directories are not used._
+***Note:*** *Only the `.gitignore` from the book root directory is used. Global
+`$HOME/.gitignore` or `.gitignore` files in parent directories are not used.*

--- a/guide/src/cli/serve.md
+++ b/guide/src/cli/serve.md
@@ -1,7 +1,13 @@
 # The serve command
 
-The serve command is used to preview a book by serving it over HTTP at
-`localhost:3000` by default. Additionally it watches the book's directory for
+The serve command is used to preview a book by serving it via HTTP at
+`localhost:3000` by default: 
+
+```bash
+mdbook serve
+```
+
+The `serve` command  watches the book's `src` directory for
 changes, rebuilding the book and refreshing clients for each change. A websocket
 connection is used to trigger the client-side refresh.
 
@@ -19,21 +25,11 @@ mdbook serve path/to/book
 
 #### Server options
 
-`serve` has four options: the HTTP port, the WebSocket port, the HTTP hostname
-to listen on, and the hostname for the browser to connect to for WebSockets.
-
-For example: suppose you have an nginx server for SSL termination which has a
-public address of 192.168.1.100 on port 80 and proxied that to 127.0.0.1 on port
-8000\. To run use the nginx proxy do:
+The `serve` hostname defaults to `localhost`, and the port defaults to 3000. Either option can be specified on the command line:
 
 ```bash
-mdbook serve path/to/book -p 8000 -n 127.0.0.1 --websocket-hostname 192.168.1.100
+mdbook serve path/to/book -p 8000 -n 127.0.0.1 
 ```
-
-If you were to want live reloading for this you would need to proxy the
-websocket calls through nginx as well from `192.168.1.100:<WS_PORT>` to
-`127.0.0.1:<WS_PORT>`. The `-w` flag allows for the websocket port to be
-configured.
 
 #### --open
 

--- a/guide/src/cli/serve.md
+++ b/guide/src/cli/serve.md
@@ -23,9 +23,9 @@ root instead of the current working directory.
 mdbook serve path/to/book
 ```
 
-#### Server options
+### Server options
 
-The `serve` hostname defaults to `localhost`, and the port defaults to 3000. Either option can be specified on the command line:
+The `serve` hostname defaults to `localhost`, and the port defaults to `3000`. Either option can be specified on the command line:
 
 ```bash
 mdbook serve path/to/book -p 8000 -n 127.0.0.1 


### PR DESCRIPTION
The guide's `serve.md` contains out of date command line option docs. This PR brings it inline with the current state of the command.

Fixes #1524.