### PR TITLE
Allow folding draft chapters with children by interacting with their names

### DIFF
--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -116,8 +116,12 @@ impl HelperDef for RenderToc {
                 continue;
             }
 
+            let is_foldable = item.get("has_sub_items").map_or(false, |flag| {
+                fold_enable && flag.parse::<bool>().unwrap_or_default()
+            });
+
             // Link
-            let path_exists: bool;
+            let has_link: bool;
             match item.get("path") {
                 Some(path) if !path.is_empty() => {
                     out.write("<a href=\"")?;
@@ -139,11 +143,15 @@ impl HelperDef for RenderToc {
                     }
 
                     out.write(">")?;
-                    path_exists = true;
+                    has_link = true;
+                }
+                _ if is_foldable => {
+                    out.write("<a class=\"toggle\">")?;
+                    has_link = true;
                 }
                 _ => {
                     out.write("<div>")?;
-                    path_exists = false;
+                    has_link = false;
                 }
             }
 
@@ -160,18 +168,15 @@ impl HelperDef for RenderToc {
                 out.write(&bracket_escape(name))?
             }
 
-            if path_exists {
+            if has_link {
                 out.write("</a>")?;
             } else {
                 out.write("</div>")?;
             }
 
             // Render expand/collapse toggle
-            if let Some(flag) = item.get("has_sub_items") {
-                let has_sub_items = flag.parse::<bool>().unwrap_or_default();
-                if fold_enable && has_sub_items {
-                    out.write("<a class=\"toggle\"><div>❱</div></a>")?;
-                }
+            if is_foldable {
+                out.write("<a class=\"toggle\"><div>❱</div></a>")?;
             }
             out.write("</li>")?;
         }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -446,15 +446,18 @@ ul#searchresults span.teaser em {
 
 .chapter li > a.toggle {
     cursor: pointer;
+}
+
+.chapter li > a.toggle:not(:first-child) {
     display: block;
     margin-left: auto;
     padding: 0 10px;
-    user-select: none;
-    opacity: 0.68;
 }
 
 .chapter li > a.toggle div {
     transition: transform 0.5s;
+    user-select: none;
+    opacity: 0.68;
 }
 
 /* collapse the section */

--- a/test_book/book.toml
+++ b/test_book/book.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [output.html]
 mathjax-support = true
+fold = { enable = true, level = 1 }
 
 [output.html.playground]
 editable = true

--- a/test_book/src/SUMMARY.md
+++ b/test_book/src/SUMMARY.md
@@ -5,7 +5,9 @@
 ---
 
 - [Introduction](README.md)
-- [Draft Chapter]()
+- [Draft Chapter with children]()
+  - [Collapsed draft chapter with children]()
+    - [The parent chapters can be collapsed by interacting with their titles in addition to the arrow]()
 
 # Actual Markdown Tag Examples
 


### PR DESCRIPTION
This PR allows links to draft chapters that have children elements to function like the "arrow" to toggle collapsing children items when clicked. This includes styling them as "real" links to highlight their interactivity, and turning the arrow when clicked.

This has been requested by some of my readers for the "Graphics" link in https://eldred.fr/gb-asm-tutorial.

This is implemented by outputting links with the `toggle` class instead of `div`s for chapters fulfilling the aforementioned criteria, removing the styling and adding the toggle functionality.

I did not add any documentation, as this is purely a UI change, and this part of the UI is not documented anywhere in the first place.