### PR TITLE
Make print page (print.html) links link to anchors on the print page

### DIFF
--- a/crates/mdbook-core/src/utils/mod.rs
+++ b/crates/mdbook-core/src/utils/mod.rs
@@ -55,7 +55,7 @@ pub fn normalize_id(content: &str) -> String {
 
 /// Generate an ID for use with anchors which is derived from a "normalised"
 /// string.
-fn id_from_content(content: &str) -> String {
+pub fn id_from_content(content: &str) -> String {
     let mut content = content.to_string();
 
     // Skip any tags or html-encoded stuff

--- a/crates/mdbook-html/src/html_handlebars/search.rs
+++ b/crates/mdbook-html/src/html_handlebars/search.rs
@@ -129,7 +129,8 @@ fn render_item(
         .with_extension("html")
         .to_url_path();
 
-    let options = HtmlRenderOptions::new(&chapter_path);
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&chapter_path, &redirect);
     let mut p = new_cmark_parser(&chapter.content, &options.markdown_options).peekable();
 
     let mut in_heading = false;

--- a/crates/mdbook-html/src/lib.rs
+++ b/crates/mdbook-html/src/lib.rs
@@ -12,9 +12,9 @@ use std::path::Path;
 /// Creates an [`HtmlRenderOptions`] from the given config.
 pub fn html_render_options_from_config<'a>(
     path: &'a Path,
-    config: &HtmlConfig,
+    config: &'a HtmlConfig,
 ) -> HtmlRenderOptions<'a> {
-    let mut options = HtmlRenderOptions::new(path);
+    let mut options = HtmlRenderOptions::new(path, &config.redirect);
     options.markdown_options.smart_punctuation = config.smart_punctuation;
     options
 }

--- a/crates/mdbook-markdown/src/tests.rs
+++ b/crates/mdbook-markdown/src/tests.rs
@@ -16,7 +16,8 @@ fn escaped_special() {
 
 #[test]
 fn preserves_external_links() {
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(
         render_markdown("[example](https://www.rust-lang.org/)", &options),
         "<p><a href=\"https://www.rust-lang.org/\">example</a></p>\n"
@@ -25,7 +26,8 @@ fn preserves_external_links() {
 
 #[test]
 fn it_can_adjust_markdown_links() {
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(
         render_markdown("[example](example.md)", &options),
         "<p><a href=\"example.html\">example</a></p>\n"
@@ -55,13 +57,15 @@ fn it_can_wrap_tables() {
 </tbody></table>
 </div>
 "#.trim();
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(src, &options), out);
 }
 
 #[test]
 fn it_can_keep_quotes_straight() {
-    let mut options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let mut options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     options.markdown_options.smart_punctuation = false;
     assert_eq!(render_markdown("'one'", &options), "<p>'one'</p>\n");
 }
@@ -79,7 +83,8 @@ fn it_can_make_quotes_curly_except_when_they_are_in_code() {
 </code></pre>
 <p><code>'three'</code> ‘four’</p>
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 }
 
@@ -102,7 +107,8 @@ more text with spaces
 </code></pre>
 <p>more text with spaces</p>
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 }
 
@@ -115,7 +121,8 @@ fn rust_code_block_properties_are_passed_as_space_delimited_class() {
 
     let expected = r#"<pre><code class="language-rust,no_run,should_panic,property_3"></code></pre>
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 }
 
@@ -128,7 +135,8 @@ fn rust_code_block_properties_with_whitespace_are_passed_as_space_delimited_clas
 
     let expected = r#"<pre><code class="language-rust,,,,,no_run,,,should_panic,,,,property_3"></code></pre>
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 }
 
@@ -141,13 +149,15 @@ fn rust_code_block_without_properties_has_proper_html_class() {
 
     let expected = r#"<pre><code class="language-rust"></code></pre>
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 
     let input = r#"
 ```rust
 ```
 "#;
-    let options = HtmlRenderOptions::new(&Path::new(""));
+    let redirect = HashMap::new();
+    let options = HtmlRenderOptions::new(&Path::new(""), &redirect);
     assert_eq!(render_markdown(input, &options), expected);
 }

--- a/guide/src/misc/contributors.md
+++ b/guide/src/misc/contributors.md
@@ -20,5 +20,6 @@ shout-out to them!
 - Vivek Akupatni ([apatniv](https://github.com/apatniv))
 - Eric Huss ([ehuss](https://github.com/ehuss))
 - Josh Rotenberg ([joshrotenberg](https://github.com/joshrotenberg))
+- Songlin Jiang ([HollowMan6](https://github.com/HollowMan6))
 
 If you feel you're missing from this list, feel free to add yourself in a PR.

--- a/tests/testsuite/print/chapter_no_h1/expected/print.html
+++ b/tests/testsuite/print/chapter_no_h1/expected/print.html
@@ -1,5 +1,5 @@
-<h1 id="chapter-1"><a class="header" href="#chapter-1">Chapter 1</a></h1>
-<p>See <a href="chapter_2.html">chapter 2</a>.</p>
-<div style="break-before: page; page-break-before: always;"></div><p>See <a href="./chapter_2.html">this</a>.</p>
-<div style="break-before: page; page-break-before: always;"></div><h2 id="h2-instead"><a class="header" href="#h2-instead">H2 instead</a></h2>
+<div id="chapter_1"></div><h1 id="chapter_1-chapter-1"><a class="header" href="#chapter_1-chapter-1">Chapter 1</a></h1>
+<p>See <a href="#chapter_2">chapter 2</a>.</p>
+<div style="break-before: page; page-break-before: always;"></div><div id="chapter_2"></div><p>See <a href="#chapter_2">this</a>.</p>
+<div style="break-before: page; page-break-before: always;"></div><div id="h2-instead"></div><h2 id="h2-instead-h2-instead"><a class="header" href="#h2-instead-h2-instead">H2 instead</a></h2>
 <p>This has H2 instead of H1.</p>

--- a/tests/testsuite/print/duplicate_ids/expected/print.html
+++ b/tests/testsuite/print/duplicate_ids/expected/print.html
@@ -1,11 +1,11 @@
-<h1 id="chapter-1"><a class="header" href="#chapter-1">Chapter 1</a></h1>
-<h2 id="some-title"><a class="header" href="#some-title">Some title</a></h2>
-<p>See <a href="chapter_2.html#some-title">other</a></p>
-<p>See <a href="chapter_1.html#some-title">this</a></p>
-<p>See <a href="chapter_1.html#some-title">this anchor only</a></p>
-<div style="break-before: page; page-break-before: always;"></div><h1 id="chapter-2"><a class="header" href="#chapter-2">Chapter 2</a></h1>
-<h2 id="some-title-1"><a class="header" href="#some-title-1">Some title</a></h2>
-<p>See <a href="chapter_1.html#some-title">other</a></p>
-<p>See <a href="chapter_2.html#some-title">this</a></p>
-<p>See <a href="chapter_2.html#some-title">this anchor only</a></p>
-<p><a href="chapter_1.html#some-title">Works with HTML extension too</a></p>
+<div id="chapter_1"></div><h1 id="chapter_1-chapter-1"><a class="header" href="#chapter_1-chapter-1">Chapter 1</a></h1>
+<h2 id="chapter_1-some-title"><a class="header" href="#chapter_1-some-title">Some title</a></h2>
+<p>See <a href="#chapter_2-some-title">other</a></p>
+<p>See <a href="#chapter_1-some-title">this</a></p>
+<p>See <a href="#chapter_1-some-title">this anchor only</a></p>
+<div style="break-before: page; page-break-before: always;"></div><div id="chapter_2"></div><h1 id="chapter_2-chapter-2"><a class="header" href="#chapter_2-chapter-2">Chapter 2</a></h1>
+<h2 id="chapter_2-some-title"><a class="header" href="#chapter_2-some-title">Some title</a></h2>
+<p>See <a href="#chapter_1-some-title">other</a></p>
+<p>See <a href="#chapter_2-some-title">this</a></p>
+<p>See <a href="#chapter_2-some-title">this anchor only</a></p>
+<p><a href="#chapter_1-some-title">Works with HTML extension too</a></p>

--- a/tests/testsuite/print/relative_links/expected/print.html
+++ b/tests/testsuite/print/relative_links/expected/print.html
@@ -1,15 +1,15 @@
-<h1 id="first-chapter"><a class="header" href="#first-chapter">First Chapter</a></h1>
-<div style="break-before: page; page-break-before: always;"></div><h1 id="first-nested"><a class="header" href="#first-nested">First Nested</a></h1>
-<div style="break-before: page; page-break-before: always;"></div><h1 id="testing-relative-links-for-the-print-page"><a class="header" href="#testing-relative-links-for-the-print-page">Testing relative links for the print page</a></h1>
-<p>When we link to <a href="second/../first/nested.html">the first section</a>, it should work on
+<div id="first-index"></div><h1 id="first-index-first-chapter"><a class="header" href="#first-index-first-chapter">First Chapter</a></h1>
+<div style="break-before: page; page-break-before: always;"></div><div id="first-nested"></div><h1 id="first-nested-first-nested"><a class="header" href="#first-nested-first-nested">First Nested</a></h1>
+<div style="break-before: page; page-break-before: always;"></div><div id="second-nested"></div><h1 id="second-nested-testing-relative-links-for-the-print-page"><a class="header" href="#second-nested-testing-relative-links-for-the-print-page">Testing relative links for the print page</a></h1>
+<p>When we link to <a href="#first-nested">the first section</a>, it should work on
 both the print page and the non-print page.</p>
-<p>The same link should work <a href="second/../first/nested.html">with an html extension</a>.</p>
-<p>A <a href="second/nested.html#some-section">fragment link</a> should work.</p>
+<p>The same link should work <a href="#first-nested">with an html extension</a>.</p>
+<p>A <a href="#second-nested-some-section">fragment link</a> should work.</p>
 <p>Link <a href="second/../../std/foo/bar.html">outside</a>.</p>
 <p>Link <a href="second/../../std/foo/bar.html#panic">outside with anchor</a>.</p>
 <p><img src="second/../images/picture.png" alt="Some image" /></p>
-<p><a href="second/../first/nested.html">HTML Link</a></p>
+<p><a href="#first-nested">HTML Link</a></p>
 <img src="second/../images/picture.png" alt="raw html">
-<h2 id="some-section"><a class="header" href="#some-section">Some section</a></h2>
+<h2 id="second-nested-some-section"><a class="header" href="#second-nested-some-section">Some section</a></h2>
 <p><a href="https://example.com/foo.html#bar">Links with scheme shouldn’t be touched.</a></p>
-<p><a href="second/../images/not-html?arg1&arg2#with-anchor">Non-html link</a></p>
+<p><a href="#images-not-html?arg1&arg2-with-anchor">Non-html link</a></p>


### PR DESCRIPTION
Resolves #1736 

Let all the anchors id on the print page to have a path id prefix to
help locate.

e.g. bar/foo.md#abc -> #bar-foo-abc

Also append a dummy div to the start of the original page to make sure
that original page links without an anchor can also be located.

Signed-off-by: Hollow Man <hollowman@opensuse.org>