### PR TITLE
add option to enable inline math $…$

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -493,6 +493,8 @@ pub struct HtmlConfig {
     pub curly_quotes: bool,
     /// Should mathjax be enabled?
     pub mathjax_support: bool,
+    /// Should mathjax enable `$…$` inline math? This option has no effect if mathjax is not enabled.
+    pub inline_math_dollar_sign: bool,
     /// Whether to fonts.css and respective font files to the output directory.
     pub copy_fonts: bool,
     /// An optional google analytics code.
@@ -554,6 +556,7 @@ impl Default for HtmlConfig {
             preferred_dark_theme: None,
             curly_quotes: false,
             mathjax_support: false,
+            inline_math_dollar_sign: false,
             copy_fonts: true,
             google_analytics: None,
             additional_css: Vec::new(),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -634,6 +634,10 @@ fn make_data(
         data.insert("mathjax_support".to_owned(), json!(true));
     }
 
+    if html_config.inline_math_dollar_sign {
+        data.insert("inline_math_dollar_sign".to_owned(), json!(true));
+    }
+
     if html_config.copy_fonts {
         data.insert("copy_fonts".to_owned(), json!(true));
     }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -52,6 +52,12 @@
         {{#if mathjax_support}}
         <!-- MathJax -->
         <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+            {{#if inline_math_dollar_sign}}
+            <!-- use $...$ for inline math -->
+            <script type="text/x-mathjax-config">
+                MathJax.Hub.Config({ tex2jax: {inlineMath: [["$","$"]]} })
+            </script>
+            {{/if}}
         {{/if}}
     </head>
     <body>


### PR DESCRIPTION
# add option to enable inline math `$…$`

We only support `\\(…\\)` for inline math right now. This PR adds an option to enable using `$…$` for inline math.

## usage

add this following to `book.toml` to enable this feature:

```toml
[output.html]
mathjax-support = true
inline-math-dollar-sign = true
```

### unwanted usage

If the user enables this option without enabling MathJax support, nothing happens:

```toml
[output.html]
inline-math-dollar-sign = true
```

## benefits

This will be helpful for writers that want to use a lot of inline math in their books, especially if it is a Mathematics book.

```text
In equation [1], $x$ is …, $y$ is …
```

Looks much more friendly than:

```text
In equation [1], \\(x\\) is …, \\(y\\) is …
```

It is also much easier to type.

Some extensions (for example, Markdown All in One for VSCode) gives a keyboard shortcut to add two `$$` and put your cursor in the middle. This is very convenient.

## drawback

If this option is enabled, the user will need to escape all their regular dollar signs:

```test
\$
```

Therefore, this option is set to `false` by default.