### PR TITLE
Rust Edition 2021 Support

### DIFF
--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -63,8 +63,8 @@ Options for the Rust language, relevant to running tests and playground
 integration.
 
 - **edition**: Rust edition to use by default for the code snippets. Default
-  is "2015". Individual code blocks can be controlled with the `edition2015`
-  or `edition2018` annotations, such as:
+  is "2015". Individual code blocks can be controlled with the `edition2015`, 
+  `edition2018` or `edition2021` annotations, such as:
 
   ~~~text
   ```rust,edition2015

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -274,6 +274,10 @@ impl MDBook {
                         RustEdition::E2018 => {
                             cmd.args(&["--edition", "2018"]);
                         }
+                        RustEdition::E2021 => {
+                            cmd.args(&["--edition", "2021"])
+                                .args(&["-Z", "unstable-options"]);
+                        }
                     }
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -467,6 +467,9 @@ pub struct RustConfig {
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 /// Rust edition to use for the code.
 pub enum RustEdition {
+    /// The 2021 edition of Rust
+    #[serde(rename = "2021")]
+    E2021,
     /// The 2018 edition of Rust
     #[serde(rename = "2018")]
     E2018,
@@ -849,6 +852,26 @@ mod tests {
 
         let rust_should_be = RustConfig {
             edition: Some(RustEdition::E2018),
+        };
+
+        let got = Config::from_str(src).unwrap();
+        assert_eq!(got.rust, rust_should_be);
+    }
+
+    #[test]
+    fn edition_2021() {
+        let src = r#"
+        [book]
+        title = "mdBook Documentation"
+        description = "Create book from markdown files. Like Gitbook but implemented in Rust"
+        authors = ["Mathieu David"]
+        src = "./source"
+        [rust]
+        edition = "2021"
+        "#;
+
+        let rust_should_be = RustConfig {
+            edition: Some(RustEdition::E2021),
         };
 
         let got = Config::from_str(src).unwrap();

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -836,13 +836,15 @@ fn add_playground_pre(
                 {
                     let contains_e2015 = classes.contains("edition2015");
                     let contains_e2018 = classes.contains("edition2018");
-                    let edition_class = if contains_e2015 || contains_e2018 {
+                    let contains_e2021 = classes.contains("edition2021");
+                    let edition_class = if contains_e2015 || contains_e2018 || contains_e2021 {
                         // the user forced edition, we should not overwrite it
                         ""
                     } else {
                         match edition {
                             Some(RustEdition::E2015) => " edition2015",
                             Some(RustEdition::E2018) => " edition2018",
+                            Some(RustEdition::E2021) => " edition2021",
                             None => "",
                         }
                     };
@@ -1060,6 +1062,30 @@ mod tests {
                     ..Playground::default()
                 },
                 Some(RustEdition::E2018),
+            );
+            assert_eq!(&*got, *should_be);
+        }
+    }
+    #[test]
+    fn add_playground_edition2021() {
+        let inputs = [
+            ("<code class=\"language-rust\">x()</code>",
+             "<pre class=\"playground\"><code class=\"language-rust edition2021\">\n<span class=\"boring\">#![allow(unused)]\n</span><span class=\"boring\">fn main() {\n</span>x()\n<span class=\"boring\">}\n</span></code></pre>"),
+            ("<code class=\"language-rust\">fn main() {}</code>",
+             "<pre class=\"playground\"><code class=\"language-rust edition2021\">fn main() {}\n</code></pre>"),
+            ("<code class=\"language-rust edition2015\">fn main() {}</code>",
+             "<pre class=\"playground\"><code class=\"language-rust edition2015\">fn main() {}\n</code></pre>"),
+            ("<code class=\"language-rust edition2018\">fn main() {}</code>",
+             "<pre class=\"playground\"><code class=\"language-rust edition2018\">fn main() {}\n</code></pre>"),
+        ];
+        for (src, should_be) in &inputs {
+            let got = add_playground_pre(
+                src,
+                &Playground {
+                    editable: true,
+                    ..Playground::default()
+                },
+                Some(RustEdition::E2021),
             );
             assert_eq!(&*got, *should_be);
         }

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -108,16 +108,19 @@ function playground_text(playground) {
 
         let text = playground_text(code_block);
         let classes = code_block.querySelector('code').classList;
-        let has_2018 = classes.contains("edition2018");
-        let edition = has_2018 ? "2018" : "2015";
-
+        let edition = "2015";
+        if(classes.contains("edition2018")) {
+            edition = "2018";
+        } else if(classes.contains("edition2021")) {
+            edition = "2021";
+        }
         var params = {
             version: "stable",
             optimize: "0",
             code: text,
             edition: edition
         };
-
+        alert(params.edition);
         if (text.indexOf("#![feature") !== -1) {
             params.version = "nightly";
         }

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -120,7 +120,7 @@ function playground_text(playground) {
             code: text,
             edition: edition
         };
-        alert(params.edition);
+
         if (text.indexOf("#![feature") !== -1) {
             params.version = "nightly";
         }


### PR DESCRIPTION
Updates to include the upcoming 2021 edition. 

Fixes #1593.