### PR TITLE
Prevent iOS Safari from enlarging text in landscape orientation

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -12,6 +12,7 @@ html {
     color: var(--fg);
     background-color: var(--bg);
     text-size-adjust: none;
+    -webkit-text-size-adjust: none;
 }
 
 body {


### PR DESCRIPTION
closes #1684

## before-and-after side-by-side 


### before this patch

Text gets bigger on landscape orientation.

<img src="https://user-images.githubusercontent.com/941947/141610037-7aa41064-5cf0-4666-a531-0831ca80f88e.jpeg" width="500dp">

### after this patch

Text keeps same size with portrait orientation.

<img src="https://user-images.githubusercontent.com/941947/141610244-9d01029f-5a5b-498a-b73d-3b264589090e.jpeg" width="500dp">

## referernces
  - https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust#basic_disabling_usage
  - https://trac.webkit.org/changeset/261940/webkit