### PR TITLE
Add a logo to the navigation bar of the HTML rendered book

### DIFF
--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -46,8 +46,11 @@ This is general information about your book.
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
+- **logo:** Path to a logo to shown at the top of the navigation bar. If this
+  is given as a relative path, it's base directory is the source directory.
 
 **book.toml**
+
 ```toml
 [book]
 title = "Example book"
@@ -55,6 +58,7 @@ authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
 language = "en"
+logo = "static/logo.png"
 ```
 
 ### Rust options

--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -47,7 +47,7 @@ This is general information about your book.
   key in the configuration file.
 - **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
 - **logo:** Path to a logo to shown at the top of the navigation bar. If this
-  is given as a relative path, it's base directory is the source directory.
+  is given as a relative path, its base directory is the source directory.
 
 **book.toml**
 

--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -58,7 +58,7 @@ authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
 language = "en"
-logo = "static/logo.png"
+logo = "static/logo.svg"
 ```
 
 ### Rust options

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,6 +417,9 @@ pub struct BookConfig {
     pub multilingual: bool,
     /// The main language of the book.
     pub language: Option<String>,
+    /// A logo to be displayed on top of the navigation bar. The path is relative to the source
+    /// path
+    pub logo: Option<PathBuf>,
 }
 
 impl Default for BookConfig {
@@ -428,6 +431,7 @@ impl Default for BookConfig {
             src: PathBuf::from("src"),
             multilingual: false,
             language: Some(String::from("en")),
+            logo: None,
         }
     }
 }
@@ -761,6 +765,8 @@ mod tests {
             multilingual: true,
             src: PathBuf::from("source"),
             language: Some(String::from("ja")),
+            // TODO: add a test logo
+            logo: None,
         };
         let build_should_be = BuildConfig {
             build_dir: PathBuf::from("outputs"),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -603,6 +603,10 @@ fn make_data(
         "description".to_owned(),
         json!(config.book.description.clone().unwrap_or_default()),
     );
+    data.insert(
+        "book_logo".to_owned(),
+        json!(config.book.logo.clone().unwrap_or_default()),
+    );
     if theme.favicon_png.is_some() {
         data.insert("favicon_png".to_owned(), json!("favicon.png"));
     }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -344,6 +344,13 @@ ul#searchresults span.teaser em {
     right: 0;
     padding: 10px 10px;
 }
+.sidebar .sidebar-scrollbox .sidebar-book-logo img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+    max-width: max-content;
+}
 .sidebar .sidebar-resize-handle {
     position: absolute;
     cursor: col-resize;

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -103,6 +103,11 @@
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
             <div class="sidebar-scrollbox">
+                {{#if book_logo }}
+                <div class="sidebar-book-logo">
+                    <img src="{{ book_logo }}">
+                </div>
+                {{/if}}
                 {{#toc}}{{/toc}}
             </div>
             <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -105,7 +105,7 @@
             <div class="sidebar-scrollbox">
                 {{#if book_logo }}
                 <div class="sidebar-book-logo">
-                    <img src="{{ book_logo }}">
+                    <img src="{{ path_to_root }}{{ book_logo }}">
                 </div>
                 {{/if}}
                 {{#toc}}{{/toc}}


### PR DESCRIPTION
I added the option to add an image as logo to the navigation bar by adding a configuration parameter to the `book` table of the `book.toml`. This resolves #877

I also thought about adding the option of a project logo to the bottom of the navigation sidebar, but wanted to wait for feedback to this first edit before adding more code.