### PR TITLE
Don't try to render summary links as markdown.

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use super::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 use crate::config::BuildConfig;
 use crate::errors::*;
+use crate::utils::bracket_escape;
 
 /// Load a book into memory from its `src/` directory.
 pub fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> {
@@ -53,7 +54,7 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
                     let mut f = File::create(&filename).with_context(|| {
                         format!("Unable to create missing file: {}", filename.display())
                     })?;
-                    writeln!(f, "# {}", link.name)?;
+                    writeln!(f, "# {}", bracket_escape(&link.name))?;
                 }
             }
 

--- a/tests/dummy_book/summary-formatting/SUMMARY.md
+++ b/tests/dummy_book/summary-formatting/SUMMARY.md
@@ -1,0 +1,6 @@
+# Summary formatting tests
+
+- [*Italic* `code` \*escape\* \`escape2\`](formatted-summary.md)
+- [Soft
+line break](soft.md)
+- [\<escaped tag\>](escaped-tag.md)

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -621,6 +621,42 @@ fn remove_absolute_components(path: &Path) -> impl Iterator<Item = Component> + 
     })
 }
 
+/// Checks formatting of summary names with inline elements.
+#[test]
+fn summary_with_markdown_formatting() {
+    let temp = DummyBook::new().build().unwrap();
+    let mut cfg = Config::default();
+    cfg.set("book.src", "summary-formatting").unwrap();
+    let md = MDBook::load_with_config(temp.path(), cfg).unwrap();
+    md.build().unwrap();
+
+    let rendered_path = temp.path().join("book/formatted-summary.html");
+    assert_contains_strings(
+        rendered_path,
+        &[
+            r#"<a href="formatted-summary.html" class="active"><strong aria-hidden="true">1.</strong> Italic code *escape* `escape2`</a>"#,
+            r#"<a href="soft.html"><strong aria-hidden="true">2.</strong> Soft line break</a>"#,
+            r#"<a href="escaped-tag.html"><strong aria-hidden="true">3.</strong> &lt;escaped tag&gt;</a>"#,
+        ],
+    );
+
+    let generated_md = temp.path().join("summary-formatting/formatted-summary.md");
+    assert_eq!(
+        fs::read_to_string(generated_md).unwrap(),
+        "# Italic code *escape* `escape2`\n"
+    );
+    let generated_md = temp.path().join("summary-formatting/soft.md");
+    assert_eq!(
+        fs::read_to_string(generated_md).unwrap(),
+        "# Soft line break\n"
+    );
+    let generated_md = temp.path().join("summary-formatting/escaped-tag.md");
+    assert_eq!(
+        fs::read_to_string(generated_md).unwrap(),
+        "# &lt;escaped tag&gt;\n"
+    );
+}
+
 #[cfg(feature = "search")]
 mod search {
     use crate::dummy_book::DummyBook;


### PR DESCRIPTION
Links in SUMMARY.md can have trouble rendering correctly if they include any sort of markdown elements. A particular example this tries to fix is escaping of asterisks like `[\*foo\*]`. Previously, the summary parser would strip out all the markdown formatting, and then the TOC renderer would then try to re-render the now stripped chapter name.  With escaped asterisks, the escaping is removed, leaving italics to be rendered.

It looks like long ago it was intended this was to handle `code` blocks in summary names. However, that hasn't worked for a long time.

There was some discussion in #70 about how this should work, and whether or not code blocks should be rendered. Properly rendering the link name with things like `code` blocks is a difficult problem, so I'm punting on that for now. The only safe thing to do would be to grab the raw text from the original markdown, which is awkward to do with pulldown_cmark.

This also fixes the create_missing pages to escape the title properly if the chapter name has angled brackets.
