### PR TITLE
Use modifier keys for chapter navigation

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -561,9 +561,25 @@ function playground_text(playground, hidden = true) {
 })();
 
 (function chapterNavigation() {
+    const modifiers = Object.fromEntries(['ctrl', 'alt', 'shift', 'meta']
+        .map((k) => [k, `${k}Key`]));
+    const matches = (event) => (matcher) => Object.values(modifiers)
+        .every((v) => matcher.includes(v) === event[v]);
+
     document.addEventListener('keydown', function (e) {
-        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) { return; }
-        if (window.search && window.search.hasFocus()) { return; }
+        const { ctrl, meta } = modifiers;
+
+        // Rejected modifier key combos when combined with left/right arrow keys:
+        // * [] is used for normal scrolling
+        // * [shift] and [ctrl, shift] are used for text selection
+        // * [alt] is used for browser history navigation
+        const combo = [ctrl];
+        const macCombo = [meta]; // mac command key
+        if (![combo, macCombo].some(matches(e))) return;
+
+        // * [ctrl] is used for hopping words if a text-input element is selected
+        const isTextInputMode = ['INPUT', 'TEXTAREA'].includes(document.activeElement.nodeName)
+        if (isTextInputMode) return;
 
         switch (e.key) {
             case 'ArrowRight':


### PR DESCRIPTION
Fixes https://github.com/rust-lang/mdBook/issues/518 and https://github.com/rust-lang/mdBook/issues/1789.

Change chapter navigation key combos from bare left/right arrow to ctrl/cmd + left/right arrow. The bare arrow key combos are bad for accessibility and very easy to press by mistake for users who expect arrow keys to scroll the page.

Edit: Actually not 100% certain it will fix https://github.com/rust-lang/mdBook/issues/1789 as I don't know if ctrl/cmd + arrow keys would also be used for navigating within code blocks when using screen reader software. Could be made less likely to clash by using more complex modifiers, e.g. ctrl+shift, at the expense of making the shortcut less easy to use.