### PR TITLE
Use std::panic::set_hook to exit serve thread if serving fails

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -161,5 +161,12 @@ async fn serve(
     let fallback_route = warp::fs::file(build_dir.join(file_404))
         .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::NOT_FOUND));
     let routes = livereload.or(book_route).or(fallback_route);
+
+    std::panic::set_hook(Box::new(move |panic_info| {
+        // exit if serve panics
+        error!("Unable to serve: {}", panic_info);
+        std::process::exit(1);
+    }));
+
     warp::serve(routes).run(address).await;
 }


### PR DESCRIPTION
`mdbook serve` starts the warp server in a thread and then continues on to watch for changes. However, if the thread panics, for example, because the address is already in use, `mdbook` doesn't exit. 

This change will explicitly call `std::process::exit(1)` from the thread if `warp::serve` panics.

Fixes #1545.