### PR TITLE
Fix up "index page" functionality

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -540,7 +540,8 @@ impl Renderer for HtmlHandlebars {
                 chapter_titles: &ctx.chapter_titles,
             };
             self.render_item(item, ctx, &mut print_content)?;
-            is_index = false;
+            // Only the first non-draft chapter item should be treated as the "index"
+            is_index &= !matches!(item, BookItem::Chapter(ch) if !ch.is_draft_chapter());
         }
 
         // Render 404 page

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -116,7 +116,7 @@ impl HtmlHandlebars {
         if ctx.is_index {
             ctx.data.insert("path".to_owned(), json!("index.md"));
             ctx.data.insert("path_to_root".to_owned(), json!(""));
-            ctx.data.insert("is_index".to_owned(), json!("true"));
+            ctx.data.insert("is_index".to_owned(), json!(true));
             let rendered_index = ctx.handlebars.render("index", &ctx.data)?;
             let rendered_index =
                 self.post_process(rendered_index, &ctx.html_config.playground, ctx.edition);

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -57,6 +57,11 @@ impl HelperDef for RenderToc {
         out.write("<ol class=\"chapter\">")?;
 
         let mut current_level = 1;
+        // The "index" page, which has this attribute set, is supposed to alias the first chapter in
+        // the book, i.e. the first link. There seems to be no easy way to determine which chapter
+        // the "index" is aliasing from within the renderer, so this is used instead to force the
+        // first link to be active. See further below.
+        let mut is_first_chapter = ctx.data().get("is_index").is_some();
 
         for item in chapters {
             // Spacer
@@ -130,7 +135,8 @@ impl HelperDef for RenderToc {
                 out.write(&tmp)?;
                 out.write("\"")?;
 
-                if path == &current_path {
+                if path == &current_path || is_first_chapter {
+                    is_first_chapter = false;
                     out.write(" class=\"active\"")?;
                 }
 

--- a/tests/dummy_book/index_html_test/SUMMARY.md
+++ b/tests/dummy_book/index_html_test/SUMMARY.md
@@ -1,0 +1,11 @@
+# Summary
+
+---
+
+- [None of these should be treated as the "index chapter"]()
+
+# Part 1
+
+- [Not this either]()
+- [Chapter 1](./chapter_1.md)
+- [And not this]()

--- a/tests/dummy_book/index_html_test/chapter_1.md
+++ b/tests/dummy_book/index_html_test/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -15,7 +15,7 @@ use select::predicate::{Class, Name, Predicate};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 use tempfile::Builder as TempFileBuilder;
@@ -476,23 +476,10 @@ fn first_chapter_is_copied_as_index_even_if_not_first_elem() {
     let md = MDBook::load_with_config(temp.path(), cfg).unwrap();
     md.build().unwrap();
 
-    // In theory, just reading the entire files into memory and comparing is sufficient for *testing*,
-    // but since the files are temporary and get deleted when the test completes, we'll want to print
-    // the differences on failure.
-    // We could invoke `diff` on the files on failure, but that may not be portable (hi, Windows...)
-    // so we'll do the job ourselves—potentially a bit sloppily, but that can always be piped into
-    // `diff` manually afterwards.
-    let book_path = temp.path().join("book");
-    let read_file = |path: &str| {
-        let mut buf = String::new();
-        fs::File::open(book_path.join(path))
-            .with_context(|| format!("Failed to read {}", path))
-            .unwrap()
-            .read_to_string(&mut buf)
-            .unwrap();
-        buf
-    };
-    pretty_assertions::assert_eq!(read_file("chapter_1.html"), read_file("index.html"));
+    let root = temp.path().join("book");
+    let chapter = fs::read_to_string(root.join("chapter_1.html")).expect("read chapter 1");
+    let index = fs::read_to_string(root.join("index.html")).expect("read index");
+    pretty_assertions::assert_eq!(chapter, index);
 }
 
 #[test]


### PR DESCRIPTION
- Fixes #1814 by only marking the first non-draft chapter as the "index" page, and adds a test for that
- Makes the link to the first chapter active in the "index" page, improving consistency (and making the aforementioned test pass without hacks)

Additionally, I would've liked to document that "index page" functionality, but I couldn't find any place for it in the documentation.