### PR TITLE
Deploy {x86_64,aarch64}-unknown-linux-musl binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,19 +9,35 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        target:
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+        include:
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     steps:
     - uses: actions/checkout@master
     - name: Install hub
       run: ci/install-hub.sh ${{ matrix.os }}
       shell: bash
     - name: Install Rust
-      run: ci/install-rust.sh stable
+      run: ci/install-rust.sh stable ${{ matrix.target }}
       shell: bash
     - name: Build and deploy artifacts
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ci/make-release.sh ${{ matrix.os }}
+      run: ci/make-release.sh ${{ matrix.os }} ${{ matrix.target }}
       shell: bash
   pages:
     name: GitHub Pages

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -13,6 +13,17 @@ TOOLCHAIN="$1"
 rustup set profile minimal
 rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
 rustup update --no-self-update $TOOLCHAIN
+if [ -n "$2" ]
+then
+    TARGET="$2"
+    HOST=$(rustc -Vv | grep ^host: | sed -e "s/host: //g")
+    if [ "$HOST" != "$TARGET" ]
+    then
+        rustup component add llvm-tools-preview --toolchain=$TOOLCHAIN
+        rustup component add rust-std-$TARGET --toolchain=$TOOLCHAIN
+    fi
+fi
+
 rustup default $TOOLCHAIN
 rustup -V
 rustc -Vv

--- a/ci/make-release.sh
+++ b/ci/make-release.sh
@@ -11,16 +11,21 @@ fi
 TAG=${GITHUB_REF#*/tags/}
 
 host=$(rustc -Vv | grep ^host: | sed -e "s/host: //g")
+target=$2
+if [ "$host" != "$target" ]
+then
+  export "CARGO_TARGET_$(echo $target | tr a-z- A-Z_)_LINKER"=rust-lld
+fi
 export CARGO_PROFILE_RELEASE_LTO=true
-cargo build --bin mdbook --release
-cd target/release
+cargo build --bin mdbook --release --target $target
+cd target/$target/release
 case $1 in
   ubuntu*)
-    asset="mdbook-$TAG-$host.tar.gz"
+    asset="mdbook-$TAG-$target.tar.gz"
     tar czf ../../$asset mdbook
     ;;
   macos*)
-    asset="mdbook-$TAG-$host.tar.gz"
+    asset="mdbook-$TAG-$target.tar.gz"
     # There is a bug with BSD tar on macOS where the first 8MB of the file are
     # sometimes all NUL bytes. See https://github.com/actions/cache/issues/403
     # and https://github.com/rust-lang/cargo/issues/8603 for some more
@@ -30,7 +35,7 @@ case $1 in
     tar czf ../../$asset mdbook
     ;;
   windows*)
-    asset="mdbook-$TAG-$host.zip"
+    asset="mdbook-$TAG-$target.zip"
     7z a ../../$asset mdbook.exe
     ;;
   *)


### PR DESCRIPTION
Added functionality to `.github/workflows/deploy.yml` and associated scripts to deploy pre-built binaries for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`.

The `x86_64-unknown-linux-musl` executable is statically linked, so it will work with older versions of glibc or the Alpine Linux container environment.
I also added the `aarch64-unknown-linux-musl` executable because I want mdBook to run in aarch64 Linux environments (using rust-lld as the linker makes cross-compilation easier).

This fixes #1779 