### PR TITLE
Update docs link in Cargo.toml to HTTPS version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Michael-F-Bryan <michaelfbryan@gmail.com>",
     "Matt Ickstadt <mattico8@gmail.com>"
 ]
-documentation = "http://rust-lang.github.io/mdBook/index.html"
+documentation = "https://rust-lang.github.io/mdBook/index.html"
 edition = "2021"
 exclude = ["/guide/*"]
 keywords = ["book", "gitbook", "rustbook", "markdown"]


### PR DESCRIPTION
Currently, the documentation link is specified in `Cargo.toml` as:

```
documentation = "http://rust-lang.github.io/mdBook/index.html"
```

which propagates to [crates.io](https://crates.io/crates/mdbook), and if users click on the docs link there they get the non-TLS version. Not likely to cause major issues, but still best practice to use the HTTPS version since it's there