### PR TITLE
Add `open` command

### DIFF
--- a/src/cmd/open.rs
+++ b/src/cmd/open.rs
@@ -1,0 +1,30 @@
+use super::command_prelude::*;
+use crate::{get_book_dir, open};
+use mdbook::errors::Result;
+use mdbook::MDBook;
+use std::path::PathBuf;
+
+// Create clap subcommand arguments
+pub fn make_subcommand() -> Command {
+    Command::new("open")
+        .about("Opens a book previously constructed")
+        .arg_dest_dir()
+        .arg_root_dir()
+        .arg_open()
+}
+
+// Build command implementation
+pub fn execute(args: &ArgMatches) -> Result<()> {
+    let book_dir = get_book_dir(args);
+    let mut book = MDBook::load(&book_dir)?;
+
+    // FIXME: What's the right behaviour if we don't use the HTML renderer?
+    let path = book.build_dir_for("html").join("index.html");
+    if !path.exists() {
+        error!("No chapter available to open");
+        std::process::exit(1)
+    }
+    open(path);
+
+    Ok(())
+}


### PR DESCRIPTION
Addresses https://github.com/rust-lang/mdBook/issues/1969.

This is intended to allow the user to browse the documents with the same convenience as `mdbook build --open`, but without building a book redundantly when it's already built. And without hijacking the terminal like `mdbook watch` and `mdbook serve`. 

This is a rough first iteration. I have likely missed some details (I'm new to the codebase).