### PR TITLE
Use the configured book src directory for the edit url template path

### DIFF
--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -541,6 +541,57 @@ fn redirects_are_emitted_correctly() {
     }
 }
 
+#[test]
+fn edit_url_has_default_src_dir_edit_url() {
+    let temp = DummyBook::new().build().unwrap();
+    let book_toml = r#"
+        [book]
+        title = "implicit"
+
+        [output.html]
+        edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"    
+        "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    let md = MDBook::load(temp.path()).unwrap();
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(
+        index_html,
+        &vec![
+            r#"href="https://github.com/rust-lang/mdBook/edit/master/guide/src/README.md" title="Suggest an edit""#,
+        ],
+    );
+}
+
+#[test]
+fn edit_url_has_configured_src_dir_edit_url() {
+    let temp = DummyBook::new().build().unwrap();
+    let book_toml = r#"
+        [book]
+        title = "implicit"
+        src = "src2"
+
+        [output.html]
+        edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"    
+        "#;
+
+    write_file(&temp.path(), "book.toml", book_toml.as_bytes()).unwrap();
+
+    let md = MDBook::load(temp.path()).unwrap();
+    md.build().unwrap();
+
+    let index_html = temp.path().join("book").join("index.html");
+    assert_contains_strings(
+        index_html,
+        &vec![
+            r#"href="https://github.com/rust-lang/mdBook/edit/master/guide/src2/README.md" title="Suggest an edit""#,
+        ],
+    );
+}
+
 fn remove_absolute_components(path: &Path) -> impl Iterator<Item = Component> + '_ {
     path.components().skip_while(|c| match c {
         Component::Prefix(_) | Component::RootDir => true,


### PR DESCRIPTION
The "Suggest an edit" URL used `src` as the top level path to the file to edit regardless of whether the book.toml `src` config was set resulting in an incorrect link to the file. This change uses the actual configured `src` to build the path instead.

Fixes #1543.