### PR TITLE
增加用户指定 summary 文件的功能（now support to appoint the summary file）

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -15,7 +15,7 @@ pub use self::init::BookBuilder;
 pub use self::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::string::ToString;
 use tempfile::Builder as TempFileBuilder;
@@ -46,8 +46,15 @@ pub struct MDBook {
 
 impl MDBook {
     /// Load a book from its root directory on disk.
-    pub fn load<P: Into<PathBuf>>(book_root: P) -> Result<MDBook> {
-        let book_root = book_root.into();
+    pub fn load<P: AsRef<Path> + Into<PathBuf>>(book_root: P) -> Result<MDBook> {
+        let config = MDBook::load_config(&book_root)?;
+
+        MDBook::load_with_config(book_root, config)
+    }
+
+    /// Load a book's custom `Config`
+    pub fn load_config<P: AsRef<Path> + Into<PathBuf>>(book_root: &P) -> Result<Config> {
+        let book_root = book_root.as_ref();
         let config_location = book_root.join("book.toml");
 
         // the book.json file is no longer used, so we should emit a warning to
@@ -75,7 +82,7 @@ impl MDBook {
             }
         }
 
-        MDBook::load_with_config(book_root, config)
+        Ok(config)
     }
 
     /// Load a book from its root directory using a custom `Config`.
@@ -84,6 +91,33 @@ impl MDBook {
 
         let src_dir = root.join(&config.book.src);
         let book = book::load_book(&src_dir, &config.build)?;
+
+        let renderers = determine_renderers(&config);
+        let preprocessors = determine_preprocessors(&config)?;
+
+        Ok(MDBook {
+            root,
+            config,
+            book,
+            renderers,
+            preprocessors,
+        })
+    }
+
+    /// Load a book from its root directory using a custom `Config` and a pointed custom summary.
+    pub fn load_with_summary<P: AsRef<Path> + Into<PathBuf>>(
+        book_root: P,
+        summary: &str,
+    ) -> Result<MDBook> {
+        let config = MDBook::load_config(&book_root)?;
+
+        let root = book_root.into();
+        let src_dir = root.join(&config.book.src);
+
+        let summary_md = src_dir.join(&summary);
+        let summary = book::load_summary(summary_md, &config.build)?;
+
+        let book = book::load_book_from_disk(&summary, &src_dir)?;
 
         let renderers = determine_renderers(&config);
         let preprocessors = determine_preprocessors(&config)?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -12,6 +12,11 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
              Relative paths are interpreted relative to the book's root directory.{n}\
              If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
         )
+        .args_from_usage(
+            "-s, --summary=[summary-file] 'Book's summary file{n}\
+             Relative paths are interpreted relative to the book's src root directory.{n}\
+             If omitted, use the default `SUMMARY.md` as summary file.",
+        )
         .arg_from_usage(
             "[dir] 'Root directory for the book{n}\
              (Defaults to the Current Directory when omitted)'",
@@ -22,7 +27,13 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
 // Build command implementation
 pub fn execute(args: &ArgMatches) -> Result<()> {
     let book_dir = get_book_dir(args);
-    let mut book = MDBook::load(&book_dir)?;
+
+    let mut book: MDBook;
+    if let Some(summary) = args.value_of("summary") {
+        book = MDBook::load_with_summary(&book_dir, summary)?;
+    } else {
+        book = MDBook::load(&book_dir)?;
+    }
 
     if let Some(dest_dir) = args.value_of("dest-dir") {
         book.config.build.build_dir = dest_dir.into();


### PR DESCRIPTION
add -s or --summary Option in subcommand(build):
```
    -s, --summary <summary-file>    Book's summary file
                                    Relative paths are interpreted relative to the book's src root directory.
                                    If omitted, use the default `SUMMARY.md` as summary file
```
allow user to appoint a custom `summary` file rather than always use the `SUMMARY.md`
