### PR TITLE
livereload uses host, port and HTTP(S) protocol of current page

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -62,11 +62,10 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     let address = format!("{}:{}", hostname, port);
 
-    let livereload_url = format!("ws://{}/{}", address, LIVE_RELOAD_ENDPOINT);
     let update_config = |book: &mut MDBook| {
         book.config
-            .set("output.html.livereload-url", &livereload_url)
-            .expect("livereload-url update failed");
+            .set("output.html.live-reload-endpoint", &LIVE_RELOAD_ENDPOINT)
+            .expect("live-reload-endpoint update failed");
         if let Some(dest_dir) = args.value_of("dest-dir") {
             book.config.build.build_dir = dest_dir.into();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,16 +531,16 @@ pub struct HtmlConfig {
     pub cname: Option<String>,
     /// Edit url template, when set shows a "Suggest an edit" button for
     /// directly jumping to editing the currently viewed page.
-    /// Contains {path} that is replaced with chapter source file path
+    /// Contains {path} that is replaced with chapter source file path[[[[
     pub edit_url_template: Option<String>,
-    /// This is used as a bit of a workaround for the `mdbook serve` command.
-    /// Basically, because you set the websocket port from the command line, the
-    /// `mdbook serve` command needs a way to let the HTML renderer know where
-    /// to point livereloading at, if it has been enabled.
+    /// Endpoint of websocket, for livereload usage. Value loaded from .toml file
+    /// is ignored, because our code overrides this field with the value [`LIVE_RELOAD_ENDPOINT`]
+    ///
+    /// [`LIVE_RELOAD_ENDPOINT`]: cmd::serve::LIVE_RELOAD_ENDPOINT
     ///
     /// This config item *should not be edited* by the end user.
     #[doc(hidden)]
-    pub livereload_url: Option<String>,
+    pub live_reload_endpoint: Option<String>,
     /// The mapping from old pages to new pages/URLs to use when generating
     /// redirects.
     pub redirect: HashMap<String, String>,
@@ -569,7 +569,7 @@ impl Default for HtmlConfig {
             input_404: None,
             site_url: None,
             cname: None,
-            livereload_url: None,
+            live_reload_endpoint: None,
             redirect: HashMap::new(),
         }
     }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -606,8 +606,11 @@ fn make_data(
     if theme.favicon_svg.is_some() {
         data.insert("favicon_svg".to_owned(), json!("favicon.svg"));
     }
-    if let Some(ref livereload) = html_config.livereload_url {
-        data.insert("livereload".to_owned(), json!(livereload));
+    if let Some(ref live_reload_endpoint) = html_config.live_reload_endpoint {
+        data.insert(
+            "live_reload_endpoint".to_owned(),
+            json!(live_reload_endpoint),
+        );
     }
 
     let default_theme = match html_config.default_theme {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -219,10 +219,12 @@
 
         </div>
 
-        {{#if livereload}}
+        {{#if live_reload_endpoint}}
         <!-- Livereload script (if served using the cli tool) -->
         <script type="text/javascript">
-            var socket = new WebSocket("{{{livereload}}}");
+            const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const wsAddress = wsProtocol + "//" + location.host + "/" + "{{{live_reload_endpoint}}}";
+            const socket = new WebSocket(wsAddress);
             socket.onmessage = function (event) {
                 if (event.data === "reload") {
                     socket.close();


### PR DESCRIPTION
livereload uses host&port of current page; livereload works with a HTTPS site

Closes #1698