### PR TITLE
Add absolute links support

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -109,6 +109,7 @@ edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path
 site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"
+use-site-url-as-root = false
 ```
 
 The following configuration options are available:

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -164,6 +164,7 @@ The following configuration options are available:
   navigation links and script/css imports in the 404 file work correctly, even when accessing
   urls in subdirectories. Defaults to `/`. If `site-url` is set,
   make sure to use document relative links for your assets, meaning they should not start with `/`.
+- **use-site-url-as-root:** Prepend the `site_url` in links with absolute path.
 - **cname:** The DNS subdomain or apex domain at which your book will be hosted.
   This string will be written to a file named CNAME in the root of your site, as
   required by GitHub Pages (see [*Managing a custom domain for your GitHub Pages

--- a/src/config.rs
+++ b/src/config.rs
@@ -582,6 +582,8 @@ pub struct HtmlConfig {
     pub input_404: Option<String>,
     /// Absolute url to site, used to emit correct paths for the 404 page, which might be accessed in a deeply nested directory
     pub site_url: Option<String>,
+    /// Prepend the `site_url` in links with absolute path.
+    pub use_site_url_as_root: bool,
     /// The DNS subdomain or apex domain at which your book will be hosted. This
     /// string will be written to a file named CNAME in the root of your site,
     /// as required by GitHub Pages (see [*Managing a custom domain for your
@@ -632,6 +634,7 @@ impl Default for HtmlConfig {
             edit_url_template: None,
             input_404: None,
             site_url: None,
+            use_site_url_as_root: false,
             cname: None,
             live_reload_endpoint: None,
             redirect: HashMap::new(),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -58,7 +58,7 @@ impl HtmlHandlebars {
         }
 
         let content = if ctx.html_config.use_site_url_as_root {
-            utils::render_markdown_with_path(
+            utils::render_markdown_with_abs_path(
                 &ch.content,
                 ctx.html_config.smart_punctuation(),
                 None,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -62,7 +62,7 @@ impl HtmlHandlebars {
                 &ch.content,
                 ctx.html_config.smart_punctuation(),
                 None,
-                ctx.html_config.site_url.as_ref(),
+                ctx.html_config.site_url.as_deref(),
             )
         } else {
             utils::render_markdown(&ch.content, ctx.html_config.smart_punctuation())
@@ -72,7 +72,6 @@ impl HtmlHandlebars {
             &ch.content,
             ctx.html_config.smart_punctuation(),
             Some(path),
-            None,
         );
         if !ctx.is_index && ctx.html_config.print.page_break {
             // Add page break between chapters

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -57,12 +57,22 @@ impl HtmlHandlebars {
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));
         }
 
-        let content = utils::render_markdown(&ch.content, ctx.html_config.smart_punctuation());
+        let content = if ctx.html_config.use_site_url_as_root {
+            utils::render_markdown_with_path(
+                &ch.content,
+                ctx.html_config.smart_punctuation(),
+                None,
+                ctx.html_config.site_url.as_ref(),
+            )
+        } else {
+            utils::render_markdown(&ch.content, ctx.html_config.smart_punctuation())
+        };
 
         let fixed_content = utils::render_markdown_with_path(
             &ch.content,
             ctx.html_config.smart_punctuation(),
             Some(path),
+            None,
         );
         if !ctx.is_index && ctx.html_config.print.page_break {
             // Add page break between chapters

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -613,6 +613,88 @@ more text with spaces
         }
     }
 
+    mod render_markdown_with_abs_path {
+        use super::super::render_markdown_with_abs_path;
+        use std::path::Path;
+
+        #[test]
+        fn preserves_external_links() {
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](https://www.rust-lang.org/)",
+                    false,
+                    None,
+                    Some(&"ABS_PATH".to_string())
+                ),
+                "<p><a href=\"https://www.rust-lang.org/\">example</a></p>\n"
+            );
+        }
+
+        #[test]
+        fn replace_root_links() {
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](/testing)",
+                    false,
+                    None,
+                    Some(&"ABS_PATH".to_string())
+                ),
+                "<p><a href=\"ABS_PATH/testing\">example</a></p>\n"
+            );
+        }
+
+        #[test]
+        fn replace_root_links_using_path() {
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](bar.md)",
+                    false,
+                    Some(Path::new("foo/chapter.md")),
+                    Some(&"ABS_PATH".to_string())
+                ),
+                "<p><a href=\"ABS_PATH/foo/bar.html\">example</a></p>\n"
+            );
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](/bar.md)",
+                    false,
+                    Some(Path::new("foo/chapter.md")),
+                    Some(&"ABS_PATH".to_string())
+                ),
+                "<p><a href=\"ABS_PATH/foo/bar.html\">example</a></p>\n"
+            );
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](/bar.html)",
+                    false,
+                    Some(Path::new("foo/chapter.md")),
+                    None
+                ),
+                "<p><a href=\"foo/bar.html\">example</a></p>\n"
+            );
+        }
+
+        #[test]
+        fn preserves_relative_links() {
+            assert_eq!(
+                render_markdown_with_abs_path(
+                    "[example](../testing)",
+                    false,
+                    None,
+                    Some(&"ABS_PATH".to_string())
+                ),
+                "<p><a href=\"../testing\">example</a></p>\n"
+            );
+        }
+
+        #[test]
+        fn preserves_root_links() {
+            assert_eq!(
+                render_markdown_with_abs_path("[example](/testing)", false, None, None),
+                "<p><a href=\"/testing\">example</a></p>\n"
+            );
+        }
+    }
     #[allow(deprecated)]
     mod id_from_content {
         use super::super::id_from_content;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -230,7 +230,6 @@ pub fn render_markdown_with_path(text: &str, curly_quotes: bool, path: Option<&P
     render_markdown_with_abs_path(text, curly_quotes, path, None)
 }
 
-
 /// Renders markdown to HTML.
 ///
 /// `path` should only be set if this is being generated for the consolidated
@@ -651,12 +650,7 @@ more text with spaces
         #[test]
         fn replace_root_links() {
             assert_eq!(
-                render_markdown_with_abs_path(
-                    "[example](/testing)",
-                    false,
-                    None,
-                    Some("ABS_PATH")
-                ),
+                render_markdown_with_abs_path("[example](/testing)", false, None, Some("ABS_PATH")),
                 "<p><a href=\"ABS_PATH/testing\">example</a></p>\n"
             );
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -147,7 +147,7 @@ fn adjust_links<'a>(event: Event<'a>, path: Option<&Path>, abs_url: Option<&str>
                     );
                 }
             }
-            return CowStr::from(format!("{}", fixed_link));
+            return CowStr::from(fixed_link.to_string());
         }
         dest
     }


### PR DESCRIPTION
### Prepend the `site-url` in links with absolute path.

##### Problem:
If we host in the book in a sub page we lost the references for the relative root. We already have the `site-url` in configs, but we do not use it. If we want to link a page in the root of the book, we need to prepend a lot of `../` to reach the actual root, and if we  move pages these relative refs could lead us to dead links. 


##### Proposal
Add a new flag `use-site-url-as-root` in the `HtmlConfig`.
The changes should have backward compatibility, we'll need to enable the `use-site-url-as-root` flag in `[output.html]` section inside the `book.toml` file to use the new feature.

#### TODO: 

- [x] check if other type of links were affected by the changes 


Closes: #1764