### PR TITLE
bail! in render() if specified theme directory does not exist

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -481,7 +481,13 @@ impl Renderer for HtmlHandlebars {
         let mut handlebars = Handlebars::new();
 
         let theme_dir = match html_config.theme {
-            Some(ref theme) => ctx.root.join(theme),
+            Some(ref theme) => {
+                let dir = ctx.root.join(theme);
+                if !dir.is_dir() {
+                    bail!("theme dir {} does not exist", dir.display());
+                }
+                dir
+            }
             None => ctx.root.join("theme"),
         };
 


### PR DESCRIPTION
This PR fixes #1756.

With the following config,
```toml
#book.toml

[output.html]
theme = "./xxx"
```
if `./xxx` directory does not exist, an error message will be logged:
```log
#log

2022-04-25 02:19:12 [INFO] (mdbook::book): Book building has started
2022-04-25 02:19:12 [INFO] (mdbook::book): Running the html backend
2022-04-25 02:19:12 [ERROR] (mdbook::config): theme dir "./xxx" does not exist
2022-04-25 02:19:12 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2022-04-25 02:19:12 [INFO] (warp::server): Server::run; addr=127.0.0.1:3000
2022-04-25 02:19:12 [INFO] (warp::server): listening on http://127.0.0.1:3000 
2022-04-25 02:19:12 [ERROR] (mdbook::config): theme dir "./xxx" does not exist
2022-04-25 02:19:12 [INFO] (mdbook::cmd::watch): Listening for changes...
```
