### PR TITLE
Fix inconsistent between bash version and rust version of the sample

### DIFF
--- a/guide/src/format/mdbook.md
+++ b/guide/src/format/mdbook.md
@@ -21,7 +21,7 @@ Will render as
 ```rust
 # fn main() {
     let x = 5;
-    let y = 7;
+    let y = 6;
 
     println!("{}", x + y);
 # }


### PR DESCRIPTION
In the bash version, `y` have value 6, while rust version it has value 7