### PR TITLE
Only apply "key" styling to nested <kbd>s

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -148,7 +148,7 @@ blockquote {
     border-bottom: .1em solid var(--quote-border);
 }
 
-kbd {
+kbd > kbd {
     background-color: var(--table-border-color);
     border-radius: 4px;
     border: solid 1px var(--theme-popup-border);


### PR DESCRIPTION
It turns out that this is the recommended practice: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd#representing_keystrokes_within_an_input