### PR TITLE
Add test code to show preprocessor developers what the interface data looks like

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
       run: bash ci/install-rust.sh ${{ matrix.rust }}
     - name: Build and run tests
       run: cargo test
+    - name: Test examples
+      run: cargo test --examples
     - name: Test no default
       run: cargo test --no-default-features
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,6 @@ jobs:
       run: bash ci/install-rust.sh ${{ matrix.rust }}
     - name: Build and run tests
       run: cargo test
-    - name: Test examples
-      run: cargo test --examples
     - name: Test no default
       run: cargo test --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ search = ["elasticlunr-rs", "ammonia"]
 [[bin]]
 doc = false
 name = "mdbook"
+
+[[example]]
+name = "nop-preprocessor"
+test = true

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -101,4 +101,58 @@ mod nop_lib {
             renderer != "not-supported"
         }
     }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn nop_preprocessor_run() {
+            let input_json = r##"[
+                {
+                    "root": "/path/to/book",
+                    "config": {
+                        "book": {
+                            "authors": ["AUTHOR"],
+                            "language": "en",
+                            "multilingual": false,
+                            "src": "src",
+                            "title": "TITLE"
+                        },
+                        "preprocessor": {
+                            "nop": {}
+                        }
+                    },
+                    "renderer": "html",
+                    "mdbook_version": "0.4.21"
+                },
+                {
+                    "sections": [
+                        {
+                            "Chapter": {
+                                "name": "Chapter 1",
+                                "content": "# Chapter 1\n",
+                                "number": [1],
+                                "sub_items": [],
+                                "path": "chapter_1.md",
+                                "source_path": "chapter_1.md",
+                                "parent_names": []
+                            }
+                        }
+                    ],
+                    "__non_exhaustive": null
+                }
+            ]"##;
+            let input_json = input_json.as_bytes();
+
+            let (ctx, book) = mdbook::preprocess::CmdPreprocessor::parse_input(input_json).unwrap();
+            let expected_book = book.clone();
+            let result = Nop::new().run(&ctx, book);
+            assert!(result.is_ok());
+
+            // The nop-preprocessor should not have made any changes to the book content.
+            let actual_book = result.unwrap();
+            assert_eq!(actual_book, expected_book);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds test code to the nop-preprocessor example.

If you have better test data or test methods, I would appreciate your suggestions.

### Purpose

The purpose of this PR is showing preprocessor developers what the interface (input) data looks like and how to test the preprocessing results.  Currently, the documentation states that JSON data consisting of a two-element array `[context, book]` is passed from the mdbook, but developers need to actually dump the input themselves to get the actual input data.

### Consideration

Since this PR hard-codes an example of current interface data, it is necessary to keep up with the changes if the interface JSON format changes in the future.

This may not be the best solution to compatibility testing (#1574), but it may be part of it.