### PR TITLE
Add '--is-dark-theme' css variable to support dynamic css-only dark theme image modifications

### DIFF
--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -48,6 +48,8 @@
     --searchresults-border-color: #888;
     --searchresults-li-bg: #252932;
     --search-mark-bg: #e3b171;
+
+    --is-dark-theme: 1;
 }
 
 .coal {
@@ -88,6 +90,8 @@
     --searchresults-border-color: #98a3ad;
     --searchresults-li-bg: #2b2b2f;
     --search-mark-bg: #355c7d;
+
+    --is-dark-theme: 1;
 }
 
 .light {
@@ -128,6 +132,8 @@
     --searchresults-border-color: #888;
     --searchresults-li-bg: #e4f2fe;
     --search-mark-bg: #a2cff5;
+
+    --is-dark-theme: 0;
 }
 
 .navy {
@@ -168,6 +174,8 @@
     --searchresults-border-color: #5c5c68;
     --searchresults-li-bg: #242430;
     --search-mark-bg: #a2cff5;
+
+    --is-dark-theme: 1;
 }
 
 .rust {
@@ -208,6 +216,8 @@
     --searchresults-border-color: #888;
     --searchresults-li-bg: #dec2a2;
     --search-mark-bg: #e69f67;
+
+    --is-dark-theme: 0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -249,5 +259,7 @@
         --searchresults-border-color: #98a3ad;
         --searchresults-li-bg: #2b2b2f;
         --search-mark-bg: #355c7d;
+
+        --is-dark-theme: 1;
     }
 }


### PR DESCRIPTION
This PR adds a `--is-dark-theme` variable to each theme. This is useful when you have images or diagrams that you want to look nice in both light and dark themes. This is kind of a hack and doesn't help in situations where you want to switch between different dark-theme and light-theme images, but on the other hand this is a very simple way to help support dynamic light/dark theme images with very little change. Anyways, just a suggestion :)

For example, in the markdown:

```html
<img class="color-adapting-image" src="assets/my-diagram.svg">
```

Then in `book.toml`:

```toml
[output.html]
additional-css = ["custom.css"]
```

And in `custom.css`:

```css
img.color-adapting-image,
figure.color-adapting-image img {
    filter: invert(calc(85% * var(--is-dark-theme))) hue-rotate(calc(180deg * var(--is-dark-theme)));
}
```

![theme-example](https://user-images.githubusercontent.com/3708797/167031324-21c4f11c-41dc-4839-8444-607486665387.gif)