### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ If possible, do your best to avoid breaking older browser releases.
 Any change to the HTML or styling is encouraged to manually check on as many browsers and platforms that you can.
 Unfortunately at this time we don't have any automated UI or browser testing, so your assistance in testing is appreciated.
 
-## Updating higlight.js
+## Updating highlight.js
 
 The following are instructions for updating [highlight.js](https://highlightjs.org/).
 

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -454,7 +454,7 @@ impl<'a> SummaryParser<'a> {
                     items.push(item);
                 }
                 Some(Event::Start(Tag::List(..))) => {
-                    // Skip this tag after comment bacause it is not nested.
+                    // Skip this tag after comment because it is not nested.
                     if items.is_empty() {
                         continue;
                     }


### PR DESCRIPTION
Found via `codespell -S ./src/theme -L crate,nam,varius,phasis`