### PR TITLE
Add additional-hljs-packages option

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -102,6 +102,7 @@ mathjax-support = false
 copy-fonts = true
 additional-css = ["custom.css", "custom2.css"]
 additional-js = ["custom.js"]
+additional-hljs-packages = ["custom.min.js"]
 no-section-label = false
 git-repository-url = "https://github.com/rust-lang/mdBook"
 git-repository-icon = "fa-github"
@@ -139,6 +140,7 @@ The following configuration options are available:
 - **additional-js:** If you need to add some behaviour to your book without
   removing the current behaviour, you can specify a set of JavaScript files that
   will be loaded alongside the default one.
+- **additional-hljs-packages:** If you need to add 3rd party highlight.js language packages, you can specify a set of JavaScript files that will be loaded.
 - **no-section-label:** mdBook by defaults adds numeric section labels in the table of
   contents column. For example, "1.", "2.1". Set this option to true to disable
   those labels. Defaults to `false`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -499,6 +499,8 @@ pub struct HtmlConfig {
     /// Additional JS scripts to include at the bottom of the rendered page's
     /// `<body>`.
     pub additional_js: Vec<PathBuf>,
+    /// Additional 3rd party language packages for highlight.js.
+    pub additional_hljs_packages: Vec<PathBuf>,
     /// Fold settings.
     pub fold: Fold,
     /// Playground settings.
@@ -556,6 +558,7 @@ impl Default for HtmlConfig {
             google_analytics: None,
             additional_css: Vec::new(),
             additional_js: Vec::new(),
+            additional_hljs_packages: Vec::new(),
             fold: Fold::default(),
             playground: Playground::default(),
             code: Code::default(),
@@ -988,6 +991,7 @@ mod tests {
         google-analytics = "123456"
         additional-css = ["custom.css", "custom2.css"]
         additional-js = ["custom.js"]
+        additional-hljs-packages = ["custom.min.js"]
         "#;
 
         let book_should_be = BookConfig {
@@ -1013,6 +1017,7 @@ mod tests {
             google_analytics: Some(String::from("123456")),
             additional_css: vec![PathBuf::from("custom.css"), PathBuf::from("custom2.css")],
             additional_js: vec![PathBuf::from("custom.js")],
+            additional_hljs_packages: vec![PathBuf::from("custom.min.js")],
             ..Default::default()
         };
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -378,7 +378,7 @@ impl HtmlHandlebars {
         handlebars.register_helper("theme_option", Box::new(helpers::theme::theme_option));
     }
 
-    /// Copy across any additional CSS and JavaScript files which the book
+    /// Copy across any additional CSS, JavaScript and hljs package files which the book
     /// has been configured to use.
     fn copy_additional_css_and_js(
         &self,
@@ -386,7 +386,11 @@ impl HtmlHandlebars {
         root: &Path,
         destination: &Path,
     ) -> Result<()> {
-        let custom_files = html.additional_css.iter().chain(html.additional_js.iter());
+        let custom_files = html
+            .additional_css
+            .iter()
+            .chain(html.additional_js.iter())
+            .chain(html.additional_hljs_packages.iter());
 
         debug!("Copying additional CSS and JS");
 
@@ -721,6 +725,17 @@ fn make_data(
             }
         }
         data.insert("additional_js".to_owned(), json!(js));
+    }
+
+    if !html_config.additional_hljs_packages.is_empty() {
+        let mut hljs_package = Vec::new();
+        for package in &html_config.additional_hljs_packages {
+            match package.strip_prefix(root) {
+                Ok(p) => hljs_package.push(p.to_str().expect("Could not convert to str")),
+                Err(_) => hljs_package.push(package.to_str().expect("Could not convert to str")),
+            }
+        }
+        data.insert("additional_hljs_packages".to_owned(), json!(hljs_package));
     }
 
     if html_config.playground.editable && html_config.playground.copy_js {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -309,6 +309,10 @@
 
         <script src="{{ path_to_root }}clipboard.min.js"></script>
         <script src="{{ path_to_root }}highlight.js"></script>
+        <!-- Custom 3rd highlight.js language packages -->
+        {{#each additional_hljs_packages}}
+        <script src="{{ ../path_to_root }}{{this}}"></script>
+        {{/each}}
         <script src="{{ path_to_root }}book.js"></script>
 
         <!-- Custom JS scripts -->


### PR DESCRIPTION
As a syntax highlighting tool, highlight.js supports 3rd party languages (see [instructions here](https://github.com/highlightjs/highlight.js/blob/main/docs/language-contribution.rst)) since they don't currently merge new grammars into core. This can be done by placing additional JavaScript files alongside hightlight.js's js file, and then call the syntax highlighting functions provided by `hljs`, such as `hightlightBlock` used in our `book.js`.

However, this can't be done currently in mdbook, since the `additional-js` field is designed for js files called **after** the main `book.js`, while placing the highlight.js 3rd packages there leads to `highlightBlock` called **before** those packages loaded. On the other hand, moving js files specified in `additional-js` field above the `book.js` may lead to unexpected behaviors, since it is supposed to be executed after the `book.js` is executed.

So adding another field, `additional-hljs-packages`, could solve this problem, which will place those js files between the highlight.js's js file and `book.js`.