### PR TITLE
Fix code blocks "indent" without highlight.js

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -260,6 +260,7 @@ pre > .buttons button {
     }
 }
 pre > code {
+    display: block;
     padding: 1rem;
 }
 


### PR DESCRIPTION
The `.hljs` class added by highlight.js adds a `display: block` rule which makes `padding` apply correctly (left padding on all lines, not just the first one).
This change ensures that said rule is applied even if highlight.js doesn't run for whatever reason.

Comparison ([source](https://gbdev.io/pandocs/Audio_Registers.html#ff12--nr12-channel-1-volume--envelope)):

![Without](https://github.com/rust-lang/mdBook/assets/15271137/4130276a-27b0-4096-8b0c-2d918b9254f1)

![With](https://github.com/rust-lang/mdBook/assets/15271137/3c113eaa-f81c-46d8-9b73-2ae5180a2db0)

