### PR TITLE
fix(cli): init --force skips confirmation prompts

### DIFF
--- a/guide/src/cli/init.md
+++ b/guide/src/cli/init.md
@@ -68,3 +68,7 @@ Create a `.gitignore` file configured to ignore the `book` directory created whe
 If not supplied, an interactive prompt will ask whether it should be created.
 
 [building]: build.md
+
+#### --force
+
+Skip the prompts to create a `.gitignore` and for the title for the book.

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -56,7 +56,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
             "git" => builder.create_gitignore(true),
             _ => builder.create_gitignore(false),
         };
-    } else {
+    } else if !args.get_flag("force") {
         println!("\nDo you want a .gitignore to be created? (y/n)");
         if confirm() {
             builder.create_gitignore(true);
@@ -65,6 +65,8 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     config.book.title = if args.contains_id("title") {
         args.get_one::<String>("title").map(String::from)
+    } else if args.get_flag("force") {
+        None
     } else {
         request_book_title()
     };

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -1,0 +1,24 @@
+use crate::cli::cmd::mdbook_cmd;
+use crate::dummy_book::DummyBook;
+
+use mdbook::config::Config;
+
+/// Run `mdbook init` with `--force` to skip the confirmation prompts
+#[test]
+fn base_mdbook_init_can_skip_confirmation_prompts() {
+    let temp = DummyBook::new().build().unwrap();
+
+    // doesn't exist before
+    assert!(!temp.path().join("book").exists());
+
+    let mut cmd = mdbook_cmd();
+    cmd.args(&["init", "--force"]).current_dir(temp.path());
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("\nAll done, no errors...\n"));
+
+    let config = Config::from_disk(temp.path().join("book.toml")).unwrap();
+    assert_eq!(config.book.title, None);
+
+    assert!(!temp.path().join(".gitignore").exists());
+}

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -12,7 +12,7 @@ fn base_mdbook_init_can_skip_confirmation_prompts() {
     assert!(!temp.path().join("book").exists());
 
     let mut cmd = mdbook_cmd();
-    cmd.args(&["init", "--force"]).current_dir(temp.path());
+    cmd.args(["init", "--force"]).current_dir(temp.path());
     cmd.assert()
         .success()
         .stdout(predicates::str::contains("\nAll done, no errors...\n"));

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,3 +1,4 @@
 mod build;
 mod cmd;
+mod init;
 mod test;


### PR DESCRIPTION
### Summary

This PR fixes #1556 by changing/fixing the behaviour of `mdbook init --force`.

The intent of `--force` is to skip the prompts. This is not how it currently behaves:

```
$ mdbook init --force

Do you want a .gitignore to be created? (y/n)

What title would you like to give the book? 

2023-04-02 23:17:48 [INFO] (mdbook::book::init): Creating a new book with stub content

All done, no errors...
```

### Proposed Changes

* Skip the .gitignore prompt when `--force` is set
* Skip the title prompt when `--force` is set
* Add docs to the guide for `--force`

### What should the reviewer focus on?

* I'm new to Rust and the repo. 🦀 
* I've found it hard to add a failing test that detects the CLI prompts. I did not find an example testing interactions with the CLI in the repo. The test I've added is actually a false positive that does not fail on `master` today. I'm hoping you may have some insight on how to improve it, or we could remove it since it does not add value/confidence. From what I've read, we might consider a tool like the [`rexpect` crate](https://crates.io/crates/rexpect) to help interact with the CLI.

### How have you reviewed these changes?

* I've run `cargo test`, `cargo fmt`, `cargo clippy`
* Manual validation from the debug build works as expected:
  ```
  $ target/debug/mdbook init --force
  2023-04-02 23:24:59 [INFO] (mdbook::book::init): Creating a new book with stub content

  All done, no errors...
  ```
