### PR TITLE
Fix `SummaryParser::parse_title()` consuming events (#1743)

### DIFF
--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -536,6 +536,10 @@ impl<'a> SummaryParser<'a> {
                 // Skip a HTML element such as a comment line.
                 Some(Event::Html(_)) => {}
                 // Otherwise, no title.
+                Some(ev) => {
+                    self.back(ev);
+                    return None;
+                }
                 _ => return None,
             }
         }
@@ -645,6 +649,15 @@ mod tests {
         let got = parser.parse_title().unwrap();
 
         assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn no_initial_title() {
+        let src = "[Link]()";
+        let mut parser = SummaryParser::new(src);
+
+        assert!(parser.parse_title().is_none());
+        assert!(matches!(parser.next_event(), Some(Event::Start(Tag::Paragraph))));
     }
 
     #[test]

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -659,7 +659,7 @@ mod tests {
         assert!(parser.parse_title().is_none());
         assert!(matches!(
             parser.next_event(),
-            Some(Event::Start(Tag::Paragraph)),
+            Some(Event::Start(Tag::Paragraph))
         ));
     }
 

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -657,7 +657,10 @@ mod tests {
         let mut parser = SummaryParser::new(src);
 
         assert!(parser.parse_title().is_none());
-        assert!(matches!(parser.next_event(), Some(Event::Start(Tag::Paragraph))));
+        assert!(matches!(
+            parser.next_event(),
+            Some(Event::Start(Tag::Paragraph)),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #1743

The issue can be found while looking and summary parsing output:

```markdown
#
- [First](./first.md)
  - [Nested](./nested.md)
- [Second](./second.md)
```

```
RUST_LOG=mdbook::book::summary=TRACE cargo run -- build
```

```
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Next event: Some(Start(Heading(H1, None, [])))
2022-02-11 11:52:10 [DEBUG] (mdbook::book::summary): Found a h1 in the SUMMARY
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Next event: Some(End(Heading(H1, None, [])))
2022-02-11 11:52:10 [DEBUG] (mdbook::book::summary): Parsing prefix items
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:10 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:10 [DEBUG] (mdbook::book::summary): Parsing numbered chapters at level 0
...
```

---

```markdown
- [First](./first.md)
  - [Nested](./nested.md)
- [Second](./second.md)
```

```
RUST_LOG=mdbook::book::summary=TRACE cargo run -- build
```

```
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:46 [DEBUG] (mdbook::book::summary): Parsing prefix items
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(Item))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(Link(Inline, Borrowed("./first.md"), Borrowed(""))))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Text(Borrowed("First")))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(End(Link(Inline, Borrowed("./first.md"), Borrowed(""))))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 11:52:46 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 11:52:46 [DEBUG] (mdbook::book::summary): Parsing numbered chapters at level 0
...
```

By looking at first 2 lines of the output, we can see that `Some(Start(List(None)))` event isn't pushed back and so is skipped. This causes parser to see `- [First](./first.md)` as `[First](./first.md)` and so interprets it as prefix chapter.

After applying a fix we can see following output:

```
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 12:16:38 [DEBUG] (mdbook::book::summary): Parsing prefix items
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Next event: Some(Start(List(None)))
2022-02-11 12:16:38 [TRACE] (mdbook::book::summary): Back: Start(List(None))
2022-02-11 12:16:38 [DEBUG] (mdbook::book::summary): Parsing numbered chapters at level 0
...
```