### PR TITLE
Fix unreadable code blocks chrome.css

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -193,7 +193,7 @@ a > .hljs {
     border-radius: 3px;
 }
 
-:not(pre):not(a) > .hljs {
+:not(pre):not(a):not(td):not(p) > .hljs {
     color: var(--inline-code-color);
     overflow-x: initial;
 }


### PR DESCRIPTION
I am not sure cases `.hljs` is used so I can't specifically enable this so I added a few other whitelisted stuff.

Before

![image](https://user-images.githubusercontent.com/4687791/135758585-934deecb-ba93-4052-a5f0-114cc1bcab59.png)

After

![image](https://user-images.githubusercontent.com/4687791/135758570-356a2d30-1a63-4b56-928c-5b03035dd8fb.png)

Screenshots taken from helix editor. https://github.com/helix-editor/helix although the styles are a bit custom but these parts are not customized.