### PR TITLE
Apply max width to video as well as images

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -92,7 +92,7 @@ h6:target::before {
 .content ul { line-height: 1.45em; }
 .content a { text-decoration: none; }
 .content a:hover { text-decoration: underline; }
-.content img { max-width: 100%; }
+.content img, .content video { max-width: 100%; }
 .content .header:link,
 .content .header:visited {
     color: var(--fg);


### PR DESCRIPTION
Since videos are essentially animated images, this same max width makes sense for both.