### PR TITLE
Display line numbers for code examples

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -210,7 +210,7 @@ The `[output.html.playground]` table provides options for controlling Rust sampl
 editable = false         # allows editing the source code
 copyable = true          # include the copy button for copying code snippets
 copy-js = true           # includes the JavaScript for the code editor
-line-numbers = false     # displays line numbers for editable code
+line-numbers = true      # displays line numbers for editable code
 runnable = true          # displays a run button for rust code
 ```
 


### PR DESCRIPTION
This makes it easier to refer to a specific line of code while teaching or collaborating on a code snippet.