### PR TITLE
Fix test with multiple library paths

### DIFF
--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -25,7 +25,6 @@ pub fn make_subcommand() -> Command {
                 .long("library-path")
                 .value_name("dir")
                 .value_delimiter(',')
-                .num_args(1..)
                 .value_parser(NonEmptyStringValueParser::new())
                 .action(ArgAction::Append)
                 .help(


### PR DESCRIPTION
This fixes the situation of `mdbook test -L deps path-to-book`. clap3 seemed to used to ignore `multiple_values` if there was an optional positional argument (but only if one argument passed to `-L`). clap4 was instead ignoring the positional `path-to-book` argument. This fixes it by removing the "multiple values" altogether. I can't find a situation in clap3 where space-separated values actually worked. 

In my testing, the following cases are the same with clap3 and with this PR:

Allowed:
```
mdbook test -L deps
mdbook test -L deps1,deps2
mdbook test -L deps1 -L deps2
# clap3 was previously smart about knowing there is a positional
# argument, but only if one argument is passed
mdbook test -L deps path-to-book
mdbook test path-to-book -L deps
```

Not allowed
```
# clap3 seemed to get prevent multiple occurrences if there is a positional argument
mdbook test -L deps1 deps2 path-to-book
# The order doesn't seem to matter
mdbook test docs -L deps1 deps2
# I thought dash arguments should interrupt parsing, but that doesn't seem to work
mdbook test -L deps1 deps2 -d output
mdbook test -L deps1 deps2 -d output path-to-book
```

There's likely some edge case that I'm missing. However, I think space-separated values with an optional positional argument are confusing and dangerous enough that I think it is best not to even try to support it. The docs for [`multiple_values`](https://docs.rs/clap/3.2.23/clap/builder/struct.Arg.html#method.multiple_values) explains the hazards with it.

Fixes #1958