### PR TITLE
Update proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
The latest nightly doesn't work with the currently pinned version, but a new release has fixed the issue.