### PR TITLE
Deprecate google-analytics

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -21,8 +21,8 @@ The following configuration options are available:
 - **mathjax-support:** Adds support for [MathJax](../mathjax.md). Defaults to
   `false`.
 - **copy-fonts:** Copies fonts.css and respective font files to the output directory and use them in the default theme. Defaults to `true`.
-- **google-analytics:** If you use Google Analytics, this option lets you enable
-  it by simply specifying your ID in the configuration file.
+- **google-analytics:** This field has been deprecated and will be removed in a future release.
+  Use the `theme/head.hbs` file to add the appropriate Google Analytics code instead.
 - **additional-css:** If you need to slightly change the appearance of your book
   without overwriting the whole style, you can specify a set of stylesheets that
   will be loaded after the default ones where you can surgically change the
@@ -131,7 +131,6 @@ preferred-dark-theme = "navy"
 curly-quotes = true
 mathjax-support = false
 copy-fonts = true
-google-analytics = "UA-123456-7"
 additional-css = ["custom.css", "custom2.css"]
 additional-js = ["custom.js"]
 no-section-label = false

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -70,6 +70,20 @@ impl MDBook {
 
         config.update_from_env();
 
+        if config
+            .html_config()
+            .map_or(false, |html| html.google_analytics.is_some())
+        {
+            warn!(
+                "The output.html.google-analytics field has been deprecated; \
+                 it will be removed in a future release.\n\
+                 Consider placing the appropriate site tag code into the \
+                 theme/head.hbs file instead.\n\
+                 The tracking code may be found in the Google Analytics Admin page.\n\
+               "
+            );
+        }
+
         if log_enabled!(log::Level::Trace) {
             for line in format!("Config: {:#?}", config).lines() {
                 trace!("{}", line);


### PR DESCRIPTION
This puts a deprecation notice for the `output.html.google-analytics` field, with the intent to remove it in the 0.5 release. The current code has been outdated for a while, and doesn't provide very much flexibility.  I also prefer not to endorse any particular service, instead letting the user pick whichever they want.  Placing the code in the `<head>` tag is the recommended approach, and the `head.hbs` extension provides a means to do so.

Closes #1635