### PR TITLE
Switch macOS notify to kqueue.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ toml = "0.7.6"
 topological-sort = "0.2.2"
 
 # Watch feature
-notify = { version = "6.0.1", optional = true }
+notify = { version = "6.0.1", optional = true, features = ["macos_kqueue"] }
 notify-debouncer-mini = { version = "0.3.0", optional = true }
 ignore = { version = "0.4.20", optional = true }
 


### PR DESCRIPTION
macOS has been having some issues with triggering repeated builds whenever a file is modified if there are any "extra" files in the source tree. This is an attempt at a solution by using a different change-notification backend on macOS. There is more detail at https://github.com/rust-lang/mdBook/issues/2133#issuecomment-1662533364 and https://github.com/notify-rs/notify/issues/465#issuecomment-1657261035 about why this is happening and different options. There is some risk with this change because I don't know what considerations there might be with the kqueue backend, what kind of compatibility there will be, or if there will be problems with different environments. I'm going to go ahead and move forward with this and see if anyone reports any problems. If there are, then I think reverting this and moving to a manual file copy would be another choice.

Fixes #2133