### PR TITLE
fix copying invisible text

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -11,7 +11,7 @@ function playground_text(playground) {
         let editor = window.ace.edit(code_block);
         return editor.getValue();
     } else {
-        return code_block.textContent;
+        return code_block.innerText;
     }
 }
 


### PR DESCRIPTION
I noticed this bug whenever I copied any code from a book, in rust, it would copy a 
```
#![allow(unused_variables)]
fn main() {
...
}
```
or
```
#![allow(unused)]
fn main() {
...
}
```

This fixes that, by copying the `innerText`, instead of the `textContent`, which included invisible text (`display: none`, or `.boring` class)