### PR TITLE
don't use additional features for pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,15 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd16514d1af5f7a71f909a44ef253cdb712a376d7ebc8ae4a471a9be9743548"
 dependencies = [
  "bitflags",
- "getopts",
  "memchr",
  "unicase",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.0"
 log = "0.4"
 memchr = "2.0"
 opener = "0.5"
-pulldown-cmark = "0.9.0"
+pulldown-cmark = { version = "0.9", default-features = false }
 regex = "1.0.0"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
There no need to pull arg parsing crate