### PR TITLE
Require Rust 2021 edition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           - build: msrv
             os: ubuntu-latest
             # sync MSRV with docs: guide/src/guide/installation.md
-            rust: 1.54.0
+            rust: 1.56.0
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Matt Ickstadt <mattico8@gmail.com>"
 ]
 documentation = "http://rust-lang.github.io/mdBook/index.html"
-edition = "2018"
+edition = "2021"
 exclude = ["/guide/*"]
 keywords = ["book", "gitbook", "rustbook", "markdown"]
 license = "MPL-2.0"

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -8,7 +8,7 @@ use super::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 use crate::config::BuildConfig;
 use crate::errors::*;
 use crate::utils::bracket_escape;
-
+use log::debug;
 use serde::{Deserialize, Serialize};
 
 /// Load a book into memory from its `src/` directory.

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -6,6 +6,7 @@ use super::MDBook;
 use crate::config::Config;
 use crate::errors::*;
 use crate::theme;
+use log::{debug, error, info, trace};
 
 /// A helper for setting up a new book and its directory structure.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -14,6 +14,7 @@ pub use self::book::{load_book, Book, BookItem, BookItems, Chapter};
 pub use self::init::BookBuilder;
 pub use self::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 
+use log::{debug, error, info, log_enabled, trace, warn};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use log::{debug, trace, warn};
 use memchr::{self, Memchr};
 use pulldown_cmark::{self, Event, HeadingLevel, Tag};
 use serde::{Deserialize, Serialize};

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@
 
 #![deny(missing_docs)]
 
+use log::{debug, trace, warn};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::env;
@@ -295,7 +296,7 @@ impl Default for Config {
     }
 }
 
-impl<'de> Deserialize<'de> for Config {
+impl<'de> serde::Deserialize<'de> for Config {
     fn deserialize<D: Deserializer<'de>>(de: D) -> std::result::Result<Self, D::Error> {
         let raw = Value::deserialize(de)?;
 
@@ -717,6 +718,7 @@ impl<'de, T> Updateable<'de> for T where T: Serialize + Deserialize<'de> {}
 mod tests {
     use super::*;
     use crate::utils::fs::get_404_output_file;
+    use serde_json::json;
 
     const COMPLEX_CONFIG: &str = r#"
         [book]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,17 +83,6 @@
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_json;
-
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 pub mod book;
 pub mod config;
 pub mod preprocess;

--- a/src/preprocess/cmd.rs
+++ b/src/preprocess/cmd.rs
@@ -1,6 +1,7 @@
 use super::{Preprocessor, PreprocessorContext};
 use crate::book::Book;
 use crate::errors::*;
+use log::{debug, trace, warn};
 use shlex::Shlex;
 use std::io::{self, Read, Write};
 use std::process::{Child, Command, Stdio};

--- a/src/preprocess/index.rs
+++ b/src/preprocess/index.rs
@@ -1,10 +1,11 @@
 use regex::Regex;
 use std::path::Path;
 
-use crate::errors::*;
-
 use super::{Preprocessor, PreprocessorContext};
 use crate::book::{Book, BookItem};
+use crate::errors::*;
+use lazy_static::lazy_static;
+use log::warn;
 
 /// A preprocessor for converting file name `README.md` to `index.md` since
 /// `README.md` is the de facto index file in markdown-based documentation.

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 
 use super::{Preprocessor, PreprocessorContext};
 use crate::book::{Book, BookItem};
+use lazy_static::lazy_static;
+use log::{error, warn};
 
 const ESCAPE_CHAR: char = '\\';
 const MAX_LINK_NESTED_DEPTH: usize = 10;

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -12,11 +12,10 @@ use crate::book::Book;
 use crate::config::Config;
 use crate::errors::*;
 
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
 
 /// Extra information for a `Preprocessor` to give them more context when
 /// processing a book.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -14,7 +14,10 @@ use std::path::{Path, PathBuf};
 
 use crate::utils::fs::get_404_output_file;
 use handlebars::Handlebars;
+use lazy_static::lazy_static;
+use log::{debug, trace, warn};
 use regex::{Captures, Regex};
+use serde_json::json;
 
 #[derive(Default)]
 pub struct HtmlHandlebars;

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError, Renderable};
 
 use crate::utils;
+use log::{debug, trace};
+use serde_json::json;
 
 type StringMap = BTreeMap<String, String>;
 

--- a/src/renderer/html_handlebars/helpers/theme.rs
+++ b/src/renderer/html_handlebars/helpers/theme.rs
@@ -1,4 +1,5 @@
 use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError};
+use log::trace;
 
 pub fn theme_option(
     h: &Helper<'_, '_>,

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -10,7 +10,8 @@ use crate::config::Search;
 use crate::errors::*;
 use crate::theme::searcher;
 use crate::utils;
-
+use lazy_static::lazy_static;
+use log::{debug, warn};
 use serde::Serialize;
 
 const MAX_WORD_LENGTH_TO_INDEX: usize = 80;

--- a/src/renderer/markdown_renderer.rs
+++ b/src/renderer/markdown_renderer.rs
@@ -2,7 +2,7 @@ use crate::book::BookItem;
 use crate::errors::*;
 use crate::renderer::{RenderContext, Renderer};
 use crate::utils;
-
+use log::trace;
 use std::fs;
 
 #[derive(Default)]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -27,6 +27,7 @@ use std::process::{Command, Stdio};
 use crate::book::Book;
 use crate::config::Config;
 use crate::errors::*;
+use log::{error, info, trace, warn};
 use toml::Value;
 
 use serde::{Deserialize, Serialize};

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -12,7 +12,7 @@ use std::io::Read;
 use std::path::Path;
 
 use crate::errors::*;
-
+use log::warn;
 pub static INDEX: &[u8] = include_bytes!("index.hbs");
 pub static HEAD: &[u8] = include_bytes!("head.hbs");
 pub static REDIRECT: &[u8] = include_bytes!("redirect.hbs");

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use log::{debug, trace};
 use std::convert::Into;
 use std::fs::{self, File};
 use std::io::Write;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,9 +4,10 @@ pub mod fs;
 mod string;
 pub(crate) mod toml_ext;
 use crate::errors::Error;
-use regex::Regex;
-
+use lazy_static::lazy_static;
+use log::error;
 use pulldown_cmark::{html, CodeBlockKind, CowStr, Event, Options, Parser, Tag};
+use regex::Regex;
 
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use regex::Regex;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::RangeBounds;


### PR DESCRIPTION
This allows us to clean up and simplify the code.

The changes were originally written by @Dylan-DPC in #1831. This PR fixes a few build errors in that PR, thanks to the helpful comments made by @ISSOtm. I've also rebased the changes onto the latest `master`.