### PR TITLE
Revert "book: use non_exhaustive attribute for struct Book"

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -74,10 +74,10 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
 /// [`iter()`]: #method.iter
 /// [`for_each_mut()`]: #method.for_each_mut
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
 pub struct Book {
     /// The sections in this book.
     pub sections: Vec<BookItem>,
+    __non_exhaustive: (),
 }
 
 impl Book {
@@ -225,7 +225,10 @@ pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P)
         chapters.push(chapter);
     }
 
-    Ok(Book { sections: chapters })
+    Ok(Book {
+        sections: chapters,
+        __non_exhaustive: (),
+    })
 }
 
 fn load_summary_item<P: AsRef<Path> + Clone>(


### PR DESCRIPTION
This reverts commit c1b2bec7d7a56909f695f103d316453dab68798e due to a breaking change. 

Fixes #1571. 
See #1557.