### PR TITLE
Release 0.5.0 - #[non_exhaustive] attribute

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -77,10 +77,10 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
 /// [`iter()`]: #method.iter
 /// [`for_each_mut()`]: #method.for_each_mut
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Book {
     /// The sections in this book.
     pub sections: Vec<BookItem>,
-    __non_exhaustive: (),
 }
 
 impl Book {
@@ -228,10 +228,7 @@ pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P)
         chapters.push(chapter);
     }
 
-    Ok(Book {
-        sections: chapters,
-        __non_exhaustive: (),
-    })
+    Ok(Book { sections: chapters })
 }
 
 fn load_summary_item<P: AsRef<Path> + Clone>(

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -152,6 +152,7 @@ impl From<Chapter> for BookItem {
 /// The representation of a "chapter", usually mapping to a single file on
 /// disk however it may contain multiple sub-chapters.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Chapter {
     /// The chapter's name.
     pub name: String,

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 /// Extra information for a `Preprocessor` to give them more context when
 /// processing a book.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct PreprocessorContext {
     /// The location of the book directory on disk.
     pub root: PathBuf,
@@ -32,8 +33,6 @@ pub struct PreprocessorContext {
     pub mdbook_version: String,
     #[serde(skip)]
     pub(crate) chapter_titles: RefCell<HashMap<PathBuf, String>>,
-    #[serde(skip)]
-    __non_exhaustive: (),
 }
 
 impl PreprocessorContext {
@@ -45,7 +44,6 @@ impl PreprocessorContext {
             renderer,
             mdbook_version: crate::MDBOOK_VERSION.to_string(),
             chapter_titles: RefCell::new(HashMap::new()),
-            __non_exhaustive: (),
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -51,6 +51,7 @@ pub trait Renderer {
 
 /// The context provided to all renderers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RenderContext {
     /// Which version of `mdbook` did this come from (as written in `mdbook`'s
     /// `Cargo.toml`). Useful if you know the renderer is only compatible with
@@ -68,8 +69,6 @@ pub struct RenderContext {
     pub destination: PathBuf,
     #[serde(skip)]
     pub(crate) chapter_titles: HashMap<PathBuf, String>,
-    #[serde(skip)]
-    __non_exhaustive: (),
 }
 
 impl RenderContext {
@@ -86,7 +85,6 @@ impl RenderContext {
             root: root.into(),
             destination: destination.into(),
             chapter_titles: HashMap::new(),
-            __non_exhaustive: (),
         }
     }
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -45,6 +45,7 @@ pub static FONT_AWESOME_OTF: &[u8] = include_bytes!("FontAwesome/fonts/FontAweso
 /// You should only ever use the static variables directly if you want to
 /// override the user's theme with the defaults.
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub struct Theme {
     pub index: Vec<u8>,
     pub head: Vec<u8>,


### PR DESCRIPTION
This follows multiple discussions: #1848 #1851 #1835.

As stated, this PR could be accepted when the release 0.5.0 will be landed.
I've added the non_exhaustive attribute on the Chapter and Theme structs, since this is a breaking change anyway.
I checked if adding non_exhaustive attribute on enums is a good practice, but in my research I have found that is not really very well handled by serde: Link [here](https://github.com/serde-rs/serde/issues/1991). I think this PR is good as it is.