### PR TITLE
authors -> author in user guide

### DIFF
--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -7,7 +7,7 @@ Here is an example of what a ***book.toml*** file might look like:
 ```toml
 [book]
 title = "Example book"
-author = "John Doe"
+authors = ["John Doe"]
 description = "The example book covers examples."
 
 [rust]


### PR DESCRIPTION
It looks like this was the only place author was used in the user guide.

Closes #1804