### PR TITLE
Add data property to chapter struct

### DIFF
--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -138,7 +138,8 @@ mod nop_lib {
                                 "sub_items": [],
                                 "path": "chapter_1.md",
                                 "source_path": "chapter_1.md",
-                                "parent_names": []
+                                "parent_names": [],
+                                "data": {}
                             }
                         }
                     ],

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -165,6 +165,9 @@ pub struct Chapter {
     pub source_path: Option<PathBuf>,
     /// An ordered list of the names of each chapter above this one in the hierarchy.
     pub parent_names: Vec<String>,
+    /// Data that can be shared between preprocessors, accessed in the renderer
+    /// or accessed in the theme's `.hbs` files
+    pub data: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Chapter {
@@ -444,6 +447,7 @@ And here is some \
             source_path: Some(PathBuf::from("second.md")),
             parent_names: vec![String::from("Chapter 1")],
             sub_items: Vec::new(),
+            data: serde_json::Map::new(),
         };
         let should_be = BookItem::Chapter(Chapter {
             name: String::from("Chapter 1"),
@@ -457,6 +461,7 @@ And here is some \
                 BookItem::Separator,
                 BookItem::Chapter(nested),
             ],
+            data: serde_json::Map::new(),
         });
 
         let got = load_summary_item(&SummaryItem::Link(root), temp.path(), Vec::new()).unwrap();
@@ -533,6 +538,7 @@ And here is some \
                             Vec::new(),
                         )),
                     ],
+                    data: serde_json::Map::new(),
                 }),
                 BookItem::Separator,
             ],
@@ -586,6 +592,7 @@ And here is some \
                             Vec::new(),
                         )),
                     ],
+                    data: serde_json::Map::new(),
                 }),
                 BookItem::Separator,
             ],

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -105,6 +105,7 @@ impl HtmlHandlebars {
             ctx.data
                 .insert("section".to_owned(), json!(section.to_string()));
         }
+        ctx.data.insert("data".to_owned(), json!(ch.data));
 
         // Render the handlebars template with the data
         debug!("Render template");


### PR DESCRIPTION
This data property makes it possible to share data between pre-processors, or between pre-processors and the renderer, including the "html" renderer which exposes the chapter data as "data" in the .hbs files.

I've explicitly not provided a built-in way to configure data. Any built-in approach for parsing data would have to be discussed. While I consider hugo/jekyll style [front-matter](https://gohugo.io/content-management/front-matter/) pretty standard for this kind of thing, others might disagree. Even if everyone agreed, the question would then become "what flavours of front-matter do we support?"

I've also explicitly not created any data properties that are used out of the box by mdBook itself.

I'm assuming this PR would need to go in 0.5.0, as it changes the JSON model and any pre-processors compiled with older versions of mdBook would strip the property.

For reference, my use case: I have (many) large JSON files containing data, and I want to use a pre-processor to insert the correct data in every chapter, to then use it in our theme's `.hbs` file to generate a metadata table, links, that kind of stuff.

Related:

- Request for chapter metadata: #2142 
- Request for TOML front-matter: #277
- Other PR adding a data property to chapters: #1465. That PR adds a pre-processor to extrat TOML front-matter, and it defines a few data properties that are built into mdBook. This PR is more limited in scope.
- Crate [`mdbook_frontmatter`](https://docs.rs/mdbook-frontmatter/0.0.4/src/mdbook_frontmatter/lib.rs.html#1-139) which processes a fixed, limited, set of data properties in YAML front-matter