### PR TITLE
fix: random `Array` ref in `src/theme/book.js`

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -166,7 +166,6 @@ function playground_text(playground) {
             .filter(function (node) {return node.classList.contains("editable"); })
             .forEach(function (block) { block.classList.remove('language-rust'); });
 
-        Array
         code_nodes
             .filter(function (node) {return !node.classList.contains("editable"); })
             .forEach(function (block) { hljs.highlightBlock(block); });


### PR DESCRIPTION
Removes `Array` class ref as it's needed and was a mistake 
Closes #1945 