### PR TITLE
Workaround rust nightly borrowcheck error (#1860)

### DIFF
--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -149,8 +149,8 @@ fn render(
     _h.template()
         .ok_or_else(|| RenderError::new("Error with the handlebars template"))
         .and_then(|t| {
-            let mut local_rc = rc.clone();
             let local_ctx = Context::wraps(&context)?;
+            let mut local_rc = rc.clone();
             t.render(r, &local_ctx, &mut local_rc, out)
         })?;
 


### PR DESCRIPTION
Surprisingly, this fixes the error filed at #1860!

This seems suspicious, perhaps indicative of a bug in Rust's non-lexical
lifetime handling on nightly?

The lifetimes in the `handlebars::Renderable::render` method signature
are quite complicated, and its unclear to me whether or not Rust is
catching some new safety edge-case that wasn't previously handled
correctly...

Possibly related to `drop` order, which I *think* is related to the
order of binding statements?