### PR TITLE
Fixed html errors caused by redundant `meta[http-equiv]`

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -15,7 +15,6 @@
         <!-- Custom HTML head -->
         {{> head}}
 
-        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />


### PR DESCRIPTION
Quoting from the HTML specification<sup>[1]</sup> about "Specifying the document's character encoding":

  A document must not contain both a `meta` element with an `http-equiv` attribute
  in the `Encoding declaration state` and a `meta` element with the `charset`
  attribute present.

Closes: #1919

[1]: https://html.spec.whatwg.org/dev/semantics.html#charset