### PR TITLE
Don't use distinct background for code in headers when printing

### DIFF
--- a/src/theme/css/print.css
+++ b/src/theme/css/print.css
@@ -22,14 +22,6 @@
     overflow-y: initial;
 }
 
-code {
-    background-color: #666666;
-    border-radius: 5px;
-
-    /* Force background to be printed in Chrome */
-    -webkit-print-color-adjust: exact;
-}
-
 pre > .buttons {
     z-index: 2;
 }


### PR DESCRIPTION
Fixes #1933

`#666666` is too dark when printing. `#f6f7f6` is already used to highlight code outside headers, making it a good choice for headers as well: https://github.com/rust-lang/mdBook/blob/ab2cb71c00b1556f83f69c494f176019b8863c20/src/theme/highlight.css#L62

The background in question is also used by mdbook-pdf, where is generates black text on dark gray background. That text can become completely unreadable in some PDF readers when they adjust colors for more comfortable reading experience. https://github.com/HollowMan6/mdbook-pdf/issues/26

It's a simple change, let's make it as better fixes are discussed and developed.