### PR TITLE
Simplify the use of `Option::and_then`

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -89,8 +89,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let input_404 = book
         .config
         .get("output.html.input-404")
-        .map(toml::Value::as_str)
-        .and_then(std::convert::identity) // flatten
+        .and_then(toml::Value::as_str)
         .map(ToString::to_string);
     let file_404 = get_404_output_file(&input_404);
 

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -148,15 +148,12 @@ fn render(
 
     trace!("Render template");
 
-    _h.template()
-        .ok_or_else(|| RenderError::new("Error with the handlebars template"))
-        .and_then(|t| {
-            let local_ctx = Context::wraps(&context)?;
-            let mut local_rc = rc.clone();
-            t.render(r, &local_ctx, &mut local_rc, out)
-        })?;
-
-    Ok(())
+    let t = _h
+        .template()
+        .ok_or_else(|| RenderError::new("Error with the handlebars template"))?;
+    let local_ctx = Context::wraps(&context)?;
+    let mut local_rc = rc.clone();
+    t.render(r, &local_ctx, &mut local_rc, out)
 }
 
 pub fn previous(

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -117,35 +117,35 @@ impl HelperDef for RenderToc {
             }
 
             // Link
-            let path_exists = if let Some(path) =
-                item.get("path")
-                    .and_then(|p| if p.is_empty() { None } else { Some(p) })
-            {
-                out.write("<a href=\"")?;
+            let path_exists: bool;
+            match item.get("path") {
+                Some(path) if !path.is_empty() => {
+                    out.write("<a href=\"")?;
+                    let tmp = Path::new(path)
+                        .with_extension("html")
+                        .to_str()
+                        .unwrap()
+                        // Hack for windows who tends to use `\` as separator instead of `/`
+                        .replace('\\', "/");
 
-                let tmp = Path::new(item.get("path").expect("Error: path should be Some(_)"))
-                    .with_extension("html")
-                    .to_str()
-                    .unwrap()
-                    // Hack for windows who tends to use `\` as separator instead of `/`
-                    .replace('\\', "/");
+                    // Add link
+                    out.write(&utils::fs::path_to_root(&current_path))?;
+                    out.write(&tmp)?;
+                    out.write("\"")?;
 
-                // Add link
-                out.write(&utils::fs::path_to_root(&current_path))?;
-                out.write(&tmp)?;
-                out.write("\"")?;
+                    if path == &current_path || is_first_chapter {
+                        is_first_chapter = false;
+                        out.write(" class=\"active\"")?;
+                    }
 
-                if path == &current_path || is_first_chapter {
-                    is_first_chapter = false;
-                    out.write(" class=\"active\"")?;
+                    out.write(">")?;
+                    path_exists = true;
                 }
-
-                out.write(">")?;
-                true
-            } else {
-                out.write("<div>")?;
-                false
-            };
+                _ => {
+                    out.write("<div>")?;
+                    path_exists = false;
+                }
+            }
 
             if !self.no_section_label {
                 // Section does not necessarily exist


### PR DESCRIPTION
I found a few places where `Option::and_then` could be simplified (in my opinion) with `?` or with `match`.