### PR TITLE
Allow serving any renderer's output

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -43,6 +43,15 @@ pub fn make_subcommand() -> Command {
                 .value_parser(NonEmptyStringValueParser::new())
                 .help("Port to use for HTTP connections"),
         )
+        .arg(
+            Arg::new("renderer")
+                .short('r')
+                .long("renderer")
+                .num_args(1)
+                .default_value("html")
+                .value_parser(NonEmptyStringValueParser::new())
+                .help("Renderer to serve the output of"),
+        )
         .arg_open()
         .arg_watcher()
 }
@@ -54,6 +63,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     let port = args.get_one::<String>("port").unwrap();
     let hostname = args.get_one::<String>("hostname").unwrap();
+    let renderer = args.get_one::<String>("renderer").unwrap();
     let open_browser = args.get_flag("open");
 
     let address = format!("{hostname}:{port}");
@@ -73,7 +83,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         .to_socket_addrs()?
         .next()
         .ok_or_else(|| anyhow::anyhow!("no address found for {}", address))?;
-    let build_dir = book.build_dir_for("html");
+    let build_dir = book.build_dir_for(renderer);
     let html_config = book.config.html_config().unwrap_or_default();
     let file_404 = html_config.get_404_output_file();
 


### PR DESCRIPTION
I use [custom](https://github.com/gbdev/pandocs/tree/master/renderer) [renderers](https://github.com/ISSOtm/gb-asm-tutorial-v2/tree/master/renderer), which serve to post-process the HTML renderer's output (this is arguably fragile, relying on implementation details of that renderer, but it seems to be the least bad solution) and some other files (such as stripping some "utility" comments from a file, in the latter's case).

One downside is not being able to use `serve`'s auto-reload feature, which this adds support for.