### PR TITLE
Use a better merge-queue success check.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,42 +48,19 @@ jobs:
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt --check
 
-  # These success/failure jobs are here to consolidate the total
-  # success/failure state of all other jobs. These jobs are then included in
-  # the GitHub branch protection rule which prevents merges unless all other
-  # jobs are passing. This makes it easier to manage the list of jobs via this
-  # yml file and to prevent accidentally adding new jobs without also updating
-  # the branch protections.
-  #
-  # Unfortunately this requires two jobs because the branch protection
-  # considers skipped jobs as successful. The status check functions like
-  # success() can only be in an `if` condition.
-  #
-  # Beware that success() is false if any dependent job is skipped. See
-  # https://github.com/orgs/community/discussions/45058. This means there
-  # cannot be optional jobs. One workaround is to check for all other
-  # statuses:
-  #     (contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure'))
-  # but that is a mess.
+  # The success job is here to consolidate the total success/failure state of
+  # all other jobs. This job is then included in the GitHub branch protection
+  # rule which prevents merges unless all other jobs are passing. This makes
+  # it easier to manage the list of jobs via this yml file and to prevent
+  # accidentally adding new jobs without also updating the branch protections.
   success:
     name: Success gate
-    runs-on: ubuntu-latest
+    if: always()
     needs:
       - test
       - rustfmt
-    if: "success()"
-    steps:
-      - name: mark the job as a success
-        run: echo success
-  failure:
-    name: Failure gate
     runs-on: ubuntu-latest
-    needs:
-      - test
-      - rustfmt
-    if: "!success()"
     steps:
-      - name: mark the job as a failure
-        run: |
-          echo One or more jobs failed
-          exit 1
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+      - name: Done
+        run: exit 0


### PR DESCRIPTION
This switches the success/fail merge queue check to use a better check. This requires only a single job, should work better, and also supports skipped jobs. This was copied from https://github.com/orgs/community/discussions/46757#discussioncomment-5831752.