### PR TITLE
Fix MDBOOK_BOOK environment variable example

### DIFF
--- a/guide/src/format/configuration/environment-variables.md
+++ b/guide/src/format/configuration/environment-variables.md
@@ -29,7 +29,7 @@ book's title without needing to touch your `book.toml`.
 > building the book with something like
 >
 > ```shell
-> $ export MDBOOK_BOOK="{'title': 'My Awesome Book', authors: ['Michael-F-Bryan']}"
+> $ export MDBOOK_BOOK='{"title": "My Awesome Book", "authors": ["Michael-F-Bryan"]}'
 > $ mdbook build
 > ```
 


### PR DESCRIPTION
This fixes the example to use correct JSON syntax.

Fixes #1966