### PR TITLE
[+] Add the ability to config the hostname and port in book.toml

### DIFF
--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -17,6 +17,10 @@ edition = "2018"
 build-dir = "my-example-book"
 create-missing = false
 
+[serve]
+hostname = "localhost"
+port = "3000"
+
 [preprocessor.index]
 
 [preprocessor.links]
@@ -108,3 +112,16 @@ use-default-preprocessors = true  # use the default preprocessors
     default preprocessors from running.
   - Adding `[preprocessor.links]`, for example, will ensure, regardless of
     `use-default-preprocessors` that `links` it will run.
+
+### Serve options
+
+This controls the serve process of your book.
+
+```toml
+[serve]
+hostname = "localhost"
+port = "3000"
+```
+
+- **hostname:** The hostname to serve the book, by default it will be `localhost`.
+- **port:** The port to serve the book, by default it will be `3000`.

--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -19,7 +19,7 @@ create-missing = false
 
 [serve]
 hostname = "localhost"
-port = "3000"
+port = 3000
 
 [preprocessor.index]
 
@@ -120,7 +120,7 @@ This controls the serve process of your book.
 ```toml
 [serve]
 hostname = "localhost"
-port = "3000"
+port = 3000
 ```
 
 - **hostname:** The hostname to serve the book, by default it will be `localhost`.

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -63,13 +63,13 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let hostname: String = match (args.value_of("hostname"), &book.config.serve.hostname) {
         (Some(h), _) => h.to_owned(),
         (_, Some(h)) => h.to_owned(),
-        (_, _) => "localhost".to_owned(),
+        (_, _) => String::from("localhost"),
     };
 
     let port: String = match (args.value_of("port"), &book.config.serve.port) {
         (Some(p), _) => p.to_owned(),
-        (_, Some(p)) => p.to_owned(),
-        (_, _) => "3000".to_owned(),
+        (_, Some(p)) => p.to_string(),
+        (_, _) => 3000.to_string(),
     };
 
     let open_browser = args.is_present("open");

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -41,7 +41,6 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .short('n')
                 .long("hostname")
                 .takes_value(true)
-                .default_value("localhost")
                 .forbid_empty_values(true)
                 .help("Hostname to listen on for HTTP connections"),
         )
@@ -50,7 +49,6 @@ pub fn make_subcommand<'help>() -> App<'help> {
                 .short('p')
                 .long("port")
                 .takes_value(true)
-                .default_value("3000")
                 .forbid_empty_values(true)
                 .help("Port to use for HTTP connections"),
         )
@@ -62,8 +60,18 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let book_dir = get_book_dir(args);
     let mut book = MDBook::load(&book_dir)?;
 
-    let port = args.value_of("port").unwrap();
-    let hostname = args.value_of("hostname").unwrap();
+    let hostname: String = match (args.value_of("hostname"), &book.config.serve.hostname) {
+        (Some(h), _) => h.to_owned(),
+        (_, Some(h)) => h.to_owned(),
+        (_, _) => "localhost".to_owned(),
+    };
+
+    let port: String = match (args.value_of("port"), &book.config.serve.port) {
+        (Some(p), _) => p.to_owned(),
+        (_, Some(p)) => p.to_owned(),
+        (_, _) => "3000".to_owned(),
+    };
+
     let open_browser = args.is_present("open");
 
     let address = format!("{}:{}", hostname, port);

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,7 +466,7 @@ pub struct ServeConfig {
     /// Default hostname
     pub hostname: Option<String>,
     /// Default port
-    pub port: Option<String>,
+    pub port: Option<u16>,
 }
 
 /// Configuration for the Rust compiler(e.g., for playground)

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct Config {
     pub book: BookConfig,
     /// Information about the build environment.
     pub build: BuildConfig,
+    /// Information about the serve environment
+    pub serve: ServeConfig,
     /// Information about Rust language support.
     pub rust: RustConfig,
     rest: Value,
@@ -289,6 +291,7 @@ impl Default for Config {
         Config {
             book: BookConfig::default(),
             build: BuildConfig::default(),
+            serve: ServeConfig::default(),
             rust: RustConfig::default(),
             rest: Value::Table(Table::default()),
         }
@@ -333,6 +336,12 @@ impl<'de> Deserialize<'de> for Config {
             .transpose()?
             .unwrap_or_default();
 
+        let serve: ServeConfig = table
+            .remove("serve")
+            .map(|serve| serve.try_into().map_err(D::Error::custom))
+            .transpose()?
+            .unwrap_or_default();
+
         let rust: RustConfig = table
             .remove("rust")
             .map(|rust| rust.try_into().map_err(D::Error::custom))
@@ -342,6 +351,7 @@ impl<'de> Deserialize<'de> for Config {
         Ok(Config {
             book,
             build,
+            serve,
             rust,
             rest: Value::Table(table),
         })
@@ -447,6 +457,16 @@ impl Default for BuildConfig {
             use_default_preprocessors: true,
         }
     }
+}
+
+/// Configuration for the serve procedure
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ServeConfig {
+    /// Default hostname
+    pub hostname: Option<String>,
+    /// Default port
+    pub port: Option<String>,
 }
 
 /// Configuration for the Rust compiler(e.g., for playground)


### PR DESCRIPTION
This PR add the ability to specify the default hostname and port for serve the book in book.toml file.

## Why I need this feature?

Sometime I need to run multiple mdBook instances, but in order to do so, I need to set the port explicitly, otherwise new instances will try to reuse the same port with existing instance, which will be failed.

This PR allow to set default hostname/port for a book, so user doesn't need to set port every time they serve book in above use case. If user would like to override the port via command line, they still able to do so.

Other benefit is that when you run the book again and again, it will keep using old host/port you already choosen, without the need to remember it. By doing so, you will also have better browser history, i.e. you can filter them easier, avoid the case when at different time you run different books but share the same address. The consistent also help in case you have some browser externsion and you want to apply some filter rules to specific books only (i.e. inject some CSS/JS,...).