### PR TITLE
Fix handling of copy-fonts=true when fonts.css is overridden

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -294,7 +294,7 @@ impl HtmlHandlebars {
                 if html_config.copy_fonts {
                     warn!(
                         "output.html.copy_fonts is deprecated.\n\
-                        Set copy_fonts=false and ensure the fonts you want are in \
+                        Set copy-fonts=false in book.toml and ensure the fonts you want are in \
                         the `theme/fonts/` directory."
                     );
                 }
@@ -304,7 +304,7 @@ impl HtmlHandlebars {
         if !html_config.copy_fonts && theme.fonts_css.is_none() {
             warn!(
                 "output.html.copy_fonts is deprecated.\n\
-                This book appears to have copy_fonts=false without a fonts.css file.\n\
+                This book appears to have copy-fonts=false in book.toml without a fonts.css file.\n\
                 Add an empty `theme/fonts/fonts.css` file to squelch this warning."
             );
         }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -275,7 +275,8 @@ impl HtmlHandlebars {
             "FontAwesome/fonts/FontAwesome.ttf",
             theme::FONT_AWESOME_TTF,
         )?;
-        if html_config.copy_fonts {
+        // Don't copy the stock fonts if the user has specified their own fonts to use.
+        if html_config.copy_fonts && theme.fonts_css.is_none() {
             write_file(destination, "fonts/fonts.css", theme::fonts::CSS)?;
             for (file_name, contents) in theme::fonts::LICENSES.iter() {
                 write_file(destination, file_name, contents)?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -291,19 +291,12 @@ impl HtmlHandlebars {
         }
         if let Some(fonts_css) = &theme.fonts_css {
             if !fonts_css.is_empty() {
-                if html_config.copy_fonts {
-                    warn!(
-                        "output.html.copy_fonts is deprecated.\n\
-                        Set copy-fonts=false in book.toml and ensure the fonts you want are in \
-                        the `theme/fonts/` directory."
-                    );
-                }
                 write_file(destination, "fonts/fonts.css", &fonts_css)?;
             }
         }
         if !html_config.copy_fonts && theme.fonts_css.is_none() {
             warn!(
-                "output.html.copy_fonts is deprecated.\n\
+                "output.html.copy-fonts is deprecated.\n\
                 This book appears to have copy-fonts=false in book.toml without a fonts.css file.\n\
                 Add an empty `theme/fonts/fonts.css` file to squelch this warning."
             );

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -891,8 +891,8 @@ fn custom_fonts() {
     assert_eq!(actual_files(&p.join("book/fonts")), &builtin_fonts);
     assert!(has_fonts_css(p));
 
-    // Mixed with copy_fonts=true
-    // This should generate a deprecation warning.
+    // Mixed with copy-fonts=true
+    // Should ignore the copy-fonts setting since the user has provided their own fonts.css.
     let temp = TempFileBuilder::new().prefix("mdbook").tempdir().unwrap();
     let p = temp.path();
     MDBook::init(p).build().unwrap();
@@ -900,10 +900,10 @@ fn custom_fonts() {
     write_file(&p.join("theme/fonts"), "myfont.woff", b"").unwrap();
     MDBook::load(p).unwrap().build().unwrap();
     assert!(has_fonts_css(p));
-    let mut expected = Vec::from(builtin_fonts);
-    expected.push("myfont.woff");
-    expected.sort();
-    assert_eq!(actual_files(&p.join("book/fonts")), expected.as_slice());
+    assert_eq!(
+        actual_files(&p.join("book/fonts")),
+        ["fonts.css", "myfont.woff"]
+    );
 
     // copy-fonts=false, no theme
     // This should generate a deprecation warning.


### PR DESCRIPTION
I'm new to mdbook. This is my experience when I failed to configure it.

```bash
$ mdbook init --theme
$ mdbook serve
...
2023-04-28 12:47:53 [WARN] (mdbook::renderer::html_handlebars::hbs_renderer): output.html.copy_fonts is deprecated.
Set  and ensure the fonts you want are in the `theme/fonts/` directory.
...
```

After that, I added `copy_fonts=false` to the book.toml, but this warning is not resolved since it seems that an attribute name convension in book.toml is different.

So, I suggest showing this warning.

```
2023-04-28 12:39:46 [WARN] (mdbook::renderer::html_handlebars::hbs_renderer): output.html.copy_fonts is deprecated.
Set copy-fonts=false in book.toml and ensure the fonts you want are in the `theme/fonts/` directory.
```