### PR TITLE
Make page-break configurable

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -173,10 +173,12 @@ By default, mdBook will include an icon on the top right of the book (which look
 ```toml
 [output.html.print]
 enable = true    # include support for printable output
+page-break = true # insert page-break after each chapter
 ```
 
 - **enable:** Enable print support. When `false`, all print support will not be
   rendered. Defaults to `true`.
+- **page-break** Insert page breaks between chapters. Defaults to `true`.
 
 ### `[output.html.fold]`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -592,11 +592,16 @@ impl HtmlConfig {
 pub struct Print {
     /// Whether print support is enabled.
     pub enable: bool,
+    /// Insert page breaks between chapters. Default: `true`.
+    pub page_break: bool,
 }
 
 impl Default for Print {
     fn default() -> Self {
-        Self { enable: true }
+        Self {
+            enable: true,
+            page_break: true,
+        }
     }
 }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -56,7 +56,7 @@ impl HtmlHandlebars {
 
         let fixed_content =
             utils::render_markdown_with_path(&ch.content, ctx.html_config.curly_quotes, Some(path));
-        if !ctx.is_index {
+        if !ctx.is_index && ctx.html_config.print.page_break {
             // Add page break between chapters
             // See https://developer.mozilla.org/en-US/docs/Web/CSS/break-before and https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-before
             // Add both two CSS properties because of the compatibility issue


### PR DESCRIPTION
As discussed in #1190, the option to disable page-breaks between chapters is useful for some specific use-cases. I use mdBook for printable cheat sheets, and therefore want to keep the printable version as compact as possible.