### PR TITLE
Port mdBook to clap3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,8 @@ jobs:
             rust: stable
           - build: msrv
             os: ubuntu-latest
-            rust: 1.46.0
+            # sync MSRV with docs: guide/src/guide/installation.md
+            rust: 1.54.0
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,17 +185,27 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -837,6 +847,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "elasticlunr-rs",
  "env_logger",
  "futures-util",
@@ -1051,6 +1062,15 @@ checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
  "bstr",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1590,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -1659,12 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "time"
@@ -1873,12 +1890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,12 +1912,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ description = "Creates a book from markdown files"
 [dependencies]
 anyhow = "1.0.28"
 chrono = "0.4"
-clap = "2.24"
+clap = { version = "3.0", features = ["cargo"] }
+clap_complete = "3.0"
 env_logger = "0.7.1"
 handlebars = "4.0"
 lazy_static = "1.0"

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -1,5 +1,5 @@
 use crate::nop_lib::Nop;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches};
 use mdbook::book::Book;
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor, PreprocessorContext};
@@ -11,7 +11,7 @@ pub fn make_app() -> App<'static> {
     App::new("nop-preprocessor")
         .about("A mdbook preprocessor which does precisely nothing")
         .subcommand(
-            SubCommand::with_name("supports")
+            App::new("supports")
                 .arg(Arg::new("renderer").required(true))
                 .about("Check whether a renderer is supported by this preprocessor"),
         )

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -12,7 +12,7 @@ pub fn make_app() -> App<'static> {
         .about("A mdbook preprocessor which does precisely nothing")
         .subcommand(
             SubCommand::with_name("supports")
-                .arg(Arg::with_name("renderer").required(true))
+                .arg(Arg::new("renderer").required(true))
                 .about("Check whether a renderer is supported by this preprocessor"),
         )
 }

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -7,7 +7,7 @@ use semver::{Version, VersionReq};
 use std::io;
 use std::process;
 
-pub fn make_app() -> App<'static, 'static> {
+pub fn make_app() -> App<'static> {
     App::new("nop-preprocessor")
         .about("A mdbook preprocessor which does precisely nothing")
         .subcommand(

--- a/guide/src/guide/installation.md
+++ b/guide/src/guide/installation.md
@@ -20,7 +20,7 @@ To make it easier to run, put the path to the binary into your `PATH`.
 
 To build the `mdbook` executable from source, you will first need to install Rust and Cargo.
 Follow the instructions on the [Rust installation page].
-mdBook currently requires at least Rust version 1.46.
+mdBook currently requires at least Rust version 1.54.
 
 Once you have installed Rust, the following command can be used to build and install mdBook:
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,11 +1,11 @@
 use crate::{get_book_dir, open};
-use clap::{App, ArgMatches, SubCommand};
+use clap::{App, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::MDBook;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("build")
+    App::new("build")
         .about("Builds a book from its markdown files")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -4,7 +4,7 @@ use mdbook::errors::Result;
 use mdbook::MDBook;
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("build")
         .about("Builds a book from its markdown files")
         .arg_from_usage(

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,5 +1,5 @@
 use crate::{get_book_dir, open};
-use clap::{App, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::MDBook;
 
@@ -7,16 +7,22 @@ use mdbook::MDBook;
 pub fn make_subcommand<'help>() -> App<'help> {
     App::new("build")
         .about("Builds a book from its markdown files")
-        .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
-             Relative paths are interpreted relative to the book's root directory.{n}\
-             If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
+        .arg(
+            Arg::new("dest-dir")
+                .short('d')
+                .long("dest-dir")
+                .value_name("dest-dir")
+                .help(
+                    "Output directory for the book{n}\
+                    Relative paths are interpreted relative to the book's root directory.{n}\
+                    If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.",
+                ),
         )
-        .arg_from_usage(
-            "[dir] 'Root directory for the book{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
-        .arg_from_usage("-o, --open 'Opens the compiled book in a web browser'")
+        .arg(arg!([dir]
+            "Root directory for the book{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
+        .arg(arg!(-o --open "Opens the compiled book in a web browser"))
 }
 
 // Build command implementation

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -1,12 +1,12 @@
 use crate::get_book_dir;
 use anyhow::Context;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{App, ArgMatches};
 use mdbook::MDBook;
 use std::fs;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("clean")
+    App::new("clean")
         .about("Deletes a built book")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -5,7 +5,7 @@ use mdbook::MDBook;
 use std::fs;
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("clean")
         .about("Deletes a built book")
         .arg_from_usage(

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -1,6 +1,6 @@
 use crate::get_book_dir;
 use anyhow::Context;
-use clap::{App, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use mdbook::MDBook;
 use std::fs;
 
@@ -8,16 +8,21 @@ use std::fs;
 pub fn make_subcommand<'help>() -> App<'help> {
     App::new("clean")
         .about("Deletes a built book")
-        .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
-             Relative paths are interpreted relative to the book's root directory.{n}\
-             Running this command deletes this directory.{n}\
-             If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
+        .arg(
+            Arg::new("dest-dir")
+                .short('d')
+                .long("dest-dir")
+                .value_name("dest-dir")
+                .help(
+                    "Output directory for the book{n}\
+                    Relative paths are interpreted relative to the book's root directory.{n}\
+                    If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.",
+                ),
         )
-        .arg_from_usage(
-            "[dir] 'Root directory for the book{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
+        .arg(arg!([dir]
+            "Root directory for the book{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
 }
 
 // Clean command implementation

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::process::Command;
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("init")
         .about("Creates the boilerplate structure and files for a new book")
         // the {n} denotes a newline which will properly aligned in all help messages

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,5 +1,5 @@
 use crate::get_book_dir;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches};
 use mdbook::config;
 use mdbook::errors::Result;
 use mdbook::MDBook;
@@ -9,7 +9,7 @@ use std::process::Command;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("init")
+    App::new("init")
         .about("Creates the boilerplate structure and files for a new book")
         // the {n} denotes a newline which will properly aligned in all help messages
         .arg_from_usage(

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -19,14 +19,14 @@ pub fn make_subcommand<'help>() -> App<'help> {
         .arg_from_usage("--theme 'Copies the default theme into your source folder'")
         .arg_from_usage("--force 'Skips confirmation prompts'")
         .arg(
-            Arg::with_name("title")
+            Arg::new("title")
                 .long("title")
                 .takes_value(true)
                 .help("Sets the book title")
                 .required(false),
         )
         .arg(
-            Arg::with_name("ignore")
+            Arg::new("ignore")
                 .long("ignore")
                 .takes_value(true)
                 .possible_values(&["none", "git"])

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,5 +1,5 @@
 use crate::get_book_dir;
-use clap::{App, Arg, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use mdbook::config;
 use mdbook::errors::Result;
 use mdbook::MDBook;
@@ -12,12 +12,12 @@ pub fn make_subcommand<'help>() -> App<'help> {
     App::new("init")
         .about("Creates the boilerplate structure and files for a new book")
         // the {n} denotes a newline which will properly aligned in all help messages
-        .arg_from_usage(
-            "[dir] 'Directory to create the book in{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
-        .arg_from_usage("--theme 'Copies the default theme into your source folder'")
-        .arg_from_usage("--force 'Skips confirmation prompts'")
+        .arg(arg!([dir]
+            "Directory to create the book in{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
+        .arg(arg!(--theme "Copies the default theme into your source folder"))
+        .arg(arg!(--force "Skips confirmation prompts"))
         .arg(
             Arg::new("title")
                 .long("title")

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -18,7 +18,7 @@ use warp::Filter;
 const LIVE_RELOAD_ENDPOINT: &str = "__livereload";
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("serve")
         .about("Serves a book at http://localhost:3000, and rebuilds it on changes")
         .arg_from_usage(
@@ -32,7 +32,7 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("hostname")
-                .short("n")
+                .short('n')
                 .long("hostname")
                 .takes_value(true)
                 .default_value("localhost")
@@ -41,7 +41,7 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("port")
-                .short("p")
+                .short('p')
                 .long("port")
                 .takes_value(true)
                 .default_value("3000")

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "watch")]
 use super::watch;
 use crate::{get_book_dir, open};
-use clap::{App, Arg, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use futures_util::sink::SinkExt;
 use futures_util::StreamExt;
 use mdbook::errors::*;
@@ -21,15 +21,21 @@ const LIVE_RELOAD_ENDPOINT: &str = "__livereload";
 pub fn make_subcommand<'help>() -> App<'help> {
     App::new("serve")
         .about("Serves a book at http://localhost:3000, and rebuilds it on changes")
-        .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
-             Relative paths are interpreted relative to the book's root directory.{n}\
-             If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
+        .arg(
+            Arg::new("dest-dir")
+                .short('d')
+                .long("dest-dir")
+                .value_name("dest-dir")
+                .help(
+                    "Output directory for the book{n}\
+                    Relative paths are interpreted relative to the book's root directory.{n}\
+                    If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.",
+                ),
         )
-        .arg_from_usage(
-            "[dir] 'Root directory for the book{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
+        .arg(arg!([dir]
+            "Root directory for the book{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
         .arg(
             Arg::new("hostname")
                 .short('n')
@@ -48,7 +54,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .forbid_empty_values(true)
                 .help("Port to use for HTTP connections"),
         )
-        .arg_from_usage("-o, --open 'Opens the book server in a web browser'")
+        .arg(arg!(-o --open "Opens the compiled book in a web browser"))
 }
 
 // Serve command implementation

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -31,7 +31,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
              (Defaults to the Current Directory when omitted)'",
         )
         .arg(
-            Arg::with_name("hostname")
+            Arg::new("hostname")
                 .short('n')
                 .long("hostname")
                 .takes_value(true)
@@ -40,7 +40,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .help("Hostname to listen on for HTTP connections"),
         )
         .arg(
-            Arg::with_name("port")
+            Arg::new("port")
                 .short('p')
                 .long("port")
                 .takes_value(true)

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -36,7 +36,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .long("hostname")
                 .takes_value(true)
                 .default_value("localhost")
-                .empty_values(false)
+                .forbid_empty_values(true)
                 .help("Hostname to listen on for HTTP connections"),
         )
         .arg(
@@ -45,7 +45,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .long("port")
                 .takes_value(true)
                 .default_value("3000")
-                .empty_values(false)
+                .forbid_empty_values(true)
                 .help("Port to use for HTTP connections"),
         )
         .arg_from_usage("-o, --open 'Opens the book server in a web browser'")

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "watch")]
 use super::watch;
 use crate::{get_book_dir, open};
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches};
 use futures_util::sink::SinkExt;
 use futures_util::StreamExt;
 use mdbook::errors::*;
@@ -19,7 +19,7 @@ const LIVE_RELOAD_ENDPOINT: &str = "__livereload";
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("serve")
+    App::new("serve")
         .about("Serves a book at http://localhost:3000, and rebuilds it on changes")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -1,5 +1,5 @@
 use crate::get_book_dir;
-use clap::{App, Arg, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::MDBook;
 
@@ -7,15 +7,21 @@ use mdbook::MDBook;
 pub fn make_subcommand<'help>() -> App<'help> {
     App::new("test")
         .about("Tests that a book's Rust code samples compile")
-        .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
-             Relative paths are interpreted relative to the book's root directory.{n}\
-             If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
+        .arg(
+            Arg::new("dest-dir")
+                .short('d')
+                .long("dest-dir")
+                .value_name("dest-dir")
+                .help(
+                    "Output directory for the book{n}\
+                    Relative paths are interpreted relative to the book's root directory.{n}\
+                    If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.",
+                ),
         )
-        .arg_from_usage(
-            "[dir] 'Root directory for the book{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
+        .arg(arg!([dir]
+            "Root directory for the book{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
         .arg(Arg::new("library-path")
             .short('L')
             .long("library-path")

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -23,7 +23,8 @@ pub fn make_subcommand<'help>() -> App<'help> {
             .takes_value(true)
             .use_delimiter(true)
             .require_delimiter(true)
-            .multiple(true)
+            .multiple_values(true)
+            .multiple_occurrences(true)
             .forbid_empty_values(true)
             .help("A comma-separated list of directories to add to {n}the crate search path when building tests"))
 }

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -4,7 +4,7 @@ use mdbook::errors::Result;
 use mdbook::MDBook;
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("test")
         .about("Tests that a book's Rust code samples compile")
         .arg_from_usage(
@@ -17,10 +17,11 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
              (Defaults to the Current Directory when omitted)'",
         )
         .arg(Arg::with_name("library-path")
-            .short("L")
+            .short('L')
             .long("library-path")
             .value_name("dir")
             .takes_value(true)
+            .use_delimiter(true)
             .require_delimiter(true)
             .multiple(true)
             .empty_values(false)

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -24,7 +24,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
             .use_delimiter(true)
             .require_delimiter(true)
             .multiple(true)
-            .empty_values(false)
+            .forbid_empty_values(true)
             .help("A comma-separated list of directories to add to {n}the crate search path when building tests"))
 }
 

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -16,7 +16,7 @@ pub fn make_subcommand<'help>() -> App<'help> {
             "[dir] 'Root directory for the book{n}\
              (Defaults to the Current Directory when omitted)'",
         )
-        .arg(Arg::with_name("library-path")
+        .arg(Arg::new("library-path")
             .short('L')
             .long("library-path")
             .value_name("dir")

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -1,11 +1,11 @@
 use crate::get_book_dir;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::MDBook;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("test")
+    App::new("test")
         .about("Tests that a book's Rust code samples compile")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,5 +1,5 @@
 use crate::{get_book_dir, open};
-use clap::{App, ArgMatches, SubCommand};
+use clap::{App, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::utils;
 use mdbook::MDBook;
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
-    SubCommand::with_name("watch")
+    App::new("watch")
         .about("Watches a book's files and rebuilds it on changes")
         .arg_from_usage(
             "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -10,7 +10,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 // Create clap subcommand arguments
-pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
+pub fn make_subcommand<'help>() -> App<'help> {
     SubCommand::with_name("watch")
         .about("Watches a book's files and rebuilds it on changes")
         .arg_from_usage(

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,5 +1,5 @@
 use crate::{get_book_dir, open};
-use clap::{App, ArgMatches};
+use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::utils;
 use mdbook::MDBook;
@@ -13,16 +13,22 @@ use std::time::Duration;
 pub fn make_subcommand<'help>() -> App<'help> {
     App::new("watch")
         .about("Watches a book's files and rebuilds it on changes")
-        .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
-             Relative paths are interpreted relative to the book's root directory.{n}\
-             If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.'",
+        .arg(
+            Arg::new("dest-dir")
+                .short('d')
+                .long("dest-dir")
+                .value_name("dest-dir")
+                .help(
+                    "Output directory for the book{n}\
+                    Relative paths are interpreted relative to the book's root directory.{n}\
+                    If omitted, mdBook uses build.build-dir from book.toml or defaults to `./book`.",
+                ),
         )
-        .arg_from_usage(
-            "[dir] 'Root directory for the book{n}\
-             (Defaults to the Current Directory when omitted)'",
-        )
-        .arg_from_usage("-o, --open 'Open the compiled book in a web browser'")
+        .arg(arg!([dir]
+            "Root directory for the book{n}\
+            (Defaults to the Current Directory when omitted)"
+        ))
+        .arg(arg!(-o --open "Opens the compiled book in a web browser"))
 }
 
 // Watch command implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,6 @@ fn create_clap_app() -> App<'static> {
         .version(VERSION)
         .setting(AppSettings::GlobalVersion)
         .setting(AppSettings::ArgRequiredElseHelp)
-        .setting(AppSettings::ColoredHelp)
         .after_help(
             "For more information about a specific command, try `mdbook <command> --help`\n\
              The source code for mdBook is available at: https://github.com/rust-lang/mdBook",

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate log;
 
 use anyhow::anyhow;
 use chrono::Local;
-use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use clap_complete::Shell;
 use env_logger::Builder;
 use log::LevelFilter;
@@ -78,7 +78,7 @@ fn create_clap_app() -> App<'static> {
         .subcommand(cmd::test::make_subcommand())
         .subcommand(cmd::clean::make_subcommand())
         .subcommand(
-            SubCommand::with_name("completions")
+            App::new("completions")
                 .about("Generate shell completions for your shell to stdout")
                 .arg(
                     Arg::new("shell")

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn create_clap_app() -> App<'static> {
             SubCommand::with_name("completions")
                 .about("Generate shell completions for your shell to stdout")
                 .arg(
-                    Arg::with_name("shell")
+                    Arg::new("shell")
                         .takes_value(true)
                         .possible_values(Shell::possible_values())
                         .help("the shell to generate completions for")

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn create_clap_app() -> App<'static> {
         .about(crate_description!())
         .author("Mathieu David <mathieudavid@mathieudavid.org>")
         .version(VERSION)
-        .setting(AppSettings::GlobalVersion)
+        .setting(AppSettings::PropagateVersion)
         .setting(AppSettings::ArgRequiredElseHelp)
         .after_help(
             "For more information about a specific command, try `mdbook <command> --help`\n\


### PR DESCRIPTION
This includes resolving the deprecation warnings, one warning per commit.  This was a fairly straightforward conversion, sticking to simpler parts of clap.  `App::arg_from_usage` was probably the most involved.  The replacement, `arg!()`, doesn't seem to support kebab-case in value names.

I tested by
- Adding the `App::debug_assert()` test
- Inspecting before/after of `--help` for each subcommand

I'm assuming there is some end-to-end tests to at least catch egregious cases.

Differences I noticed (all cosmetic)
- Colored help is now on all subcommands (`ColoredHelp` was set only on the parent before rather than with `global_setting`, now its the default)
- Combining of the Flags and Options sections (`UnifiedHelpMessage` is now the only behavior)
- Some spacing is slightly different so more lines of text wrap.