### PR TITLE
Explain how to use `site-url` with asset URLs

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -157,7 +157,8 @@ The following configuration options are available:
   Defaults to `404.md`.
 - **site-url:** The url where the book will be hosted. This is required to ensure
   navigation links and script/css imports in the 404 file work correctly, even when accessing
-  urls in subdirectories. Defaults to `/`.
+  urls in subdirectories. Defaults to `/`. If `site-url` is set,
+  make sure to use document relative links for your assets, meaning they should not start with `/`.
 - **cname:** The DNS subdomain or apex domain at which your book will be hosted.
   This string will be written to a file named CNAME in the root of your site, as
   required by GitHub Pages (see [*Managing a custom domain for your GitHub Pages


### PR DESCRIPTION
I made the mistake of using root relative links: `/assets/some-file.jpg` instead of using document relative links: `assets/some-file.jpg`. This works fine when using `mdbook serve`, but after deploying my pages, the images broke down. A warning notice in the docs might prevent others from making the same mistake.