### PR TITLE
User Guide: Fix typo 'mbdook' to 'mdbook'

### DIFF
--- a/guide/src/guide/creating.md
+++ b/guide/src/guide/creating.md
@@ -97,7 +97,7 @@ So if you have images or other static files, just include them somewhere in the 
 
 Once you've written your book, you may want to host it somewhere for others to view.
 The first step is to build the output of the book.
-This can be done with the `mbdook build` command in the same directory where the `book.toml` file is located:
+This can be done with the `mdbook build` command in the same directory where the `book.toml` file is located:
 
 ```sh
 mdbook build


### PR DESCRIPTION
Hi, first-time contributor here 👋 

I noticed that there was a typo within the [Publishing A Book](https://rust-lang.github.io/mdBook/guide/creating.html#publishing-a-book) section of the mdBook User Guide and decided that it would be an easy fix! This commit fixes the typo `mbdook` to `mdbook`

Hope that this is okay!