### PR TITLE
Switch from gitignore to ignore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           - build: msrv
             os: ubuntu-20.04
             # sync MSRV with docs: guide/src/guide/installation.md and Cargo.toml
-            rust: 1.60.0
+            rust: 1.63.0
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
  "memchr",
  "once_cell",
@@ -510,19 +510,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gitignore"
-version = "1.0.7"
+name = "globset"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78aa90e4620c1498ac434c06ba6e521b525794bbdacf085d490cc794b4a2f9a4"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "glob",
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
@@ -719,6 +717,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,8 +935,8 @@ dependencies = [
  "elasticlunr-rs",
  "env_logger",
  "futures-util",
- "gitignore",
  "handlebars",
+ "ignore",
  "log",
  "memchr",
  "notify",
@@ -1656,6 +1677,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MPL-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/mdBook"
 description = "Creates a book from markdown files"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [dependencies]
 anyhow = "1.0.28"
@@ -39,7 +39,7 @@ topological-sort = "0.2.2"
 # Watch feature
 notify = { version = "5.0.0", optional = true }
 notify-debouncer-mini = { version = "0.2.1", optional = true }
-gitignore = { version = "1.0", optional = true }
+ignore = { version = "0.4.20", optional = true }
 
 # Serve feature
 futures-util = { version = "0.3.4", optional = true }
@@ -60,9 +60,9 @@ walkdir = "2.0"
 
 [features]
 default = ["watch", "serve", "search"]
-watch = ["notify", "notify-debouncer-mini", "gitignore"]
-serve = ["futures-util", "tokio", "warp"]
-search = ["elasticlunr-rs", "ammonia"]
+watch = ["dep:notify", "dep:notify-debouncer-mini", "dep:ignore"]
+serve = ["dep:futures-util", "dep:tokio", "dep:warp"]
+search = ["dep:elasticlunr-rs", "dep:ammonia"]
 
 [[bin]]
 doc = false

--- a/guide/src/guide/installation.md
+++ b/guide/src/guide/installation.md
@@ -20,7 +20,7 @@ To make it easier to run, put the path to the binary into your `PATH`.
 
 To build the `mdbook` executable from source, you will first need to install Rust and Cargo.
 Follow the instructions on the [Rust installation page].
-mdBook currently requires at least Rust version 1.60.
+mdBook currently requires at least Rust version 1.63.
 
 Once you have installed Rust, the following command can be used to build and install mdBook:
 


### PR DESCRIPTION
The gitignore crate is no longer maintained and has some issues. This switches to `ignore` which should be more reliable and maintained.

I started work on a test for this, but `notify` was giving me some trouble on macOS. I might return to it later. For now, I have done some manual testing.
