### PR TITLE
Don't highlight `inline code` blocks in headers with output.html. playpen(playgroud).editable=true

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -162,12 +162,13 @@ function playground_text(playground) {
     if (window.ace) {
         // language-rust class needs to be removed for editable
         // blocks or highlightjs will capture events
-        Array
-            .from(document.querySelectorAll('code.editable'))
+        code_nodes
+            .filter(function (node) {return node.classList.contains("editable"); })
             .forEach(function (block) { block.classList.remove('language-rust'); });
 
         Array
-            .from(document.querySelectorAll('code:not(.editable)'))
+        code_nodes
+            .filter(function (node) {return !node.classList.contains("editable"); })
             .forEach(function (block) { hljs.highlightBlock(block); });
     } else {
         code_nodes.forEach(function (block) { hljs.highlightBlock(block); });


### PR DESCRIPTION
Don't highlight `inline code` blocks in headers with output.html. playpen(playgroud).editable=true

Fixes #1580