### PR TITLE
remove __non_exhaustive members, add non_exhaustive attribute instead

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -77,10 +77,10 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
 /// [`iter()`]: #method.iter
 /// [`for_each_mut()`]: #method.for_each_mut
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Book {
     /// The sections in this book.
     pub sections: Vec<BookItem>,
-    __non_exhaustive: (),
 }
 
 impl Book {
@@ -228,10 +228,7 @@ pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P)
         chapters.push(chapter);
     }
 
-    Ok(Book {
-        sections: chapters,
-        __non_exhaustive: (),
-    })
+    Ok(Book { sections: chapters })
 }
 
 fn load_summary_item<P: AsRef<Path> + Clone>(

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 /// Extra information for a `Preprocessor` to give them more context when
 /// processing a book.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct PreprocessorContext {
     /// The location of the book directory on disk.
     pub root: PathBuf,
@@ -32,8 +33,6 @@ pub struct PreprocessorContext {
     pub mdbook_version: String,
     #[serde(skip)]
     pub(crate) chapter_titles: RefCell<HashMap<PathBuf, String>>,
-    #[serde(skip)]
-    __non_exhaustive: (),
 }
 
 impl PreprocessorContext {
@@ -45,7 +44,6 @@ impl PreprocessorContext {
             renderer,
             mdbook_version: crate::MDBOOK_VERSION.to_string(),
             chapter_titles: RefCell::new(HashMap::new()),
-            __non_exhaustive: (),
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -51,6 +51,7 @@ pub trait Renderer {
 
 /// The context provided to all renderers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RenderContext {
     /// Which version of `mdbook` did this come from (as written in `mdbook`'s
     /// `Cargo.toml`). Useful if you know the renderer is only compatible with
@@ -68,8 +69,6 @@ pub struct RenderContext {
     pub destination: PathBuf,
     #[serde(skip)]
     pub(crate) chapter_titles: HashMap<PathBuf, String>,
-    #[serde(skip)]
-    __non_exhaustive: (),
 }
 
 impl RenderContext {
@@ -86,7 +85,6 @@ impl RenderContext {
             root: root.into(),
             destination: destination.into(),
             chapter_titles: HashMap::new(),
-            __non_exhaustive: (),
         }
     }
 


### PR DESCRIPTION
As stated in #1835, I deleted every non_exhaustive members and added the `#[non_exhaustive]` attribute.  
There are two more structs that may benefit from this: the Chapter struct and the Theme struct. The remaining structs have either a private member either all public members and doesn't deserve the attribute (to my opinion).
I could have put this attribute to enums as well, but this and adding attribute to the two structs above would be a breaking change. [The page reference for non_exhaustive attribute](https://doc.rust-lang.org/reference/attributes/type_system.html). So I let this up to review.