### PR TITLE
update regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 memchr = "2.0"
 opener = "0.5"
 pulldown-cmark = { version = "0.9.1", default-features = false }
-regex = "1.0.0"
+regex = "1.5.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Update regex to `1.5.5` due to [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)