### PR TITLE
Always open index page with `serve --open`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,8 +1,7 @@
-use crate::{first_chapter, get_book_dir, open};
+use crate::{get_book_dir, open};
 use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
 use mdbook::MDBook;
-use std::path::Path;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'help>() -> App<'help> {
@@ -39,15 +38,12 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     if args.is_present("open") {
         // FIXME: What's the right behaviour if we don't use the HTML renderer?
-        match first_chapter(&book)
-            .map(|path| book.build_dir_for("html").join(path).with_extension("html"))
-        {
-            Some(path) if Path::new(&path).exists() => open(path),
-            _ => {
-                error!("No chapter available to open");
-                std::process::exit(1)
-            }
+        let path = book.build_dir_for("html").join("index.html");
+        if !path.exists() {
+            error!("No chapter available to open");
+            std::process::exit(1)
         }
+        open(path);
     }
 
     Ok(())

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "watch")]
 use super::watch;
-use crate::{first_chapter, get_book_dir, open};
+use crate::{get_book_dir, open};
 use clap::{arg, App, Arg, ArgMatches};
 use futures_util::sink::SinkExt;
 use futures_util::StreamExt;
@@ -103,10 +103,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     });
 
     if open_browser {
-        let serving_url = match first_chapter(&book).map(|path| path.with_extension("html")) {
-            Some(path) => format!("http://{}/{}", address, path.display()),
-            _ => format!("http://{}", address),
-        };
+        let serving_url = format!("http://{}", address);
         info!("Serving on: {}", serving_url);
         open(serving_url);
     }

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,4 +1,3 @@
-use crate::first_chapter;
 use crate::{get_book_dir, open};
 use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
@@ -46,12 +45,12 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     if args.is_present("open") {
         book.build()?;
-        match first_chapter(&book)
-            .map(|path| book.build_dir_for("html").join(path).with_extension("html"))
-        {
-            Some(path) if Path::new(&path).exists() => open(path),
-            _ => warn!("No chapter available to open"),
+        let path = book.build_dir_for("html").join("index.html");
+        if !path.exists() {
+            error!("No chapter available to open");
+            std::process::exit(1)
         }
+        open(path);
     }
 
     trigger_on_change(&book, |paths, book_dir| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,7 @@ use clap::{App, AppSettings, Arg, ArgMatches};
 use clap_complete::Shell;
 use env_logger::Builder;
 use log::LevelFilter;
-use mdbook::book::Chapter;
 use mdbook::utils;
-use mdbook::BookItem;
-use mdbook::MDBook;
 use std::env;
 use std::ffi::OsStr;
 use std::io::Write;
@@ -138,17 +135,6 @@ fn get_book_dir(args: &ArgMatches) -> PathBuf {
     } else {
         env::current_dir().expect("Unable to determine the current directory")
     }
-}
-
-// Return the first displayable chapter of the given book, or None if no displayable
-// chapter is found (i.e. only drafts).
-fn first_chapter(book: &MDBook) -> Option<&PathBuf> {
-    book.iter().find_map(|item| match item {
-        BookItem::Chapter(Chapter {
-            path: Some(path), ..
-        }) => Some(path),
-        _ => None,
-    })
 }
 
 fn open<P: AsRef<OsStr>>(path: P) {


### PR DESCRIPTION
This fixes an issue where `mdbook serve --open` may land on a 404 page if the file name is changed. This is easily reproduced by running `mdbook serve --open guide` on mdBook itself, which will open `http://localhost:3000/README.html`, which 404's thanks to the `index` preproc.

Since mdBook seems to always generate an `index.html` page for the first chapter anyway, it seems that "trimming the fat" is also more correct.