### PR TITLE
Add support for watching additional directories

### DIFF
--- a/guide/src/format/configuration/general.md
+++ b/guide/src/format/configuration/general.md
@@ -87,6 +87,7 @@ This controls the build process of your book.
 build-dir = "book"                # the directory where the output is placed
 create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
+extra-watch-dirs = []             # directories to watch for triggering builds
 ```
 
 - **build-dir:** The directory to put the rendered book in. By default this is
@@ -108,3 +109,6 @@ use-default-preprocessors = true  # use the default preprocessors
     default preprocessors from running.
   - Adding `[preprocessor.links]`, for example, will ensure, regardless of
     `use-default-preprocessors` that `links` it will run.
+- **extra-watch-dirs**: A list of paths to directories that will be watched in
+  the `watch` and `serve` commands. Changes to files under these directories will
+  trigger rebuilds. Useful if your book depends on files outside its `src` directory.

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -149,7 +149,10 @@ where
     for dir in &book.config.build.extra_watch_dirs {
         let path = dir.canonicalize().unwrap();
         if let Err(e) = watcher.watch(&path, Recursive) {
-            error!("Error while watching extra directory {path:?}:\n    {e:?}");
+            error!(
+                "Error while watching extra directory {:?}:\n    {:?}",
+                path, e
+            );
             std::process::exit(1);
         }
     }

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -146,6 +146,10 @@ where
     // Add the book.toml file to the watcher if it exists
     let _ = watcher.watch(book.root.join("book.toml"), NonRecursive);
 
+    for dir in &book.config.build.extra_watch_dirs {
+        let _ = watcher.watch(dir, Recursive);
+    }
+
     info!("Listening for changes...");
 
     loop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -437,6 +437,8 @@ pub struct BuildConfig {
     /// Should the default preprocessors always be used when they are
     /// compatible with the renderer?
     pub use_default_preprocessors: bool,
+    /// Extra directories to trigger rebuild when watching/serving
+    pub extra_watch_dirs: Vec<PathBuf>,
 }
 
 impl Default for BuildConfig {
@@ -445,6 +447,7 @@ impl Default for BuildConfig {
             build_dir: PathBuf::from("book"),
             create_missing: true,
             use_default_preprocessors: true,
+            extra_watch_dirs: Vec::new(),
         }
     }
 }
@@ -770,6 +773,7 @@ mod tests {
             build_dir: PathBuf::from("outputs"),
             create_missing: false,
             use_default_preprocessors: true,
+            extra_watch_dirs: Vec::new(),
         };
         let rust_should_be = RustConfig { edition: None };
         let playground_should_be = Playground {
@@ -980,6 +984,7 @@ mod tests {
             build_dir: PathBuf::from("my-book"),
             create_missing: true,
             use_default_preprocessors: true,
+            extra_watch_dirs: Vec::new(),
         };
 
         let html_should_be = HtmlConfig {

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -95,7 +95,7 @@ fn run_mdbook_init_with_custom_book_and_src_locations() {
     let contents = fs::read_to_string(temp.path().join("book.toml")).unwrap();
     assert_eq!(
         contents,
-        "[book]\nauthors = []\nlanguage = \"en\"\nmultilingual = false\nsrc = \"in\"\n\n[build]\nbuild-dir = \"out\"\ncreate-missing = true\nuse-default-preprocessors = true\n"
+        "[book]\nauthors = []\nlanguage = \"en\"\nmultilingual = false\nsrc = \"in\"\n\n[build]\nbuild-dir = \"out\"\ncreate-missing = true\nextra-watch-dirs = []\nuse-default-preprocessors = true\n"
     );
 }
 


### PR DESCRIPTION
When using mdBook preprocessors like [mdbook-quiz](https://github.com/willcrichton/mdbook-quiz), the book depends on files outside the source directory, such as TOML files describing quizzes. It would be very convenient as an author for the book to automatically rebuild when these files change. However, the `watch` and `serve` commands (via `trigger_on_change`) only watch a fixed set of directories.

Probably the ideal solution would be for preprocessors to register files to be watched, similar to how extensible build systems like [esbuild](https://esbuild.github.io/plugins/#on-resolve-results) manage plugins. However, this would be a big change with a lot of work. A much cheaper solution is to allow mdbook CLI users to pass desired directories-to-watch on the command line.

Therefore this PR adds a new flag to `watch` and `serve`, `--extra-watch-dirs`. For example, a user could write:

```
mdbook serve --extra-watch-dirs quizzes,snippets
```

The `--extra-watch-dirs` flag takes as input a comma-separated list of directories. Each of these directories is added to the file watcher, so the book is regenerated when a file in these directories is changed.