### PR TITLE
Update opener to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "notify"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,11 +1108,12 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opener"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
 dependencies = [
  "bstr",
+ "normpath",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ env_logger = "0.10.0"
 handlebars = "4.3.7"
 log = "0.4.17"
 memchr = "2.5.0"
-opener = "0.5.2"
+opener = "0.6.1"
 pulldown-cmark = { version = "0.9.3", default-features = false }
 regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }


### PR DESCRIPTION
opener 0.5.2 → 0.6.1

CHANGELOG: https://github.com/Seeker14491/opener/blob/master/CHANGELOG.md#061---2023-04-14