### PR TITLE
Anonymize IP for Google analytics

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -23,6 +23,8 @@ The following configuration options are available:
 - **copy-fonts:** Copies fonts.css and respective font files to the output directory and use them in the default theme. Defaults to `true`.
 - **google-analytics:** If you use Google Analytics, this option lets you enable
   it by simply specifying your ID in the configuration file.
+- **anonymize-ip:** If you use Google Analytics, this option lets you
+  anonymize IPs for better privacy. Defaults to false.
 - **additional-css:** If you need to slightly change the appearance of your book
   without overwriting the whole style, you can specify a set of stylesheets that
   will be loaded after the default ones where you can surgically change the

--- a/src/config.rs
+++ b/src/config.rs
@@ -497,6 +497,8 @@ pub struct HtmlConfig {
     pub copy_fonts: bool,
     /// An optional google analytics code.
     pub google_analytics: Option<String>,
+    /// If google analytics should anonymize IPs for improved privacy.
+    pub anonymize_ip: bool,
     /// Additional CSS stylesheets to include in the rendered page's `<head>`.
     pub additional_css: Vec<PathBuf>,
     /// Additional JS scripts to include at the bottom of the rendered page's
@@ -556,6 +558,7 @@ impl Default for HtmlConfig {
             mathjax_support: false,
             copy_fonts: true,
             google_analytics: None,
+            anonymize_ip: false,
             additional_css: Vec::new(),
             additional_js: Vec::new(),
             fold: Fold::default(),
@@ -736,6 +739,7 @@ mod tests {
         default-theme = "rust"
         curly-quotes = true
         google-analytics = "123456"
+        anonymize-ip = true
         additional-css = ["./foo/bar/baz.css"]
         git-repository-url = "https://foo.com/"
         git-repository-icon = "fa-code-fork"
@@ -780,6 +784,7 @@ mod tests {
         let html_should_be = HtmlConfig {
             curly_quotes: true,
             google_analytics: Some(String::from("123456")),
+            anonymize_ip: true,
             additional_css: vec![PathBuf::from("./foo/bar/baz.css")],
             theme: Some(PathBuf::from("./themedir")),
             default_theme: Some(String::from("rust")),
@@ -968,6 +973,7 @@ mod tests {
             theme: Some(PathBuf::from("my-theme")),
             curly_quotes: true,
             google_analytics: Some(String::from("123456")),
+            anonymize_ip: false,
             additional_css: vec![PathBuf::from("custom.css"), PathBuf::from("custom2.css")],
             additional_js: vec![PathBuf::from("custom.js")],
             ..Default::default()

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -630,6 +630,10 @@ fn make_data(
         data.insert("google_analytics".to_owned(), json!(ga));
     }
 
+    if html_config.anonymize_ip {
+        data.insert("anonymize_ip".to_owned(), json!(true));
+    }
+
     if html_config.mathjax_support {
         data.insert("mathjax_support".to_owned(), json!(true));
     }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -248,7 +248,7 @@
                 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
+                ga('set','anonymizeIp',!0);
                 ga('create', '{{google_analytics}}', 'auto');
                 ga('send', 'pageview');
             }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -248,7 +248,9 @@
                 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        {{#if anonymize_ip}}
                 ga('set','anonymizeIp',!0);
+        {{/if}}
                 ga('create', '{{google_analytics}}', 'auto');
                 ga('send', 'pageview');
             }


### PR DESCRIPTION
This patch anonymizes IPs tracked by Google analytics
to address privacy concerns.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>