### PR TITLE
Open up support for alternative playground languages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -631,7 +631,7 @@ pub struct Playground {
     /// Display line numbers on playground snippets. Default: `false`.
     pub line_numbers: bool,
     /// Set's the language the playground will work with
-    /// TODO: Turn this into an array when there's support for multiple languages
+    /// TODO: Use an array when there's support for multiple languages simultaneously
     pub language: String,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -630,6 +630,9 @@ pub struct Playground {
     pub copy_js: bool,
     /// Display line numbers on playground snippets. Default: `false`.
     pub line_numbers: bool,
+    /// Set's the language the playground will work with
+    /// TODO: Turn this into an array when there's support for multiple languages
+    pub language: String,
 }
 
 impl Default for Playground {
@@ -639,6 +642,7 @@ impl Default for Playground {
             copyable: true,
             copy_js: true,
             line_numbers: false,
+            language: "rust".to_string(),
         }
     }
 }
@@ -748,6 +752,7 @@ mod tests {
         [output.html.playground]
         editable = true
         editor = "ace"
+        language = "rust"
 
         [output.html.redirect]
         "index.html" = "overview.html"
@@ -781,6 +786,7 @@ mod tests {
             copyable: true,
             copy_js: true,
             line_numbers: false,
+            language: "rust".to_string(),
         };
         let html_should_be = HtmlConfig {
             curly_quotes: true,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -843,6 +843,7 @@ fn add_playground_pre(
         .into_owned()
 }
 
+/// Ensures proper formatting specifically for rust code
 fn add_playground_pre_rust(
     playground_config: &Playground,
     edition: Option<RustEdition>,


### PR DESCRIPTION
This PR opens up the ability for the playground to run code for languages other than rust. 

It adds an option to set which language is "playground-able" in `book.toml`, and then uses that config option to choose whether the html `pre` blocks and friends should be wrapped around that code. Overall, it's a pretty minor change, but this allows others languages with playgrounds (e.g: purescript) to have active code blocks in mdbook. 

(It looks like the remainder of the heavy lifting to implement the playground for other languages rests in the hands of an alternative `book.js` via `mdbook init --theme`.)

Related to #350 and purescript-contrib/purescript-book#91

Im happy to make changes if anything seems wrong. Thanks!