### PR TITLE
Add documentation on how to add a highlight.js for additional syntax highlighting support

### DIFF
--- a/guide/src/format/theme/syntax-highlighting.md
+++ b/guide/src/format/theme/syntax-highlighting.md
@@ -63,12 +63,17 @@ your own `highlight.js` file:
 - xml
 - yaml
 
+If you want to support another set of languages for syntax highlighting,
+you can download a "Custom package" from their website, rename the
+`highlight.min.js` to `highlight.js` and move it into the `theme` folder of your
+book.
+
 ## Custom theme
 Like the rest of the theme, the files used for syntax highlighting can be
 overridden with your own.
 
 - ***highlight.js*** normally you shouldn't have to overwrite this file, unless
-  you want to use a more recent version.
+  you want to use a more recent version or support additional languages.
 - ***highlight.css*** theme used by highlight.js for syntax highlighting.
 
 If you want to use another theme for `highlight.js` download it from their


### PR DESCRIPTION
This adds a few lines on how a custom version of `highlight.js` can be obtained and made available to `mdbook`. With that information available, all issues about adding support for a specific language should be safe to be closed because `mdbook` in its default setup probably does not need to support every possible language.

I have seen that there are ongoing efforts to move away from `highlight.js` but I guess this information may nevertheless be useful in the meantime.