### PR TITLE
Add useful messages when command line preprocessor fails

### DIFF
--- a/src/preprocess/cmd.rs
+++ b/src/preprocess/cmd.rs
@@ -109,18 +109,28 @@ impl Preprocessor for CmdPreprocessor {
 
         self.write_input_to_child(&mut child, &book, ctx);
 
-        let output = child
-            .wait_with_output()
-            .with_context(|| "Error waiting for the preprocessor to complete")?;
+        let output = child.wait_with_output().with_context(|| {
+            format!(
+                "Error waiting for the \"{}\" preprocessor to complete",
+                self.name
+            )
+        })?;
 
         trace!("{} exited with output: {:?}", self.cmd, output);
         ensure!(
             output.status.success(),
-            "The preprocessor exited unsuccessfully"
+            format!(
+                "The \"{}\" preprocessor exited unsuccessfully with {} status",
+                self.name, output.status
+            )
         );
 
-        serde_json::from_slice(&output.stdout)
-            .with_context(|| "Unable to parse the preprocessed book")
+        serde_json::from_slice(&output.stdout).with_context(|| {
+            format!(
+                "Unable to parse the preprocessed book from \"{}\" processor",
+                self.name
+            )
+        })
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {


### PR DESCRIPTION
Error messages before and after the changes

# Before
2021-05-05 18:48:39 [INFO] (mdbook::book): Book building has started
thread 'main' panicked at 'nn', src/main.rs:53:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-05-05 18:48:39 [ERROR] (mdbook::utils): Error: The preprocessor exited unsuccessfully

2021-05-05 18:50:53 [INFO] (mdbook::book): Book building has started
2021-05-05 18:50:53 [ERROR] (mdbook::utils): Error: Unable to parse the preprocessed book
2021-05-05 18:50:53 [ERROR] (mdbook::utils):    Caused By: expected value at line 1 column 1

# After 

2021-05-08 12:44:54 [INFO] (mdbook::book): Book building has started
thread 'main' panicked at 'ddd', src/main.rs:50:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-05-08 12:44:54 [ERROR] (mdbook::utils): Error: The "cat" preprocessor exited unsuccessfully with exit code: 101 status


2021-05-05 18:53:36 [INFO] (mdbook::book): Book building has started
2021-05-05 18:53:36 [ERROR] (mdbook::utils): Error: Unable to parse the preprocessed book from "cat" processor
2021-05-05 18:53:36 [ERROR] (mdbook::utils):    Caused By: expected value at line 1 column 1
