### PR TITLE
Bump MSRV to 1.56 to get access to Rust 2021 crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           - build: msrv
             os: ubuntu-latest
             # sync MSRV with docs: guide/src/guide/installation.md
-            rust: 1.54.0
+            rust: 1.56.0
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/guide/src/guide/installation.md
+++ b/guide/src/guide/installation.md
@@ -20,7 +20,7 @@ To make it easier to run, put the path to the binary into your `PATH`.
 
 To build the `mdbook` executable from source, you will first need to install Rust and Cargo.
 Follow the instructions on the [Rust installation page].
-mdBook currently requires at least Rust version 1.54.
+mdBook currently requires at least Rust version 1.56 (the 2021 edition).
 
 Once you have installed Rust, the following command can be used to build and install mdBook:
 


### PR DESCRIPTION
I noticed in #1864 that mdBook does not yet use the Rust 2021 edition.
This 2021 edition was made stable in the 1.56 release on 2021-10-21.
The previous MSRV (1.54) was released on 2021-07-29.