### PR TITLE
Feature: support dockerized builds of current source-code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 ##### docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
 # https://github.com/docker/buildx/issues/318#issuecomment-1023226339
 #FROM --platform=$BUILDPLATFORM rustlang/rust:nightly-buster-slim as builder
-FROM rustlang/rust:nightly-buster-slim as builder
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
 
 # Installing git because of the workaround for the config
 # https://github.com/rust-lang/cargo/issues/10781#issuecomment-1441071052

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,14 +47,14 @@ RUN cargo build --locked --bin mdbook --release --target x86_64-unknown-linux-mu
 
 ################
 ##### Runtime
-FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS runtime 
+FROM alpine:3.18.4 AS runtime 
 
 # Copy application binary from builder image
 COPY --from=builder /usr/src/github.com/rust-lang/mdBook/target/x86_64-unknown-linux-musl/release/mdbook /usr/local/bin/mdbook
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /etc/build.log
-
+# Just to document which port a container from this image exposes
 EXPOSE 3000
+
+# The command to serve the books
 ENTRYPOINT ["mdbook", "serve", "--hostname", "0.0.0.0"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,22 +15,29 @@ WORKDIR /usr/src/github.com/rust-lang
 # Create blank project
 RUN USER=root cargo new mdBook
 
+WORKDIR /usr/src/github.com/rust-lang/mdBook
+
+## Install target platform (Cross-Compilation) --> Needed for Alpine
+# Use stable rather than nightly for the build target
+# Got errors while building after 6 months
+# https://substrate.stackexchange.com/questions/5379/how-do-i-fix-a-failed-build-error-e0635-unknown-feature-proc-macro-span-shri/9312#9312
+RUN rustup default stable
+
+# note: the `x86_64-unknown-linux-musl` target may not be installed  
+RUN rustup target add x86_64-unknown-linux-musl
+
 # We want dependencies cached, so copy those first.
 COPY Cargo.toml Cargo.lock /usr/src/github.com/rust-lang/mdBook
 # examples is referenced in Cargo.toml
 COPY examples /usr/src/github.com/rust-lang/mdBook/examples
 
-WORKDIR /usr/src/github.com/rust-lang/mdBook
-
-## Install target platform (Cross-Compilation) --> Needed for Alpine
-#RUN rustup install nightly  
-RUN rustup target add x86_64-unknown-linux-musl
-
-# This is a dummy build to get the dependencies cached.
+# This is a dummy build to pull dependencies and have them cached
 # https://github.com/rust-lang/cargo/issues/8172#issuecomment-659056517
 # Very slow builds: https://github.com/rust-lang/cargo/issues/9167#issuecomment-1219251978
 # Logs verbose: https://github.com/rust-lang/cargo/issues/1106#issuecomment-141555744
 RUN cargo build -vv --config "net.git-fetch-with-cli=true" --target x86_64-unknown-linux-musl --release
+
+WORKDIR /usr/src/github.com/rust-lang/mdBook
 
 # Now copy in the rest of the sources
 COPY src /usr/src/github.com/rust-lang/mdBook/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN rustup default stable
 RUN rustup target add x86_64-unknown-linux-musl
 
 # We want dependencies cached, so copy those first.
-COPY Cargo.toml Cargo.lock /usr/src/github.com/rust-lang/mdBook
+COPY Cargo.toml Cargo.lock /usr/src/github.com/rust-lang/mdBook/
 # examples is referenced in Cargo.toml
 COPY examples /usr/src/github.com/rust-lang/mdBook/examples
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+################
+##### Builder
+##### docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+# https://github.com/docker/buildx/issues/318#issuecomment-1023226339
+#FROM --platform=$BUILDPLATFORM rustlang/rust:nightly-buster-slim as builder
+FROM rustlang/rust:nightly-buster-slim as builder
+
+# Installing git because of the workaround for the config
+# https://github.com/rust-lang/cargo/issues/10781#issuecomment-1441071052
+RUN apt-get update && apt-get install -y git
+
+WORKDIR /usr/src/github.com/rust-lang
+
+# Create blank project
+RUN USER=root cargo new mdBook
+
+# We want dependencies cached, so copy those first.
+COPY Cargo.toml Cargo.lock /usr/src/github.com/rust-lang/mdBook
+# examples is referenced in Cargo.toml
+COPY examples /usr/src/github.com/rust-lang/mdBook/examples
+
+WORKDIR /usr/src/github.com/rust-lang/mdBook
+
+## Install target platform (Cross-Compilation) --> Needed for Alpine
+#RUN rustup install nightly  
+RUN rustup target add x86_64-unknown-linux-musl
+
+# This is a dummy build to get the dependencies cached.
+# https://github.com/rust-lang/cargo/issues/8172#issuecomment-659056517
+# Very slow builds: https://github.com/rust-lang/cargo/issues/9167#issuecomment-1219251978
+# Logs verbose: https://github.com/rust-lang/cargo/issues/1106#issuecomment-141555744
+RUN cargo build -vv --config "net.git-fetch-with-cli=true" --target x86_64-unknown-linux-musl --release
+
+# Now copy in the rest of the sources
+COPY src /usr/src/github.com/rust-lang/mdBook/src
+
+# This is the actual application build: # ./target/x86_64-unknown-linux-musl/release/mdbook
+RUN cargo build --locked --bin mdbook --release --target x86_64-unknown-linux-musl
+
+################
+##### Runtime
+FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS runtime 
+
+# Copy application binary from builder image
+COPY --from=builder /usr/src/github.com/rust-lang/mdBook/target/x86_64-unknown-linux-musl/release/mdbook /usr/local/bin/mdbook
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /etc/build.log
+
+EXPOSE 3000
+ENTRYPOINT ["mdbook", "serve", "--hostname", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (warp::server): listening on http:
 rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (mdbook::cmd::watch): Listening for changes...
 ```
 
+* Test it in a container as well
+
+> **NOTE**: docker compose creates a default network with the name of the `dir_default` 
+
+```console
+docker run -ti --network mdbook_default alpine/lynx mdbook:3000
+                                                                                                                                                                                  
+Introduction (p1 of 3)
+    1. Prefix Chapter
+    2.
+    3. 1. Introduction
+    4. 2. Draft Chapter
+    5.
+    6. Actual Markdown Tag Examples
+    7. 3. Markdown Individual tags
+    8.
+         1. 3.1. Heading
+         2. 3.2. Paragraphs
+         3. 3.3. Line Break
+         4. 3.4. Emphasis
+         5. 3.5. Blockquote
+         6. 3.6. List
+         7. 3.7. Code
+         8. 3.8. Image
+         9. 3.9. Links and Horizontal Rule
+        10. 3.10. Tables
+```
+
 ## License
 
 All the code in this repository is released under the ***Mozilla Public License v2.0***, for more information take a look at the [LICENSE] file.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ If you are interested in contributing to the development of mdBook, check out th
 docker run -ti -v $(pwd):/mdbook -p 3000:3000 rust-lang/mdbook
 ```
 
+* Using docker-compose.yaml, you can run to load the sources from the `test-book`.
+
+```console
+$ docker compose up --build
+[+] Building 0.0s (0/0)                                                                                                                                              docker-container:mac-linux-builder
+[+] Running 1/1
+ ✔ Container rustlang-mdbook  Recreated                                                                                                                                                            0.1s 
+Attaching to rustlang-mdbook
+rustlang-mdbook  | 2023-11-23 16:52:59 [INFO] (mdbook::book): Book building has started
+rustlang-mdbook  | 2023-11-23 16:52:59 [INFO] (mdbook::book): Running the html backend
+rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (mdbook::cmd::serve): Serving on: http://0.0.0.0:3000
+rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (warp::server): Server::run; addr=0.0.0.0:3000
+rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (warp::server): listening on http://0.0.0.0:3000
+rustlang-mdbook  | 2023-11-23 16:53:00 [INFO] (mdbook::cmd::watch): Listening for changes...
+```
+
 ## License
 
 All the code in this repository is released under the ***Mozilla Public License v2.0***, for more information take a look at the [LICENSE] file.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ The User Guide also serves as a demonstration to showcase what a book looks like
 
 If you are interested in contributing to the development of mdBook, check out the [Contribution Guide].
 
+## Container
+
+> **NOTE**: You need to have docker installed
+> https://docs.docker.com/language/golang/run-containers/
+
+1. Locate a local directory with md files
+2. Quickly run a docker container with the current version:
+
+```console
+docker run -ti -v $(pwd)/src:/src -p 3000:3000 rust-lang/mdbook
+```
+
 ## License
 
 All the code in this repository is released under the ***Mozilla Public License v2.0***, for more information take a look at the [LICENSE] file.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ If you are interested in contributing to the development of mdBook, check out th
 ## Container
 
 > **NOTE**: You need to have docker installed
-> https://docs.docker.com/language/golang/run-containers/
+> https://docs.docker.com/engine/install/
 
 1. Locate a local directory with md files
 2. Quickly run a docker container with the current version:
 
 ```console
-docker run -ti -v $(pwd)/src:/src -p 3000:3000 rust-lang/mdbook
+docker run -ti -v $(pwd):/mdbook -p 3000:3000 rust-lang/mdbook
 ```
 
 ## License

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+
+  ####
+  #### 1. Place this file in a folder where the **/*.md files exist
+  #### 2. Adjust the port number to one available locally
+  #### 3. Adjust the volume path to point to the container's /src dir
+  ####
+  mdbook:
+    image: rust-lang/mdbook
+    container_name: rustlang-mdbook
+    platform: linux/amd64
+    build:
+      context: .
+      args:
+        BASE_IMAGE: rustlang/rust:nightly-buster-slim
+    ports:
+      - 3000:3000
+    volumes:
+      - ./test_book/src:/src
+


### PR DESCRIPTION
# 🎉 Support containers

* I'm on my first day learning Rust 🦀 and Cargo 🏗️ and I must say it's good...
  * However, there's a lot of overhead for users who just want to use this amazing project.
* This is a very simple example to support a Docker image with just `25MB` built from the current code
  * I can push support for CI/CD using Github Actions, publish dev images to Github Docker Registry and push `prod` docker images to the official Docker Registry.
* This DOES SUPPORT LIVE RELOAD!
  * If a developer changes the local files and refresh the page, the server will automatically render changes!

# 🏗️ Docker image build

> **NOTE**: The final image is very minimal with Alpine Linux with `25MB`

The build below is performed from the source-code, and not from an external installation. It is building a single platform version for simplicity.

```console
$ docker buildx build --platform linux/amd64 -t rust-lang/mdbook -o type=docker  .
[+] Building 2.8s (23/23) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                     0.0s
 => => transferring dockerfile: 2.17kB                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/alpine:3.16.0                                                                                                         2.0s
 => [internal] load metadata for docker.io/rustlang/rust:nightly-buster-slim                                                                                             1.4s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                                            0.0s
 => [auth] rustlang/rust:pull token for registry-1.docker.io                                                                                                             0.0s
 => [runtime 1/3] FROM docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c                                           0.0s
 => => resolve docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c                                                   0.0s
 => [builder  1/11] FROM docker.io/rustlang/rust:nightly-buster-slim@sha256:609c65daad3c69f9a37717e45d794e2eab99ad488dc5d492b8fc85c97c1df531                             0.0s
 => => resolve docker.io/rustlang/rust:nightly-buster-slim@sha256:609c65daad3c69f9a37717e45d794e2eab99ad488dc5d492b8fc85c97c1df531                                       0.0s
 => [internal] load build context                                                                                                                                        0.0s
 => => transferring context: 4.94kB                                                                                                                                      0.0s
 => CACHED [builder  2/11] RUN apt-get update && apt-get install -y git                                                                                                  0.0s
 => CACHED [builder  3/11] WORKDIR /usr/src/github.com/rust-lang                                                                                                         0.0s
 => CACHED [builder  4/11] RUN USER=root cargo new mdBook                                                                                                                0.0s
 => CACHED [builder  5/11] COPY Cargo.toml Cargo.lock /usr/src/github.com/rust-lang/mdBook                                                                               0.0s
 => CACHED [builder  6/11] COPY examples /usr/src/github.com/rust-lang/mdBook/examples                                                                                   0.0s
 => CACHED [builder  7/11] WORKDIR /usr/src/github.com/rust-lang/mdBook                                                                                                  0.0s
 => CACHED [builder  8/11] RUN rustup target add x86_64-unknown-linux-musl                                                                                               0.0s
 => CACHED [builder  9/11] RUN cargo build -vv --config "net.git-fetch-with-cli=true" --target x86_64-unknown-linux-musl --release                                       0.0s
 => CACHED [builder 10/11] COPY src /usr/src/github.com/rust-lang/mdBook/src                                                                                             0.0s
 => CACHED [builder 11/11] RUN cargo build --locked --bin mdbook --release --target x86_64-unknown-linux-musl                                                            0.0s
 => CACHED [runtime 2/3] COPY --from=builder /usr/src/github.com/rust-lang/mdBook/target/x86_64-unknown-linux-musl/release/mdbook /usr/local/bin/mdbook                  0.0s
 => CACHED [runtime 3/3] RUN echo "I am running on linux/arm64, building for linux/amd64" > /etc/build.log                                                               0.0s
 => exporting to oci image format                                                                                                                                        0.7s
 => => exporting layers                                                                                                                                                  0.0s
 => => exporting manifest sha256:f658cf0db29cb5655960164f745fbd841fb0dbba53f2b387e60c5e23f360459b                                                                        0.0s
 => => exporting config sha256:55c34204ee9e1fea12a11af808615f46f89cb428a3c6ff1e46c1bade9282a26a                                                                          0.0s
 => => sending tarball                                                                                                                                                   0.7s
 => importing to docker                                                                                                                                                  0.0s
```

* The file size can be inspected as follows:

```console
$ docker images | grep mdbook
rust-lang/mdbook   latest  55c34204ee9e   27 minutes ago  24.8MB
```

# 🏃 Running a server

* This is a container running with a volume to the md source-code in the current dir mounted
* It also exposes a port number for the service to be reused

```console
$ ls -la $(pwd)/src
total 24
drwxr-xr-x  13 mdesales  staff   416 Feb 22 14:06 .
drwxr-xr-x  12 mdesales  staff   384 Feb 22 14:06 ..
-rw-r--r--   1 mdesales  staff   980 Feb 22 14:06 README.md
-rw-r--r--   1 mdesales  staff  4764 Feb 22 14:06 SUMMARY.md
drwxr-xr-x  10 mdesales  staff   320 Feb 22 14:06 assets
drwxr-xr-x   7 mdesales  staff   224 Feb 22 14:06 data
drwxr-xr-x  19 mdesales  staff   608 Feb 22 14:06 infra
drwxr-xr-x   7 mdesales  staff   224 Feb 22 14:06 monitoring
drwxr-xr-x   7 mdesales  staff   224 Feb 22 14:06 onboard
drwxr-xr-x  17 mdesales  staff   544 Feb 22 14:06 services
drwxr-xr-x   4 mdesales  staff   128 Feb 22 14:06 structure
drwxr-xr-x  43 mdesales  staff  1376 Feb 22 14:06 support
drwxr-xr-x  17 mdesales  staff   544 Feb 22 14:06 tips
```

* You can then mount the volume and the desired port for local development server.

```console
$ docker run -ti -v $(pwd)/src:/src -p 3000:3000 rust-lang/mdbook
2023-02-23 03:13:24 [INFO] (mdbook::book): Book building has started
2023-02-23 03:13:24 [INFO] (mdbook::book): Running the html backend
2023-02-23 03:13:29 [INFO] (mdbook::cmd::serve): Serving on: http://0.0.0.0:3000
2023-02-23 03:13:29 [INFO] (warp::server): Server::run; addr=0.0.0.0:3000
2023-02-23 03:13:29 [INFO] (warp::server): listening on http://0.0.0.0:3000
2023-02-23 03:13:29 [INFO] (mdbook::cmd::watch): Listening for changes...
```

* While the server is running, users can also change the contents of any of the files of the mapped volume and enjoy the live reloads!
  * The server will log the file changed and refresh the UI with the latest version

```console
2023-02-23 03:28:47 [INFO] (mdbook::book): Running the html backend
2023-02-23 03:28:54 [INFO] (mdbook::cmd::serve): Files changed: ["/src/onboard/.requirements.md.swp"]
2023-02-23 03:28:54 [INFO] (mdbook::cmd::serve): Building book...
2023-02-23 03:28:54 [INFO] (mdbook::book): Book building has started
2023-02-23 03:28:54 [INFO] (mdbook::book): Running the html backend
2023-02-23 03:29:05 [INFO] (mdbook::cmd::serve): Files changed: ["/src/onboard/.requirements.md.swp", "/src/onboard/requirements.md"]
2023-02-23 03:29:05 [INFO] (mdbook::cmd::serve): Building book...
2023-02-23 03:29:05 [INFO] (mdbook::book): Book building has started
2023-02-23 03:29:05 [INFO] (mdbook::book): Running the html backend
```
 
# 🐳 Docker compose option

* We can drop the following `docker-compose.yaml` for users to run locally
* Pushed to the repo as well
* Starting the server becomes even simpler to test the test-book

> **NOTE** The command below builds the docker image with for the platform `linux/amd64` and starts a container loading the sources from the dir `test_book` on this repo.

```console
$ docker compose up --build
[+] Running 1/1
 ⠿ Container handbook-mdbook-1  Recreated                                                                                                                                0.2s
Attaching to rustlang-mdbook
rustlang-mdbook  | 2023-02-24 01:00:05 [INFO] (mdbook::book): Book building has started
rustlang-mdbook  | 2023-02-24 01:00:06 [INFO] (mdbook::book): Running the html backend
rustlang-mdbook  | 2023-02-24 01:00:11 [INFO] (mdbook::cmd::serve): Serving on: http://0.0.0.0:3000
rustlang-mdbook  | 2023-02-24 01:00:11 [INFO] (warp::server): Server::run; addr=0.0.0.0:3000
rustlang-mdbook  | 2023-02-24 01:00:11 [INFO] (warp::server): listening on http://0.0.0.0:3000
rustlang-mdbook  | 2023-02-24 01:00:11 [INFO] (mdbook::cmd::watch): Listening for changes...
[+] Running 1/1
```

## 🌐 Testing in container

```console
docker run -ti --network mdbook_default alpine/lynx mdbook:3000
```
![Screenshot 2023-11-23 at 9 43 18 AM](https://github.com/rust-lang/mdBook/assets/131457/555c823f-492c-4030-93a0-311aa407fa04)
