### PR TITLE
Remove spammy `debug!` log from `path_to_root`

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -38,7 +38,6 @@ pub fn write_file<P: AsRef<Path>>(build_dir: &Path, filename: P, content: &[u8])
 /// Consider [submitting a new issue](https://github.com/rust-lang/mdBook/issues)
 /// or a [pull-request](https://github.com/rust-lang/mdBook/pulls) to improve it.
 pub fn path_to_root<P: Into<PathBuf>>(path: P) -> String {
-    debug!("path_to_root");
     // Remove filename and add "../" for every directory
 
     path.into()


### PR DESCRIPTION
The log statement is empty and simply fills up the logs when you run `mdbook` with `RUST_LOG=debug`.