### PR TITLE
Use chapter.source_path for partial includes, not chapter.path

### DIFF
--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -46,7 +46,7 @@ impl Preprocessor for LinkPreprocessor {
 
         book.for_each_mut(|section: &mut BookItem| {
             if let BookItem::Chapter(ref mut ch) = *section {
-                if let Some(ref chapter_path) = ch.path {
+                if let Some(ref chapter_path) = ch.source_path {
                     let base = chapter_path
                         .parent()
                         .map(|dir| src_dir.join(dir))

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -382,6 +382,38 @@ fn able_to_include_files_in_chapters() {
     assert_doesnt_contain_strings(&includes, &["{{#include ../SUMMARY.md::}}"]);
 }
 
+/// This makes sure chapter::path is a logical value and chapter::source_path has the real path
+/// on the file system which is used for partial includes.
+#[test]
+fn able_to_include_files_in_chapters_regardless_of_logical_path() {
+    let temp = DummyBook::new().build().unwrap();
+    let mut md = MDBook::load(temp.path()).unwrap();
+    fn bad_path(sec: &mut mdbook::BookItem) {
+        match sec {
+            mdbook::BookItem::Chapter(c) => {
+                if let Some(ref mut p) = c.path {
+                    p.set_extension("");
+                    p.push("oops.md");
+                }
+                c.sub_items.iter_mut().for_each(bad_path);
+            }
+            _ => {}
+        }
+    }
+    md.book.sections.iter_mut().for_each(bad_path);
+    md.build().unwrap();
+
+    let includes = temp.path().join("book/first/includes.html");
+
+    let summary_strings = &[
+        r##"<h1 id="summary"><a class="header" href="#summary">Summary</a></h1>"##,
+        ">First Chapter</a>",
+    ];
+    assert_contains_strings(&includes, summary_strings);
+
+    assert_doesnt_contain_strings(&includes, &["{{#include ../SUMMARY.md::}}"]);
+}
+
 /// Ensure cyclic includes are capped so that no exceptions occur
 #[test]
 fn recursive_includes_are_capped() {


### PR DESCRIPTION
Partial includes are found using relative paths, but relies on the logical `path` variable rather than the actual `source_path`. 

The `Chapter::source_path` property [was introduced](https://github.com/rust-lang/mdBook/commit/7aff98a8596bd7d52a54f7729f210b53566b9f8c) to render URLs differently from how they might be on the filesystem. It's a good change that allows preprocessors to do more with the rendered URLs, but that almost always breaks the `links` preprocessor. This PR switches to using `source_path` when looking up relative partial paths.
