### PR TITLE
Add `padding-bottom: 50vh` for <main>

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -90,7 +90,7 @@ h6:target::before {
 
 .content {
     overflow-y: auto;
-    padding: 0 5px 50px 5px;
+    padding: 0 5px 50vh 5px;
 }
 .content main {
     margin-left: auto;


### PR DESCRIPTION
Hello,
This PR introduces a simple tweak: adding extra padding to the bottom of the content area in mdBook.

Here's why it might be a good idea:

- More Comfortable Reading: This change lets users scroll the text up to the center of their screen. It's often easier to read from the middle of the screen and can help reduce eye-strain during long reads.

- Familiar Feel: This 'scroll-past-end' feature is common in popular code editors like VSCode and Atom. It might make mdBook feel a bit more like home for those folks.

This change doesn't break anything and can easily be overridden by custom stylesheets if needed.

Of course, we know changes like these can be a matter of personal preference. So, this PR is completely open for discussion. If you think it's not a great fit for the project, no worries at all if the PR gets closed.

Looking forward to hearing your thoughts!