### PR TITLE
clippy: PathBuf to Path fixes.

### DIFF
--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -58,7 +58,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-fn remove_ignored_files(book_root: &PathBuf, paths: &[PathBuf]) -> Vec<PathBuf> {
+fn remove_ignored_files(book_root: &Path, paths: &[PathBuf]) -> Vec<PathBuf> {
     if paths.is_empty() {
         return vec![];
     }
@@ -81,7 +81,7 @@ fn remove_ignored_files(book_root: &PathBuf, paths: &[PathBuf]) -> Vec<PathBuf> 
     }
 }
 
-fn find_gitignore(book_root: &PathBuf) -> Option<PathBuf> {
+fn find_gitignore(book_root: &Path) -> Option<PathBuf> {
     book_root
         .ancestors()
         .map(|p| p.join(".gitignore"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -575,7 +575,7 @@ impl Default for HtmlConfig {
 impl HtmlConfig {
     /// Returns the directory of theme from the provided root directory. If the
     /// directory is not present it will append the default directory of "theme"
-    pub fn theme_dir(&self, root: &PathBuf) -> PathBuf {
+    pub fn theme_dir(&self, root: &Path) -> PathBuf {
         match self.theme {
             Some(ref d) => root.join(d),
             None => root.join("theme"),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -131,7 +131,7 @@ impl HtmlHandlebars {
         &self,
         ctx: &RenderContext,
         html_config: &HtmlConfig,
-        src_dir: &PathBuf,
+        src_dir: &Path,
         handlebars: &mut Handlebars<'_>,
         data: &mut serde_json::Map<String, serde_json::Value>,
     ) -> Result<()> {


### PR DESCRIPTION
Fixes all instances of `warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do`