### PR TITLE
Add minimal traigebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,12 @@
+# This will allow users to self assign, and/or drop assignment
+[assign]
+
+
+[relabel]
+allow-unauthenticated = [
+# For Issue areas
+    "A-*",
+    "E-Help-Wanted",
+    "Bug",
+    "Feature-Request"
+]


### PR DESCRIPTION
Hey, I have added a very minimal triagebot config. This essentially only allows self assignment, and labeling the issues for areas. I looked at the triagebot doc, but most of the stuff there was useful for multi-team repos, which is sensible, as it is primarily meant for rustlag repo. I have added the minimal config which might be useful for mdBook, but I think even without it, there won't be that much difference. So do check it out once. I haven't work with triagebot before, even at a user-end, so there might be some mistakes.