### PR TITLE
Documentation clarification on markdown list markers

### DIFF
--- a/guide/src/format/summary.md
+++ b/guide/src/format/summary.md
@@ -54,8 +54,8 @@ to be ignored at best, or may cause an error when attempting to build the book.
 
    - [Another Chapter](relative/path/to/markdown4.md)
    ```
-   Numbered chapters can be denoted with either `-` or `*`.
-
+   Numbered chapters can be denoted with either `-` or `*` (do not mix delimiters). 
+   
 1. ***Suffix Chapter*** - Like prefix chapters, suffix chapters are unnumbered, but they come after 
    numbered chapters.
    ```markdown


### PR DESCRIPTION
The markdown list markers in a list in the `SUMMARY.md` must be of the same type to avoid creating a new list, which results in the remaining list items not being rendered. This should arguably produce an error or be handled in some other way, but in lieu of that, here is some documentation. 

This clarifies the issue seen in #1517.