### PR TITLE
Fix code padding in headings

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -252,7 +252,7 @@ pre > .buttons button {
         padding: 0.3rem 1rem;
     }
 }
-code {
+pre > code {
     padding: 1rem;
 }
 


### PR DESCRIPTION
In #1806, extra padding was added to code blocks, but this adds the padding to headings as well. I think this was only meant to affect code blocks in the main content. If spacing was intended in the headings, a margin would probably be better. This PR just limits the scope of the change from #1806.

With this PR:

### Before
![1657647912_grim](https://user-images.githubusercontent.com/3708797/178559440-54cf65e0-3390-4fc0-93a4-1953c68c7474.png)

### After
![1657648007_grim](https://user-images.githubusercontent.com/3708797/178559444-1046fc20-f269-448a-bbdb-4634e4e3d0b9.png)
