### PR TITLE
Adding LinksPreprocessor for SUMMARY.md

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use super::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 use crate::config::BuildConfig;
 use crate::errors::*;
+use crate::preprocess::SummaryPreprocessor;
 use crate::utils::bracket_escape;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -21,7 +22,9 @@ pub fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> 
         .with_context(|| format!("Couldn't open SUMMARY.md in {:?} directory", src_dir))?
         .read_to_string(&mut summary_content)?;
 
-    let summary = parse_summary(&summary_content)
+    let preprocessed_summary_content = SummaryPreprocessor::resolve(src_dir, &summary_content);
+
+    let summary = parse_summary(&preprocessed_summary_content)
         .with_context(|| format!("Summary parsing failed for file={:?}", summary_md))?;
 
     if cfg.create_missing {

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -75,10 +75,10 @@ fn create_missing(src_dir: &Path, summary: &Summary) -> Result<()> {
 /// [`iter()`]: #method.iter
 /// [`for_each_mut()`]: #method.for_each_mut
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Book {
     /// The sections in this book.
     pub sections: Vec<BookItem>,
-    __non_exhaustive: (),
 }
 
 impl Book {
@@ -226,10 +226,7 @@ pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P)
         chapters.push(chapter);
     }
 
-    Ok(Book {
-        sections: chapters,
-        __non_exhaustive: (),
-    })
+    Ok(Book { sections: chapters })
 }
 
 fn load_summary_item<P: AsRef<Path> + Clone>(

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -839,7 +839,7 @@ mod tests {
             .and_then(Value::as_str)
             .unwrap();
         assert_eq!(html, "html");
-        let html_renderer = HtmlHandlebars::default();
+        let html_renderer = HtmlHandlebars;
         let pre = LinkPreprocessor::new();
 
         let should_run = preprocessor_should_run(&pre, &html_renderer, &cfg);

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -566,9 +566,7 @@ fn get_last_link(links: &mut [SummaryItem]) -> Result<(usize, &mut Link)> {
     links
         .iter_mut()
         .enumerate()
-        .filter_map(|(i, item)| item.maybe_link_mut().map(|l| (i, l)))
-        .rev()
-        .next()
+        .filter_map(|(i, item)| item.maybe_link_mut().map(|l| (i, l))).next_back()
         .ok_or_else(||
             anyhow::anyhow!("Unable to get last link because the list of SummaryItems doesn't contain any Links")
             )

--- a/src/config.rs
+++ b/src/config.rs
@@ -646,19 +646,11 @@ impl Default for Playground {
 }
 
 /// Configuration for tweaking how the the HTML renderer handles code blocks.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Code {
     /// A prefix string to hide lines per language (one or more chars).
     pub hidelines: HashMap<String, String>,
-}
-
-impl Default for Code {
-    fn default() -> Code {
-        Code {
-            hidelines: HashMap::new(),
-        }
-    }
 }
 
 /// Configuration of the search functionality of the HTML renderer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
 fn create_clap_command() -> Command {
     let app = Command::new(crate_name!())
         .about(crate_description!())
-        .author("Mathieu David <mathieudavid@mathieudavid.org>")
+        .author("Mathieu David <mathieudavid@mathieudavid.org> and edited by Mauro Gentile <gents83@gmail.com>")
         .version(VERSION)
         .propagate_version(true)
         .arg_required_else_help(true)

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -71,7 +71,7 @@ impl Preprocessor for LinkPreprocessor {
     }
 }
 
-fn replace_all<P1, P2>(
+pub(crate) fn replace_all<P1, P2>(
     s: &str,
     path: P1,
     source: P2,

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -3,10 +3,12 @@
 pub use self::cmd::CmdPreprocessor;
 pub use self::index::IndexPreprocessor;
 pub use self::links::LinkPreprocessor;
+pub use self::summary::SummaryPreprocessor;
 
 mod cmd;
 mod index;
 mod links;
+mod summary;
 
 use crate::book::Book;
 use crate::config::Config;

--- a/src/preprocess/summary.rs
+++ b/src/preprocess/summary.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+/// A preprocessor dedicated just to the summary to resolve links
+#[derive(Default)]
+pub struct SummaryPreprocessor;
+
+impl SummaryPreprocessor {
+    /// Preprocess Summary to resolve links.
+    pub fn resolve(src_dir: &Path, content: &str) -> String {
+        let mut title = String::from("SUMMARY.md");
+        super::links::replace_all(content, src_dir, src_dir, 0, &mut title)
+    }
+}

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -823,7 +823,7 @@ fn build_header_links(html: &str) -> String {
 
             // Ignore .menu-title because now it's getting detected by the regex.
             if let Some(classes) = caps.get(3) {
-                for class in classes.as_str().split(" ") {
+                for class in classes.as_str().split(' ') {
                     if IGNORE_CLASS.contains(&class) {
                         return caps[0].to_string();
                     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -73,14 +73,12 @@ pub fn create_file(path: &Path) -> Result<File> {
 
 /// Removes all the content of a directory but not the directory itself
 pub fn remove_dir_content(dir: &Path) -> Result<()> {
-    for item in fs::read_dir(dir)? {
-        if let Ok(item) = item {
-            let item = item.path();
-            if item.is_dir() {
-                fs::remove_dir_all(item)?;
-            } else {
-                fs::remove_file(item)?;
-            }
+    for item in (fs::read_dir(dir)?).flatten() {
+        let item = item.path();
+        if item.is_dir() {
+            fs::remove_dir_all(item)?;
+        } else {
+            fs::remove_file(item)?;
         }
     }
     Ok(())

--- a/tests/custom_preprocessors.rs
+++ b/tests/custom_preprocessors.rs
@@ -17,7 +17,7 @@ fn example_supports_whatever() {
 
     let got = cmd.supports_renderer("whatever");
 
-    assert_eq!(got, true);
+    assert!(got);
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn example_doesnt_support_not_supported() {
 
     let got = cmd.supports_renderer("not-supported");
 
-    assert_eq!(got, false);
+    assert!(!got);
 }
 
 #[test]

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -966,5 +966,5 @@ fn custom_header_attributes() {
         r##"<h2 id="heading-with-classes" class="class1 class2"><a class="header" href="#heading-with-classes">Heading with classes</a></h2>"##,
         r##"<h2 id="both" class="class1 class2"><a class="header" href="#both">Heading with id and classes</a></h2>"##,
     ];
-    assert_contains_strings(&contents, summary_strings);
+    assert_contains_strings(contents, summary_strings);
 }


### PR DESCRIPTION
This commit is intended to add the possibility to reuse the LinksPreprocessor inside SUMMARY.md

Example:
This would allow to use something like {{#include autogenerated.md}} to allow a more dynamic summary with an autogenerated md file that is left to the user