### PR TITLE
Use md file's header to link name while summary file's title is blank

### DIFF
--- a/test_book/src/SUMMARY.md
+++ b/test_book/src/SUMMARY.md
@@ -23,7 +23,7 @@
   - [Tasks](individual/task.md)
   - [Strikethrough](individual/strikethrough.md)
   - [MathJax](individual/mathjax.md)
-  - [Mixed](individual/mixed.md)
+  - [](individual/mixed.md)
 - [Languages](languages/README.md)
   - [Syntax Highlight](languages/highlight.md)
 - [Rust Specific](rust/README.md)


### PR DESCRIPTION
You can leave title blank ( `[ ](foobar.md` ) ，so don't worry about different between title in summary.md with H1 header  in foobar.md.