### PR TITLE
Fix some x overflows

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -28,7 +28,7 @@ code {
 
 /* make long words/inline code not x overflow */
 main {
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
 }
 
 /* make wide tables scroll if they overflow */

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -26,9 +26,9 @@ code {
     font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
 }
 
-/* make long inline code not x overflow */
-:not(pre) > code {
-    word-break: break-word;
+/* make long words/inline code not x overflow */
+main {
+    overflow-wrap: anywhere;
 }
 
 /* make wide tables scroll if they overflow */

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -31,6 +31,11 @@ code {
     word-break: break-word;
 }
 
+/* make wide tables scroll if they overflow */
+.table-wrapper {
+    overflow-x: auto;
+}
+
 /* Don't change font size in headers. */
 h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
     font-size: unset;

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -26,6 +26,11 @@ code {
     font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
 }
 
+/* make long inline code not x overflow */
+:not(pre) > code {
+    word-break: break-word;
+}
+
 /* Don't change font size in headers. */
 h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
     font-size: unset;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -258,6 +258,22 @@ mod tests {
         }
 
         #[test]
+        fn it_can_wrap_tables() {
+            let src = r#"
+| Original        | Punycode        | Punycode + Encoding |
+|-----------------|-----------------|---------------------|
+| føø             | f-5gaa          | f_5gaa              |
+"#;
+            let out = r#"
+<div class="table-wrapper"><table><thead><tr><th>Original</th><th>Punycode</th><th>Punycode + Encoding</th></tr></thead><tbody>
+<tr><td>føø</td><td>f-5gaa</td><td>f_5gaa</td></tr>
+</tbody></table>
+</div>
+"#.trim();
+            assert_eq!(render_markdown(src, false), out);
+        }
+
+        #[test]
         fn it_can_keep_quotes_straight() {
             assert_eq!(render_markdown("'one'", false), "<p>'one'</p>\n");
         }


### PR DESCRIPTION
This PR fixes long inline code doing an x overflow.

There's another x-overflow on this page, where the table with the heading  "punycode + encoding" also overflows slightly. I have fixed this one as well.

Spotted on
https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html