### PR TITLE
Avoid menu border flash during page navigation

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -676,13 +676,14 @@ function playground_text(playground, hidden = true) {
         }, { passive: true });
     })();
     (function controllBorder() {
-        menu.classList.remove('bordered');
-        document.addEventListener('scroll', function () {
+        function updateBorder() {
             if (menu.offsetTop === 0) {
                 menu.classList.remove('bordered');
             } else {
                 menu.classList.add('bordered');
             }
-        }, { passive: true });
+        }
+        updateBorder();
+        document.addEventListener('scroll', updateBorder, { passive: true });
     })();
 })();

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -115,7 +115,7 @@
             <div class="page">
                 {{> header}}
                 <div id="menu-bar-hover-placeholder"></div>
-                <div id="menu-bar" class="menu-bar sticky bordered">
+                <div id="menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
                         <button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
                             <i class="fa fa-bars"></i>


### PR DESCRIPTION
Partially addresses #443

Previously when navigating between pages using the sidebar, the border of the menu bar would briefly appear before being hidden by JavaScript. This change fixes this flash by hiding the border initially and then letting JavaScript decide whether or not it should be shown.