### PR TITLE
Add information about a new backend `mdbook-man`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ of a book in order to validate links or run tests. Some existing renderers are:
   preprocessors.
 - [`linkcheck`] - a backend which will check that all links are valid
 - [`epub`] - an experimental EPUB generator
+- [`man`] - a backend that generates manual pages from the book
 
 > **Note for Developers:** Feel free to send us a PR if you've developed your
 > own plugin and want it mentioned here.
@@ -234,3 +235,4 @@ All the code in this repository is released under the ***Mozilla Public License 
 [master-docs]: http://rust-lang.github.io/mdBook/
 [`linkcheck`]: https://crates.io/crates/mdbook-linkcheck
 [`epub`]: https://crates.io/crates/mdbook-epub
+[`man`]: https://crates.io/crates/mdbook-man

--- a/guide/src/for_developers/backends.md
+++ b/guide/src/for_developers/backends.md
@@ -13,6 +13,7 @@ rough example of how this is accomplished in practice.
 - [mdbook-epub] - an EPUB renderer
 - [mdbook-test] - a program to run the book's contents through [rust-skeptic] to
   verify everything compiles and runs correctly (similar to `rustdoc --test`)
+- [mdbook-man] - generate manual pages from the book
 
 This page will step you through creating your own alternative backend in the form
 of a simple word counting program. Although it will be written in Rust, there's
@@ -377,6 +378,7 @@ the source code or ask questions.
 [mdbook-linkcheck]: https://github.com/Michael-F-Bryan/mdbook-linkcheck
 [mdbook-epub]: https://github.com/Michael-F-Bryan/mdbook-epub
 [mdbook-test]: https://github.com/Michael-F-Bryan/mdbook-test
+[mdbook-man]: https://github.com/vv9k/mdbook-man
 [rust-skeptic]: https://github.com/budziq/rust-skeptic
 [`RenderContext`]: https://docs.rs/mdbook/*/mdbook/renderer/struct.RenderContext.html
 [`RenderContext::from_json()`]: https://docs.rs/mdbook/*/mdbook/renderer/struct.RenderContext.html#method.from_json


### PR DESCRIPTION
This PR adds links to a new backend that I'm working on: [mdbook-man](https://github.com/vv9k/mdbook-man). It generates manual pages from the book that can later be viewed with tools like `man`.