### PR TITLE
Stabilize 2021 flag.

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -275,8 +275,7 @@ impl MDBook {
                             cmd.args(&["--edition", "2018"]);
                         }
                         RustEdition::E2021 => {
-                            cmd.args(&["--edition", "2021"])
-                                .args(&["-Z", "unstable-options"]);
+                            cmd.args(&["--edition", "2021"]);
                         }
                     }
                 }


### PR DESCRIPTION
The 2021 edition is now stable on nightly, so the `-Z` flag is no longer necessary.