### PR TITLE
Add --title option and --gitignore flag to mdbook init

### DIFF
--- a/guide/src/cli/init.md
+++ b/guide/src/cli/init.md
@@ -52,3 +52,19 @@ directory called `theme` in your source directory so that you can modify it.
 
 The theme is selectively overwritten, this means that if you don't want to
 overwrite a specific file, just delete it and the default file will be used.
+
+#### --title
+
+Specify a title for the book. If not supplied, an interactive prompt will ask for 
+a title. 
+
+```bash
+mdbook init --title="my amazing book"
+```
+
+#### --gitignore
+
+Create a `.gitignore` file configured to ignore the `book` directory created when [building] a book. 
+If not supplied, an interactive prompt will ask whether it should be created.
+
+[building]: build.md

--- a/guide/src/cli/init.md
+++ b/guide/src/cli/init.md
@@ -62,7 +62,7 @@ a title.
 mdbook init --title="my amazing book"
 ```
 
-#### --gitignore
+#### --ignore
 
 Create a `.gitignore` file configured to ignore the `book` directory created when [building] a book. 
 If not supplied, an interactive prompt will ask whether it should be created.

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -62,7 +62,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     if let Some(ignore) = args.value_of("ignore") {
         match ignore {
             "git" => builder.create_gitignore(true),
-            _ => builder.create_gitignore(false)
+            _ => builder.create_gitignore(false),
         };
     } else {
         println!("\nDo you want a .gitignore to be created? (y/n)");

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,5 +1,5 @@
 use crate::get_book_dir;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use mdbook::config;
 use mdbook::errors::Result;
 use mdbook::MDBook;
@@ -18,6 +18,20 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         )
         .arg_from_usage("--theme 'Copies the default theme into your source folder'")
         .arg_from_usage("--force 'Skips confirmation prompts'")
+        .arg(
+            Arg::with_name("title")
+                .short("t")
+                .long("title")
+                .takes_value(true)
+                .help("Sets the book title")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("gitignore")
+                .short("g")
+                .long("gitignore")
+                .help("Creates a .gitignore"),
+        )
 }
 
 // Init command implementation
@@ -25,7 +39,6 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let book_dir = get_book_dir(args);
     let mut builder = MDBook::init(&book_dir);
     let mut config = config::Config::default();
-
     // If flag `--theme` is present, copy theme to src
     if args.is_present("theme") {
         let theme_dir = book_dir.join("theme");
@@ -45,13 +58,20 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         }
     }
 
-    println!("\nDo you want a .gitignore to be created? (y/n)");
-
-    if confirm() {
+    if args.is_present("gitignore") {
         builder.create_gitignore(true);
+    } else {
+        println!("\nDo you want a .gitignore to be created? (y/n)");
+        if confirm() {
+            builder.create_gitignore(true);
+        }
     }
 
-    config.book.title = request_book_title();
+    config.book.title = if args.is_present("title") {
+        args.value_of("title").map(String::from)
+    } else {
+        request_book_title()
+    };
 
     if let Some(author) = get_author_name() {
         debug!("Obtained user name from gitconfig: {:?}", author);

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -20,7 +20,6 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         .arg_from_usage("--force 'Skips confirmation prompts'")
         .arg(
             Arg::with_name("title")
-                .short("t")
                 .long("title")
                 .takes_value(true)
                 .help("Sets the book title")
@@ -28,7 +27,6 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("gitignore")
-                .short("g")
                 .long("gitignore")
                 .help("Creates a .gitignore"),
         )

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -26,9 +26,12 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
                 .required(false),
         )
         .arg(
-            Arg::with_name("gitignore")
-                .long("gitignore")
-                .help("Creates a .gitignore"),
+            Arg::with_name("ignore")
+                .long("ignore")
+                .takes_value(true)
+                .possible_values(&["none", "git"])
+                .help("Creates a VCS ignore file (i.e. .gitignore)")
+                .required(false),
         )
 }
 
@@ -56,8 +59,11 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         }
     }
 
-    if args.is_present("gitignore") {
-        builder.create_gitignore(true);
+    if let Some(ignore) = args.value_of("ignore") {
+        match ignore {
+            "git" => builder.create_gitignore(true),
+            _ => builder.create_gitignore(false)
+        };
     } else {
         println!("\nDo you want a .gitignore to be created? (y/n)");
         if confirm() {


### PR DESCRIPTION
Adds two new flags to `mdbook init`; `--title` and `--gitignore`.

These flags optionally replace the two currently interactive prompts so that a book can be initialized without any prompts if desired. 

See #1556.