### PR TITLE
Fix incorrect version command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,6 @@ body:
     attributes:
       label: Version
       description: >
-        Please paste the output of running `mdbook version` or which version
+        Please paste the output of running `mdbook --version` or which version
         of the library you are using.
       render: text

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -19,6 +19,6 @@ body:
     attributes:
       label: Version
       description: >
-        Please paste the output of running `mdbook version` or which version
+        Please paste the output of running `mdbook --version` or which version
         of the library you are using.
       render: text


### PR DESCRIPTION
The `version` command does not exist, but clap defines a default flag `--version` or `-V`.