### PR TITLE
Switch to older ubuntu image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,11 @@ jobs:
           - x86_64-pc-windows-msvc
         include:
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
             os: windows-latest
             rust: stable
           - build: msrv
-            os: ubuntu-latest
+            os: ubuntu-20.04
             # sync MSRV with docs: guide/src/guide/installation.md and Cargo.toml
             rust: 1.60.0
     steps:


### PR DESCRIPTION
This switches from 22.04 to 20.04 in order to keep the precompiled binaries compatible with older versions of linux due to glibc version errors.

Fixes #1954