### PR TITLE
add option -no-indent to remove indentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(str_split_as_str)]
 //! # mdBook
 //!
 //! **mdBook** is a tool for rendering a collection of markdown documents into

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(str_split_as_str)]
 //! # mdBook
 //!
 //! **mdBook** is a tool for rendering a collection of markdown documents into

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ use std::fmt::Write;
 use std::path::Path;
 
 pub use self::string::{
-    take_anchored_lines, take_lines, take_rustdoc_include_anchored_lines,
+    take_anchored_lines, take_lines, take_remove_indent, take_rustdoc_include_anchored_lines,
     take_rustdoc_include_lines,
 };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,8 +15,8 @@ use std::fmt::Write;
 use std::path::Path;
 
 pub use self::string::{
-    take_anchored_lines, take_lines, take_remove_indent, take_rustdoc_include_anchored_lines,
-    take_rustdoc_include_lines,
+    take_anchored_lines, take_format_remove_indent, take_lines,
+    take_rustdoc_include_anchored_lines, take_rustdoc_include_lines,
 };
 
 /// Replaces multiple consecutive whitespace characters with a single space character.

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,5 +1,5 @@
-use once_cell::sync::Lazy;
 use anyhow::Error;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::RangeBounds;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use regex::Regex;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::RangeBounds;
@@ -112,6 +113,39 @@ pub fn take_rustdoc_include_anchored_lines(s: &str, anchor: &str) -> String {
 
     output.pop();
     output
+}
+
+pub fn take_remove_indent(s: Result<String, Error>) -> Result<String, Error> {
+    match s {
+        Err(_) => s,
+        Ok(_str) => Ok(take_format_remove_indent(_str.as_str())),
+    }
+}
+
+fn take_format_remove_indent(str: &str) -> String {
+    let mut output = Vec::<String>::new();
+    let mut min_indent = usize::MAX;
+
+    for line in str.lines() {
+        for (index, c) in line.chars().enumerate() {
+            if !c.is_whitespace() && min_indent > index {
+                min_indent = index;
+                break;
+            }
+        }
+    }
+
+    for line in str.lines() {
+        let formatted: String = line
+            .chars()
+            .take(0)
+            .chain(line.chars().skip(min_indent))
+            .collect();
+
+        output.push(formatted);
+    }
+
+    output.join("\n")
 }
 
 #[cfg(test)]

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,4 +1,3 @@
-use anyhow::Error;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::ops::Bound::{Excluded, Included, Unbounded};
@@ -116,14 +115,7 @@ pub fn take_rustdoc_include_anchored_lines(s: &str, anchor: &str) -> String {
     output
 }
 
-pub fn take_remove_indent(s: Result<String, Error>) -> Result<String, Error> {
-    match s {
-        Err(_) => s,
-        Ok(_str) => Ok(take_format_remove_indent(_str.as_str())),
-    }
-}
-
-fn take_format_remove_indent(str: &str) -> String {
+pub fn take_format_remove_indent(str: &str) -> String {
     let mut output = Vec::<String>::new();
     let mut min_indent = usize::MAX;
 


### PR DESCRIPTION
In this PR, I have added support for the new `LinkType::IncludeNoIndent`. This feature can be utilized with the `Anchor` syntax, such as `{{#include file.rs:anchor_name:-no-indent}}`, or with the `Range` syntax, `{{#include file.rs::20:-no-indent}}`.

Parsing is done in the same way as with the `Range(LineRange)` type. This means that if we use `{{#include file.rs::20: 30}}`, the command will not work until the whitespace between 20 and 30 is removed, resulting in 20:30. The same applies to the `-no-indent` command, `{{#include file.rs::20: -no-indent}}` will not work, while `{{#include file.rs::20:-no-indent}}` does.

The parsing process begins in the `parse_include_path` function where we check for the presence of the `-no-indent` command. Based on this, we return `LinkType::IncludeNoIndent` or only `LinkType::Include`.

If we have returned `LinkType::IncludeNoIndent`, the `take_format_remove_indent` function will find the part of the code closest to the left margin and move it to the left by that much space. The format of the code remains the same, with only the indentation being removed.

`{{#include file.rs::20:30}}`

![Screenshot from 2023-01-23 14-16-07](https://user-images.githubusercontent.com/28829252/214075420-c32f769c-c24f-430d-8112-ea3ab22586a0.png)

`{{#include file.rs::20:30:-no-indent}}`

![Screenshot from 2023-01-23 14-15-47](https://user-images.githubusercontent.com/28829252/214075304-44dae7ec-db91-4710-a57c-81e762b2af06.png)

`{{#include ../../../examples/providers/src/lib.rs:setup_test_blockchain}}`

![Screenshot from 2023-01-23 14-16-51](https://user-images.githubusercontent.com/28829252/214075802-bd64029f-1adf-4583-87f1-3973c441b333.png)

`{{#include ../../../examples/providers/src/lib.rs:setup_test_blockchain:-no-indent}}`

![Screenshot from 2023-01-23 14-17-14](https://user-images.githubusercontent.com/28829252/214075824-9ef9ad06-5e07-466b-95d0-74a106cfa15e.png)

