### PR TITLE
Update predicates to 3.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.0.3",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -971,7 +971,7 @@ dependencies = [
  "notify-debouncer-mini",
  "once_cell",
  "opener",
- "predicates 2.1.5",
+ "predicates",
  "pretty_assertions",
  "pulldown-cmark",
  "regex",
@@ -1273,28 +1273,17 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ ammonia = { version = "3.3.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.11"
-predicates = "2.1.5"
+predicates = "3.0.3"
 select = "0.6.0"
 semver = "1.0.17"
 pretty_assertions = "1.3.0"


### PR DESCRIPTION
predicates 2.1.5 → 3.0.3

CHANGELOG: https://github.com/assert-rs/predicates-rs/blob/master/CHANGELOG.md#303---2023-04-13