### PR TITLE
Better HTML5 conformance

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -15,7 +15,6 @@
         <!-- Custom HTML head -->
         {{> head}}
 
-        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -269,22 +269,22 @@
         {{/if}}
 
         {{#if playground_js}}
-        <script src="{{ path_to_root }}ace.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}editor.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}mode-rust.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}theme-dawn.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}theme-tomorrow_night.js" charset="utf-8"></script>
+        <script src="{{ path_to_root }}ace.js"></script>
+        <script src="{{ path_to_root }}editor.js"></script>
+        <script src="{{ path_to_root }}mode-rust.js"></script>
+        <script src="{{ path_to_root }}theme-dawn.js"></script>
+        <script src="{{ path_to_root }}theme-tomorrow_night.js"></script>
         {{/if}}
 
         {{#if search_js}}
-        <script src="{{ path_to_root }}elasticlunr.min.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}mark.min.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}searcher.js" charset="utf-8"></script>
+        <script src="{{ path_to_root }}elasticlunr.min.js"></script>
+        <script src="{{ path_to_root }}mark.min.js"></script>
+        <script src="{{ path_to_root }}searcher.js"></script>
         {{/if}}
 
-        <script src="{{ path_to_root }}clipboard.min.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}highlight.js" charset="utf-8"></script>
-        <script src="{{ path_to_root }}book.js" charset="utf-8"></script>
+        <script src="{{ path_to_root }}clipboard.min.js"></script>
+        <script src="{{ path_to_root }}highlight.js"></script>
+        <script src="{{ path_to_root }}book.js"></script>
 
         <!-- Custom JS scripts -->
         {{#each additional_js}}

--- a/src/theme/redirect.hbs
+++ b/src/theme/redirect.hbs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Redirecting...</title>
-    <meta http-equiv="refresh" content="0;URL='{{url}}'">
+    <meta http-equiv="refresh" content="0; URL={{url}}">
     <meta rel="canonical" href="{{url}}">
   </head>
   <body>

--- a/src/theme/redirect.hbs
+++ b/src/theme/redirect.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Redirecting...</title>
     <meta http-equiv="refresh" content="0; URL={{url}}">
-    <meta rel="canonical" href="{{url}}">
+    <link rel="canonical" href="{{url}}">
   </head>
   <body>
       <p>Redirecting to... <a href="{{url}}">{{url}}</a>.</p>


### PR DESCRIPTION
Four minor changes to the templates to improve HTML5 conformance. Here is the commit log

```
State canonical URL using <link> not <meta>.

The Google SEO docs describe using the link element to specify the canonical
page in a redirect. They don't mention anything about <meta>.

----

Fix formatting of content attr in <meta http-equiv=refresh>

According to the HTML specification[1], there needs to be a space after the
semicolon and the URL must be unquoted.

[1]: https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh

----

Don't generate obsolete charset attrs in <script>.

According to the HTML specification[1], the charset attribute is obsolete in
script elements.

[1]: https://html.spec.whatwg.org/multipage/obsolete.html#HTMLScriptElement-partial

----

Don't generate redundant <meta http-equiv=content-type>.

Quoting from the HTML specification[1]:

> A document must not contain both a meta element with an http-equiv attribute
> in the Encoding declaration state and a meta element with the charset
> attribute present.

So we remove the <meta> with the http-equiv attribute from our template.

[1]: https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type
```