### PR TITLE
Add styles for <kbd> elements

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -22,8 +22,8 @@ body {
 }
 
 code {
-    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace !important;
-    font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
+    font-family: var(--mono-font) !important;
+    font-size: var(--code-font-size);
 }
 
 /* make long words/inline code not x overflow */
@@ -148,6 +148,18 @@ blockquote {
     border-bottom: .1em solid var(--quote-border);
 }
 
+kbd {
+    background-color: var(--table-border-color);
+    border-radius: 4px;
+    border: solid 1px var(--theme-popup-border);
+    box-shadow: inset 0 -1px 0 var(--theme-hover);
+    display: inline-block;
+    font-size: var(--code-font-size);
+    font-family: var(--mono-font);
+    line-height: 10px;
+    padding: 4px 5px;
+    vertical-align: middle;
+}
 
 :not(.footnote-definition) + .footnote-definition,
 .footnote-definition + :not(.footnote-definition) {

--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -6,6 +6,8 @@
     --page-padding: 15px;
     --content-max-width: 750px;
     --menu-bar-height: 50px;
+    --mono-font: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
+    --code-font-size: 0.875em /* please adjust the ace font size accordingly in editor.js */
 }
 
 /* Themes */

--- a/test_book/src/individual/mixed.md
+++ b/test_book/src/individual/mixed.md
@@ -27,6 +27,8 @@ fn main(){
 }
 ```
 
+<kbd>Ctrl</kbd> + <kbd>S</kbd> saves a file.
+
 A random image sprinkled in between
 
 ![16x16 rust-lang logo](http://rust-lang.org/logos/rust-logo-16x16.png)
@@ -41,6 +43,7 @@ A random image sprinkled in between
   2. be
   3. `put`
   4. here?
+  5. **<kbd>Ctrl</kbd> + <kbd>S</kbd> saves a file.**
 
 | col1 | col2 | col 3 | col 4 | col 5 | col 6 |
 | ---- | ---- | ----- | ----- | ----- | ----- |


### PR DESCRIPTION
Allows for special styles to call them out since they're different than normal text and different than code. They can make use of styles they inherit for font style and weight.

Notes on changes:

- Added new CSS variables for reused elements
- The font-* rules are separate for each aspect so that they can inherit bold/italic/etc
- I picked the color vars based on what looks good, not necessarily based on logical name reuse

Closes https://github.com/rust-lang/mdBook/issues/1813

## Screenies

<img width="408" alt="image" src="https://user-images.githubusercontent.com/928367/194408658-555c5f9c-49cb-42ed-81e3-abd0a2e333a7.png">
<img width="412" alt="Screen Shot 2022-10-06 at 4 07 32 PM" src="https://user-images.githubusercontent.com/928367/194408535-a8c7e232-82b5-4725-bc09-eba1117fc37d.png">
<img width="387" alt="Screen Shot 2022-10-06 at 4 07 28 PM" src="https://user-images.githubusercontent.com/928367/194408537-384aded7-2c72-44b8-9565-cbb06d0626d3.png">
<img width="414" alt="Screen Shot 2022-10-06 at 4 07 24 PM" src="https://user-images.githubusercontent.com/928367/194408539-352d6dd9-959a-4f25-9c1b-b5a1d0887238.png">
<img width="412" alt="Screen Shot 2022-10-06 at 4 07 20 PM" src="https://user-images.githubusercontent.com/928367/194408540-555f5a91-148b-4394-9128-4db55a444b7e.png">

And here's how it looks in a list with bold styles applied:

<img width="318" alt="Screen Shot 2022-10-06 at 4 07 13 PM" src="https://user-images.githubusercontent.com/928367/194408541-c04071f7-8cb4-4bb5-96f2-40749b95eded.png">
