### PR TITLE
Default the sidebar to visible in large screens

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -92,10 +92,12 @@
         <!-- Hide / unhide sidebar before it is displayed -->
         <script>
             var html = document.querySelector('html');
-            var sidebar = 'hidden';
+            var sidebar = null;
             if (document.body.clientWidth >= 1080) {
                 try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';
+            } else {
+                sidebar = 'hidden';
             }
             html.classList.remove('sidebar-visible');
             html.classList.add("sidebar-" + sidebar);


### PR DESCRIPTION
The code here leads me to believe that the intention is for the sidebar to be default visible on large screens (where `clientWidth` > 1080) and hidden otherwise.

However, as previously written, if the `localStorage.getItem` call fails (for example, if the user agent is not accepting cookies), then we fall back to `sidebar = sidebar || 'visible';` — but `sidebar` is already set to `hidden`, so the `|| 'visible'` never happens.

This results in the sidebar hiding itself on every navigation through an mdBook, meaning if you're just switching between sections trying to find something that you keep needing to re-open the sidebar.