### PR TITLE
fix overflow-x on mobile

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -12,7 +12,16 @@ a > .hljs {
     color: var(--links);
 }
 
+/*
+    body-container is necessary because mobile browsers don't seem to like
+    overflow-x on the body tag when there is a <meta name="viewport"> tag.
+*/
 #body-container {
+    /*
+        This is used when the sidebar pushes the body content off the side of
+        the screen on small screens. Without it, dragging on mobile Safari
+        will want to reposition the viewport in a weird way.
+    */
     overflow-x: hidden;
 }
 

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -12,6 +12,10 @@ a > .hljs {
     color: var(--links);
 }
 
+#body-container {
+    overflow-x: hidden;
+}
+
 /* Menu Bar */
 
 #menu-bar,

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -54,6 +54,7 @@
         {{/if}}
     </head>
     <body>
+    <div id="body-container">
         <!-- Provide site root to javascript -->
         <script>
             var path_to_root = "{{ path_to_root }}";
@@ -309,5 +310,6 @@
         {{/if}}
         {{/if}}
 
+    </div>
     </body>
 </html>


### PR DESCRIPTION
The browsers on mobile devices ignore the `overflow-x: hidden` within the body tag if `<meta name="viewport">` tag is present. The fix is to add a container inside the body tag that contains everything the body would normally contain. This should solve issues #1667 and #1734.