### PR TITLE
Make fonts part of the theme.

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -126,7 +126,10 @@ The following configuration options are available:
   that occur in code blocks and code spans. Defaults to `false`.
 - **mathjax-support:** Adds support for [MathJax](../mathjax.md). Defaults to
   `false`.
-- **copy-fonts:** Copies fonts.css and respective font files to the output directory and use them in the default theme. Defaults to `true`.
+- **copy-fonts:** (**Deprecated**) If `true` (the default), mdBook uses its built-in fonts which are copied to the output directory.
+  If `false`, the built-in fonts will not be used.
+  This option is deprecated. If you want to define your own custom fonts,
+  create a `theme/fonts/fonts.css` file and store the fonts in the `theme/fonts/` directory.
 - **google-analytics:** This field has been deprecated and will be removed in a future release.
   Use the `theme/head.hbs` file to add the appropriate Google Analytics code instead.
 - **additional-css:** If you need to slightly change the appearance of your book

--- a/guide/src/format/theme/README.md
+++ b/guide/src/format/theme/README.md
@@ -26,6 +26,8 @@ Here are the files you can override:
 - **_highlight.css_** is the theme used for the code highlighting.
 - **_favicon.svg_** and **_favicon.png_** the favicon that will be used. The SVG
   version is used by [newer browsers].
+- **fonts/fonts.css** contains the definition of which fonts to load.
+  Custom fonts can be included in the `fonts` directory.
 
 Generally, when you want to tweak the theme, you don't need to override all the
 files. If you only need changes in the stylesheet, there is no point in

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -6,6 +6,7 @@ use super::MDBook;
 use crate::config::Config;
 use crate::errors::*;
 use crate::theme;
+use crate::utils::fs::write_file;
 use log::{debug, error, info, trace};
 
 /// A helper for setting up a new book and its directory structure.
@@ -157,6 +158,19 @@ impl BookBuilder {
 
         let mut highlight_js = File::create(themedir.join("highlight.js"))?;
         highlight_js.write_all(theme::HIGHLIGHT_JS)?;
+
+        write_file(&themedir.join("fonts"), "fonts.css", theme::fonts::CSS)?;
+        for (file_name, contents) in theme::fonts::LICENSES {
+            write_file(&themedir, file_name, contents)?;
+        }
+        for (file_name, contents) in theme::fonts::OPEN_SANS.iter() {
+            write_file(&themedir, file_name, contents)?;
+        }
+        write_file(
+            &themedir,
+            theme::fonts::SOURCE_CODE_PRO.0,
+            theme::fonts::SOURCE_CODE_PRO.1,
+        )?;
 
         Ok(())
     }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -9,7 +9,7 @@ pub mod searcher;
 
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::errors::*;
 use log::warn;
@@ -54,6 +54,8 @@ pub struct Theme {
     pub general_css: Vec<u8>,
     pub print_css: Vec<u8>,
     pub variables_css: Vec<u8>,
+    pub fonts_css: Option<Vec<u8>>,
+    pub font_files: Vec<PathBuf>,
     pub favicon_png: Option<Vec<u8>>,
     pub favicon_svg: Option<Vec<u8>>,
     pub js: Vec<u8>,
@@ -104,7 +106,7 @@ impl Theme {
                 ),
             ];
 
-            let load_with_warn = |filename: &Path, dest| {
+            let load_with_warn = |filename: &Path, dest: &mut Vec<u8>| {
                 if !filename.exists() {
                     // Don't warn if the file doesn't exist.
                     return false;
@@ -119,6 +121,29 @@ impl Theme {
 
             for (filename, dest) in files {
                 load_with_warn(&filename, dest);
+            }
+
+            let fonts_dir = theme_dir.join("fonts");
+            if fonts_dir.exists() {
+                let mut fonts_css = Vec::new();
+                if load_with_warn(&fonts_dir.join("fonts.css"), &mut fonts_css) {
+                    theme.fonts_css.replace(fonts_css);
+                }
+                if let Ok(entries) = fonts_dir.read_dir() {
+                    theme.font_files = entries
+                        .filter_map(|entry| {
+                            let entry = entry.ok()?;
+                            if entry.file_name() == "fonts.css" {
+                                None
+                            } else if entry.file_type().ok()?.is_dir() {
+                                log::info!("skipping font directory {:?}", entry.path());
+                                None
+                            } else {
+                                Some(entry.path())
+                            }
+                        })
+                        .collect();
+                }
             }
 
             // If the user overrides one favicon, but not the other, do not
@@ -153,6 +178,8 @@ impl Default for Theme {
             general_css: GENERAL_CSS.to_owned(),
             print_css: PRINT_CSS.to_owned(),
             variables_css: VARIABLES_CSS.to_owned(),
+            fonts_css: None,
+            font_files: Vec::new(),
             favicon_png: Some(FAVICON_PNG.to_owned()),
             favicon_svg: Some(FAVICON_SVG.to_owned()),
             js: JS.to_owned(),
@@ -209,10 +236,10 @@ mod tests {
             "favicon.png",
             "favicon.svg",
             "css/chrome.css",
-            "css/fonts.css",
             "css/general.css",
             "css/print.css",
             "css/variables.css",
+            "fonts/fonts.css",
             "book.js",
             "highlight.js",
             "tomorrow-night.css",
@@ -223,6 +250,7 @@ mod tests {
 
         let temp = TempFileBuilder::new().prefix("mdbook-").tempdir().unwrap();
         fs::create_dir(temp.path().join("css")).unwrap();
+        fs::create_dir(temp.path().join("fonts")).unwrap();
 
         // "touch" all of the special files so we have empty copies
         for file in &files {
@@ -240,6 +268,8 @@ mod tests {
             general_css: Vec::new(),
             print_css: Vec::new(),
             variables_css: Vec::new(),
+            fonts_css: Some(Vec::new()),
+            font_files: Vec::new(),
             favicon_png: Some(Vec::new()),
             favicon_svg: Some(Vec::new()),
             js: Vec::new(),

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,5 +1,6 @@
 use mdbook::config::Config;
 use mdbook::MDBook;
+use pretty_assertions::assert_eq;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
@@ -121,6 +122,20 @@ fn copy_theme() {
         "css/variables.css",
         "favicon.png",
         "favicon.svg",
+        "fonts/OPEN-SANS-LICENSE.txt",
+        "fonts/SOURCE-CODE-PRO-LICENSE.txt",
+        "fonts/fonts.css",
+        "fonts/open-sans-v17-all-charsets-300.woff2",
+        "fonts/open-sans-v17-all-charsets-300italic.woff2",
+        "fonts/open-sans-v17-all-charsets-600.woff2",
+        "fonts/open-sans-v17-all-charsets-600italic.woff2",
+        "fonts/open-sans-v17-all-charsets-700.woff2",
+        "fonts/open-sans-v17-all-charsets-700italic.woff2",
+        "fonts/open-sans-v17-all-charsets-800.woff2",
+        "fonts/open-sans-v17-all-charsets-800italic.woff2",
+        "fonts/open-sans-v17-all-charsets-italic.woff2",
+        "fonts/open-sans-v17-all-charsets-regular.woff2",
+        "fonts/source-code-pro-v11-all-charsets-500.woff2",
         "highlight.css",
         "highlight.js",
         "index.hbs",


### PR DESCRIPTION
This changes it so that fonts are part of the theme. This allows the user to override and customize the fonts.

The `output.html.copy-fonts` option is deprecated, and will be removed in a future release. If customizing the fonts, you should define a `theme/fonts/fonts.css` file with whatever settings you want, and include any fonts in the `theme/fonts` directory.

Note that FontAwesome is not part of the custom fonts. I will likely try to find some alternate solution (such as #1330) for loading (and customizing) that.

Closes #1967