### PR TITLE
Add workaround for macOS notify problem.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ toml = "0.5.11" # Do not update, see https://github.com/rust-lang/mdBook/issues/
 topological-sort = "0.2.2"
 
 # Watch feature
-notify = { version = "6.0.1", optional = true, features = ["macos_kqueue"] }
+notify = { version = "6.0.1", optional = true }
 notify-debouncer-mini = { version = "0.3.0", optional = true }
 ignore = { version = "0.4.20", optional = true }
 


### PR DESCRIPTION
This adds a new workaround for the macOS notify problem where mdbook is receiving repeated change notifications for changes to extra files (see https://github.com/rust-lang/mdBook/issues/2133). The solution is to not use `fclonefileat`, and just manually copy the file. This unfortunately will use more disk space, and probably be a little slower (though it should not be significant). 

An alternate solution would be to do content hashing, and dedupe watcher events where the content doesn't change. However, that seems sufficiently complicated that it doesn't seem particularly worth the effort.

This reverts https://github.com/rust-lang/mdBook/pull/2152 because it fails with "Too many open files" on books with lots of files.

Fixes #2155
Fixes #2133 (again)
