### PR TITLE
Use default scrollbars on webkit browsers

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -2,14 +2,6 @@
 
 @import 'variables.css';
 
-::-webkit-scrollbar {
-    background: var(--bg);
-    width: 8px;
-}
-::-webkit-scrollbar-thumb {
-    background: var(--scrollbar);
-    border-radius: 4px;
-}
 html {
     scrollbar-color: var(--scrollbar) var(--bg);
 }

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -4,9 +4,11 @@
 
 ::-webkit-scrollbar {
     background: var(--bg);
+    width: 8px;
 }
 ::-webkit-scrollbar-thumb {
     background: var(--scrollbar);
+    border-radius: 4px;
 }
 html {
     scrollbar-color: var(--scrollbar) var(--bg);


### PR DESCRIPTION
This PR thins scrollbars in Chrome and Safari to make them less assertive.
This is part of #1483, but may not completely close the issue since this does not hide the scrollbars when unused.

I will appreciate your feedback!
Many thanks.