### PR TITLE
tests/cli: ignore user's RUST_LOG= environment variable in tests

### DIFF
--- a/tests/cli/build.rs
+++ b/tests/cli/build.rs
@@ -1,6 +1,5 @@
+use crate::cli::cmd::mdbook_cmd;
 use crate::dummy_book::DummyBook;
-
-use assert_cmd::Command;
 
 #[test]
 fn mdbook_cli_dummy_book_generates_index_html() {
@@ -9,7 +8,7 @@ fn mdbook_cli_dummy_book_generates_index_html() {
     // doesn't exist before
     assert!(!temp.path().join("book").exists());
 
-    let mut cmd = Command::cargo_bin("mdbook").unwrap();
+    let mut cmd = mdbook_cmd();
     cmd.arg("build").current_dir(temp.path());
     cmd.assert()
         .success()

--- a/tests/cli/cmd.rs
+++ b/tests/cli/cmd.rs
@@ -1,0 +1,7 @@
+use assert_cmd::Command;
+
+pub(crate) fn mdbook_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("mdbook").unwrap();
+    cmd.env_remove("RUST_LOG");
+    cmd
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,2 +1,3 @@
 mod build;
+mod cmd;
 mod test;

--- a/tests/cli/test.rs
+++ b/tests/cli/test.rs
@@ -1,13 +1,13 @@
+use crate::cli::cmd::mdbook_cmd;
 use crate::dummy_book::DummyBook;
 
-use assert_cmd::Command;
 use predicates::boolean::PredicateBooleanExt;
 
 #[test]
 fn mdbook_cli_can_correctly_test_a_passing_book() {
     let temp = DummyBook::new().with_passing_test(true).build().unwrap();
 
-    let mut cmd = Command::cargo_bin("mdbook").unwrap();
+    let mut cmd = mdbook_cmd();
     cmd.arg("test").current_dir(temp.path());
     cmd.assert().success()
       .stderr(predicates::str::is_match(r##"Testing file: "([^"]+)[\\/]README.md""##).unwrap())
@@ -22,7 +22,7 @@ fn mdbook_cli_can_correctly_test_a_passing_book() {
 fn mdbook_cli_detects_book_with_failing_tests() {
     let temp = DummyBook::new().with_passing_test(false).build().unwrap();
 
-    let mut cmd = Command::cargo_bin("mdbook").unwrap();
+    let mut cmd = mdbook_cmd();
     cmd.arg("test").current_dir(temp.path());
     cmd.assert().failure()
       .stderr(predicates::str::is_match(r##"Testing file: "([^"]+)[\\/]README.md""##).unwrap())


### PR DESCRIPTION
nixpkgs build system sets `RUST_LOG=` (empty value) by default.
This switches `mdBook` into warnings+ mode (instead of info+).

This causes the following tests to fail:

    $ RUST_LOG= cargo test --test cli_tests
    ...
    cli::test::mdbook_cli_can_correctly_test_a_passing_book
    cli::test::mdbook_cli_detects_book_with_failing_tests
    cli::build::mdbook_cli_dummy_book_generates_index_html

The change drops RUST_LOG= entry.