### PR TITLE
Prefere .bookignore when build too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ shlex = "1"
 tempfile = "3.0"
 toml = "0.5.1"
 topological-sort = "0.1.0"
+gitignore = "1.0"
 
 # Watch feature
 notify = { version = "4.0", optional = true }
-gitignore = { version = "1.0", optional = true }
 
 # Serve feature
 futures-util = { version = "0.3.4", optional = true }
@@ -58,7 +58,7 @@ walkdir = "2.0"
 
 [features]
 default = ["watch", "serve", "search"]
-watch = ["notify", "gitignore"]
+watch = ["notify"]
 serve = ["futures-util", "tokio", "warp"]
 search = ["elasticlunr-rs", "ammonia"]
 

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,3 +1,4 @@
+use crate::utils::ignore::remove_ignored_files;
 use crate::{get_book_dir, open};
 use clap::{arg, App, Arg, ArgMatches};
 use mdbook::errors::Result;
@@ -67,53 +68,6 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     });
 
     Ok(())
-}
-
-fn remove_ignored_files(book_root: &Path, paths: &[PathBuf]) -> Vec<PathBuf> {
-    if paths.is_empty() {
-        return vec![];
-    }
-
-    match find_gitignore(book_root) {
-        Some(gitignore_path) => {
-            match gitignore::File::new(gitignore_path.as_path()) {
-                Ok(exclusion_checker) => filter_ignored_files(exclusion_checker, paths),
-                Err(_) => {
-                    // We're unable to read the .gitignore file, so we'll silently allow everything.
-                    // Please see discussion: https://github.com/rust-lang/mdBook/pull/1051
-                    paths.iter().map(|path| path.to_path_buf()).collect()
-                }
-            }
-        }
-        None => {
-            // There is no .gitignore file.
-            paths.iter().map(|path| path.to_path_buf()).collect()
-        }
-    }
-}
-
-fn find_gitignore(book_root: &Path) -> Option<PathBuf> {
-    book_root
-        .ancestors()
-        .map(|p| p.join(".gitignore"))
-        .find(|p| p.exists())
-}
-
-fn filter_ignored_files(exclusion_checker: gitignore::File, paths: &[PathBuf]) -> Vec<PathBuf> {
-    paths
-        .iter()
-        .filter(|path| match exclusion_checker.is_excluded(path) {
-            Ok(exclude) => !exclude,
-            Err(error) => {
-                warn!(
-                    "Unable to determine if {:?} is excluded: {:?}. Including it.",
-                    &path, error
-                );
-                true
-            }
-        })
-        .map(|path| path.to_path_buf())
-        .collect()
 }
 
 /// Calls the closure when a book source file is changed, blocking indefinitely.

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use crate::utils::ignore::remove_ignored_files;
 use log::{debug, trace};
 use std::convert::Into;
 use std::fs::{self, File};
@@ -111,6 +112,14 @@ pub fn copy_files_except_ext(
 
     for entry in fs::read_dir(from)? {
         let entry = entry?;
+
+        // Check if entry is ignored
+        let paths = vec![entry.path()];
+        let paths = remove_ignored_files(from, &paths[..]);
+        if paths.is_empty() {
+            continue;
+        }
+
         let metadata = entry
             .path()
             .metadata()

--- a/src/utils/ignore.rs
+++ b/src/utils/ignore.rs
@@ -1,0 +1,49 @@
+use log::warn;
+use std::path::{Path, PathBuf};
+
+pub fn remove_ignored_files(book_root: &Path, paths: &[PathBuf]) -> Vec<PathBuf> {
+    if paths.is_empty() {
+        return vec![];
+    }
+
+    match find_ignorefile(book_root) {
+        Some(gitignore_path) => {
+            match gitignore::File::new(gitignore_path.as_path()) {
+                Ok(exclusion_checker) => filter_ignored_files(exclusion_checker, paths),
+                Err(_) => {
+                    // We're unable to read the .gitignore file, so we'll silently allow everything.
+                    // Please see discussion: https://github.com/rust-lang/mdBook/pull/1051
+                    paths.iter().map(|path| path.to_path_buf()).collect()
+                }
+            }
+        }
+        None => {
+            // There is no .gitignore file.
+            paths.iter().map(|path| path.to_path_buf()).collect()
+        }
+    }
+}
+
+fn find_ignorefile(book_root: &Path) -> Option<PathBuf> {
+    book_root
+        .ancestors()
+        .flat_map(|p| vec![p.join(".bookignore"), p.join(".gitignore")].into_iter())
+        .find(|p| p.exists())
+}
+
+fn filter_ignored_files(exclusion_checker: gitignore::File<'_>, paths: &[PathBuf]) -> Vec<PathBuf> {
+    paths
+        .iter()
+        .filter(|path| match exclusion_checker.is_excluded(path) {
+            Ok(exclude) => !exclude,
+            Err(error) => {
+                warn!(
+                    "Unable to determine if {:?} is excluded: {:?}. Including it.",
+                    &path, error
+                );
+                true
+            }
+        })
+        .map(|path| path.to_path_buf())
+        .collect()
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)] // FIXME: Document this
 
 pub mod fs;
+pub mod ignore;
 mod string;
 pub(crate) mod toml_ext;
 use crate::errors::Error;


### PR DESCRIPTION
Reuse watch command experience (#1044) and process .bookignore (as .gitignore) if prezent.

*MOTIVATION*: I'm just type `src = "."` in [book.toml](https://github.com/podsvirov/mdbook-pikchr/blob/v0.1.2/book.toml) and understand that something is wrong...

*SOLUTION*: I'm make this PR and add [.bookignore](https://github.com/podsvirov/mdbook-pikchr/blob/master/.bookignore) file and life is good, because `mdbook build` no more copy `target` to `book`! :-)