### PR TITLE
Update pulldown-cmark to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ handlebars = "4.3.7"
 log = "0.4.17"
 memchr = "2.5.0"
 opener = "0.5.2"
-pulldown-cmark = { version = "0.9.2", default-features = false }
+pulldown-cmark = { version = "0.9.3", default-features = false }
 regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"


### PR DESCRIPTION
This includes a few small markdown rendering fixes.
Changes: https://github.com/raphlinus/pulldown-cmark/releases/tag/v0.9.3
