### PR TITLE
Fix Cargo.lock for version bump.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbook"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "ammonia",
  "anyhow",


### PR DESCRIPTION
I skipped one of the publishing steps.

Fixes #1839