### PR TITLE
Update semver dev-dependency in nop-preprocessor example to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,21 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ ammonia = { version = "3", optional = true }
 assert_cmd = "1"
 predicates = "2"
 select = "0.5"
-semver = "0.11.0"
+semver = "1.0"
 pretty_assertions = "0.6"
 walkdir = "2.0"
 


### PR DESCRIPTION
The API involved in the example is the following, none of which has changed between 0.11 and 1.0.

https://github.com/rust-lang/mdBook/blob/336640633b1741de644e971a1a2cd8b30c595368/examples/nop-preprocessor.rs#L6

https://github.com/rust-lang/mdBook/blob/336640633b1741de644e971a1a2cd8b30c595368/examples/nop-preprocessor.rs#L37-L40