### PR TITLE
include site_url on all pages

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -614,6 +614,9 @@ fn make_data(
         "book_title".to_owned(),
         json!(config.book.title.clone().unwrap_or_default()),
     );
+    if let Some(site_url) = &html_config.site_url {
+        data.insert("base_url".to_owned(), json!(site_url));
+    }
     data.insert(
         "description".to_owned(),
         json!(config.book.description.clone().unwrap_or_default()),


### PR DESCRIPTION
This PR adjusts the result of setting the `site-url` such that if it is set, the `<base>` tag will be rendered on all pages, not just the 404 page.

Based off the documentation for `site-url`, it sounded to me like including `<base>` on all pages was probably intended, just omitted by mistake?

> site-url: The url where the book will be hosted. This is required to ensure navigation links and script/css imports in the 404 file work correctly, even when accessing urls in subdirectories. Defaults to /. If site-url is set, make sure to use document relative links for your assets, meaning they should not start with /.