### PR TITLE
Add Fig completion support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           - build: msrv
             os: ubuntu-latest
             # sync MSRV with docs: guide/src/guide/installation.md
-            rust: 1.54.0
+            rust: 1.56.1
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,15 +185,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -201,11 +201,41 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.4"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77159b3389b97ee638bb2a1d572069a7d9088a55e6281e3c76fc17b9cd51227"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "clap_complete_fig",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed37b4c0c1214673eba6ad8ea31666626bf72be98ffb323067d973c48b4964b9"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -803,7 +833,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
- "clap_complete",
+ "clap_complete_command",
  "elasticlunr-rs",
  "env_logger",
  "futures-util",
@@ -998,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,9 +1060,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "output_vt100"
@@ -1601,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ description = "Creates a book from markdown files"
 anyhow = "1.0.28"
 chrono = "0.4"
 clap = { version = "3.0", features = ["cargo"] }
-clap_complete = "3.0"
+clap_complete_command = "0.3"
 env_logger = "0.9.0"
 handlebars = "4.0"
 lazy_static = "1.0"

--- a/guide/src/guide/installation.md
+++ b/guide/src/guide/installation.md
@@ -20,7 +20,7 @@ To make it easier to run, put the path to the binary into your `PATH`.
 
 To build the `mdbook` executable from source, you will first need to install Rust and Cargo.
 Follow the instructions on the [Rust installation page].
-mdBook currently requires at least Rust version 1.54.
+mdBook currently requires at least Rust version 1.56.1.
 
 Once you have installed Rust, the following command can be used to build and install mdBook:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate log;
 use anyhow::anyhow;
 use chrono::Local;
 use clap::{App, AppSettings, Arg, ArgMatches};
-use clap_complete::Shell;
+use clap_complete_command::Shell;
 use env_logger::Builder;
 use log::LevelFilter;
 use mdbook::utils;
@@ -42,12 +42,7 @@ fn main() {
                 .map_err(|s| anyhow!("Invalid shell: {}", s))?;
 
             let mut complete_app = create_clap_app();
-            clap_complete::generate(
-                shell,
-                &mut complete_app,
-                "mdbook",
-                &mut std::io::stdout().lock(),
-            );
+            shell.generate(&mut complete_app, &mut std::io::stdout().lock());
             Ok(())
         })(),
         _ => unreachable!(),


### PR DESCRIPTION
Fig completion generation provided by [`clap_complete_fig`](https://crates.io/crates/clap_complete_fig).

This adds [`clap_complete_command`](https://crates.io/crates/clap_complete_command) as a dependency to make supporting both `clap_complete`'s shells and `clap_complete_fig` simpler and keep a similar API to just using `clap_complete` (full disclosure, I'm the maintainer of this crate).