### PR TITLE
Guide: CI for Travis and GitHub Actions

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -22,7 +22,7 @@
         - [Editor](format/theme/editor.md)
     - [MathJax Support](format/mathjax.md)
     - [mdBook-specific features](format/mdbook.md)
-- [Continuous Integration](continuous-integration.md)
+- [Continuous Integration](ci/README.md)
 - [For Developers](for_developers/README.md)
     - [Preprocessors](for_developers/preprocessors.md)
     - [Alternative Backends](for_developers/backends.md)

--- a/guide/src/ci/README.md
+++ b/guide/src/ci/README.md
@@ -1,9 +1,11 @@
 # Running `mdbook` in Continuous Integration
 
-While the following examples use Travis CI, their principles should
+While the following examples use Travis CI and GitHub Actions, their principles should
 straightforwardly transfer to other continuous integration providers as well.
 
 ## Ensuring Your Book Builds and Tests Pass
+
+### Using Travis CI
 
 Here is a sample Travis CI `.travis.yml` configuration that ensures `mdbook
 build` and `mdbook test` run successfully. The key to fast CI turnaround times
@@ -11,49 +13,37 @@ is caching `mdbook` installs, so that you aren't compiling `mdbook` on every CI
 run.
 
 ```yaml
-language: rust
-sudo: false
+{{#include travis.yml::16}}
+```
 
-cache:
-  - cargo
+### Using GitHub Actions
 
-rust:
-  - stable
+Next is a sample for GitHub Actions `.github/workflows/main.yml` that ensures `mdbook build` and `mdbook test` run successfully.
 
-before_script:
-  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.3" mdbook)
-  - cargo install-update -a
-
-script:
-  - mdbook build && mdbook test # In case of custom book path: mdbook build path/to/mybook && mdbook test path/to/mybook
+```yaml
+{{#include github.yml::19}}
 ```
 
 ## Deploying Your Book to GitHub Pages
 
 Following these instructions will result in your book being published to GitHub
-pages after a successful CI run on your repository's `master` branch.
+pages after a successful CI run on your repository's `main` branch.
+
+### Using Travis CI
 
 First, create a new GitHub "Personal Access Token" with the "public_repo"
 permissions (or "repo" for private repositories). Go to your repository's Travis
 CI settings page and add an environment variable named `GITHUB_TOKEN` that is
 marked secure and *not* shown in the logs.
 
-Whilst still in your repository's settings page, navigate to Options and change the 
+Whilst still in your repository's settings page, navigate to Options and change the
 Source on GitHub pages to `gh-pages`.
 
 Then, append this snippet to your `.travis.yml` and update the path to the
 `book` directory:
 
 ```yaml
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  local-dir: book # In case of custom book path: path/to/mybook/book
-  keep-history: false
-  on:
-    branch: main
+{{#include travis.yml:18:}}
 ```
 
 That's it!
@@ -61,42 +51,23 @@ That's it!
 Note: Travis has a new [dplv2](https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release) configuration that is currently in beta. To use this new format, update your `.travis.yml` file to:
 
 ```yaml
-language: rust
-os: linux
-dist: xenial
+{{#include travis-xenial.yml}}
+```
 
-cache:
-  - cargo
+### Using GitHub Actions
 
-rust:
-  - stable
+Extend `.github/workflows/main.yml` to the following in the `jobs` section:
 
-before_script:
-  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.3" mdbook)
-  - cargo install-update -a
-
-script:
-  - mdbook build && mdbook test # In case of custom book path: mdbook build path/to/mybook && mdbook test path/to/mybook
-  
-deploy:
-  provider: pages
-  strategy: git
-  edge: true
-  cleanup: false
-  github-token: $GITHUB_TOKEN
-  local-dir: book # In case of custom book path: path/to/mybook/book
-  keep-history: false
-  on:
-    branch: main
-  target_branch: gh-pages
+```yaml
+{{#include github.yml:20:}}
 ```
 
 ### Deploying to GitHub Pages manually
 
 If your CI doesn't support GitHub pages, or you're deploying somewhere else
 with integrations such as Github Pages:
- *note: you may want to use different tmp dirs*:
+
+*note: you may want to use different tmp dirs*:
 
 ```console
 $> git worktree add /tmp/book gh-pages

--- a/guide/src/ci/github.yml
+++ b/guide/src/ci/github.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build, Test and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+      - run: mdbook build && mdbook test # In case of custom book path: mdbook build path/to/mybook && mdbook test path/to/mybook
+      - uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: book # The folder the action should deploy.

--- a/guide/src/ci/travis-xenial.yml
+++ b/guide/src/ci/travis-xenial.yml
@@ -1,0 +1,29 @@
+language: rust
+os: linux
+dist: xenial
+
+cache:
+  - cargo
+
+rust:
+  - stable
+
+before_script:
+  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+  - cargo install-update -a
+
+script:
+  - mdbook build && mdbook test # In case of custom book path: mdbook build path/to/mybook && mdbook test path/to/mybook
+
+deploy:
+  provider: pages
+  strategy: git
+  edge: true
+  cleanup: false
+  github-token: $GITHUB_TOKEN
+  local-dir: book # In case of custom book path: path/to/mybook/book
+  keep-history: false
+  on:
+    branch: main
+  target_branch: gh-pages

--- a/guide/src/ci/travis.yml
+++ b/guide/src/ci/travis.yml
@@ -1,0 +1,25 @@
+language: rust
+sudo: false
+
+cache:
+  - cargo
+
+rust:
+  - stable
+
+before_script:
+  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+  - cargo install-update -a
+
+script:
+  - mdbook build && mdbook test # In case of custom book path: mdbook build path/to/mybook && mdbook test path/to/mybook
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  local-dir: book # In case of custom book path: path/to/mybook/book
+  keep-history: false
+  on:
+    branch: main

--- a/guide/src/format/summary.md
+++ b/guide/src/format/summary.md
@@ -35,7 +35,7 @@ to be ignored at best, or may cause an error when attempting to build the book.
    Titles are optional, and the numbered chapters can be broken into as many
    parts as desired.
    ```markdown
-   # My Part Tile
+   # My Part Title
 
    - [First Chapter](relative/path/to/markdown.md)
    ```
@@ -54,9 +54,9 @@ to be ignored at best, or may cause an error when attempting to build the book.
 
    - [Another Chapter](relative/path/to/markdown4.md)
    ```
-   Numbered chapters can be denoted with either `-` or `*` (do not mix delimiters). 
-   
-1. ***Suffix Chapter*** - Like prefix chapters, suffix chapters are unnumbered, but they come after 
+   Numbered chapters can be denoted with either `-` or `*` (do not mix delimiters).
+
+1. ***Suffix Chapter*** - Like prefix chapters, suffix chapters are unnumbered, but they come after
    numbered chapters.
    ```markdown
    - [Last Chapter](relative/path/to/markdown.md)
@@ -80,14 +80,14 @@ to be ignored at best, or may cause an error when attempting to build the book.
    a line containing exclusively dashes and at least three of them: `---`.
    ```markdown
    # My Part Title
-   
+
    [A Prefix Chapter](relative/path/to/markdown.md)
 
    ---
 
    - [First Chapter](relative/path/to/markdown2.md)
    ```
-  
+
 
 ### Example
 


### PR DESCRIPTION
Hello!

I've updated the guide to provide examples for GitHub Actions as well, and also fixed three mistakes in existing text.

- Moved `continuous-integration.md` into `ci/README.md`
- Updated `cargo install --vers "^0.3" mdbook` to `cargo install --vers "^0.4" mdbook` in all examples
- Put examples into separate files for including
- Renamed `master` branch to `main` in one case

I hope you're fine with this, keep up the good work!