### PR TITLE
Change overflow-x hidden to clip

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -22,7 +22,7 @@ a > .hljs {
         the screen on small screens. Without it, dragging on mobile Safari
         will want to reposition the viewport in a weird way.
     */
-    overflow-x: hidden;
+    overflow-x: clip;
 }
 
 /* Menu Bar */


### PR DESCRIPTION
I'm sorry for my mistake, this should fix #2028. 

As it turns out, any ancestor of a sticky element that has `overflow: hidden`  becomes the scrolling container for the sticky element. Changing the `overflow` value from `hidden` to `clip` should fix it, since both are basically the same in this scenario and `clip` doesn't have this behavior. 
It's important to note that `overflow: clip` is a little bit new, but the [support](https://caniuse.com/mdn-css_properties_overflow-x_clip) is really good.

Let me know if I overlooked something else.