### PR TITLE
Ignore files listed in .mdbookignore during build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,19 +492,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gitignore"
-version = "1.0.7"
+name = "globset"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78aa90e4620c1498ac434c06ba6e521b525794bbdacf085d490cc794b4a2f9a4"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
- "glob",
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
@@ -660,6 +667,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,8 +832,8 @@ dependencies = [
  "elasticlunr-rs",
  "env_logger",
  "futures-util",
- "gitignore",
  "handlebars",
+ "ignore",
  "log",
  "memchr",
  "notify",
@@ -1629,6 +1654,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ anyhow = "1.0.28"
 chrono = "0.4"
 clap = { version = "3.0", features = ["cargo"] }
 clap_complete = "3.0"
-once_cell = "1"
 env_logger = "0.9.0"
+ignore = "0.4"
 handlebars = "4.0"
 log = "0.4"
 memchr = "2.0"
+once_cell = "1"
 opener = "0.5"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 regex = "1.5.5"
@@ -37,7 +38,6 @@ topological-sort = "0.1.0"
 
 # Watch feature
 notify = { version = "4.0", optional = true }
-ignore = { version = "0.4", optional = true }
 
 # Serve feature
 futures-util = { version = "0.3.4", optional = true }
@@ -58,7 +58,7 @@ walkdir = "2.0"
 
 [features]
 default = ["watch", "serve", "search"]
-watch = ["notify", "ignore"]
+watch = ["notify"]
 serve = ["futures-util", "tokio", "warp"]
 search = ["elasticlunr-rs", "ammonia"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ topological-sort = "0.1.0"
 
 # Watch feature
 notify = { version = "4.0", optional = true }
-gitignore = { version = "1.0", optional = true }
+ignore = { version = "0.4", optional = true }
 
 # Serve feature
 futures-util = { version = "0.3.4", optional = true }
@@ -58,7 +58,7 @@ walkdir = "2.0"
 
 [features]
 default = ["watch", "serve", "search"]
-watch = ["notify", "gitignore"]
+watch = ["notify", "ignore"]
 serve = ["futures-util", "tokio", "warp"]
 search = ["elasticlunr-rs", "ammonia"]
 

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -279,6 +279,16 @@ The value can be any valid URI the browser should navigate to (e.g. `https://rus
 This will generate an HTML page which will automatically redirect to the given location.
 Note that the source location does not support `#` anchor redirects.
 
+### `[.mdbookignore]`
+
+You can use a `.mdbookignore` file to exclude files from the build process. The file is places in the `src` directory of your book and has the format known from [`.gitignore`](https://git-scm.com/docs/gitignore) files.
+
+For example:
+```
+*.rs
+/target/
+```
+
 ## Markdown Renderer
 
 The Markdown renderer will run preprocessors and then output the resulting

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -279,9 +279,11 @@ The value can be any valid URI the browser should navigate to (e.g. `https://rus
 This will generate an HTML page which will automatically redirect to the given location.
 Note that the source location does not support `#` anchor redirects.
 
-### `[.mdbookignore]`
+### `.mdbookignore`
 
-You can use a `.mdbookignore` file to exclude files from the build process. The file is places in the `src` directory of your book and has the format known from [`.gitignore`](https://git-scm.com/docs/gitignore) files.
+You can use a `.mdbookignore` file to exclude files from the build process.
+The file is placed in the `src` directory of your book and has the same format as
+[`.gitignore`](https://git-scm.com/docs/gitignore) files.
 
 For example:
 ```

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -859,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn build_test_book() {
+    fn mdbookignore_ignores_file() {
         let temp_dir = TempFileBuilder::new().prefix("mdbook-").tempdir().unwrap();
         let test_book_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_book");
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -587,6 +587,7 @@ fn preprocessor_should_run(
 mod tests {
     use super::*;
     use std::str::FromStr;
+    use tempfile::Builder as TempFileBuilder;
     use toml::value::{Table, Value};
 
     #[test]
@@ -855,5 +856,22 @@ mod tests {
         let should_be = false;
         let got = preprocessor_should_run(&BoolPreprocessor(should_be), &html, &cfg);
         assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn build_test_book() {
+        let temp_dir = TempFileBuilder::new().prefix("mdbook-").tempdir().unwrap();
+        let test_book_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_book");
+
+        utils::fs::copy_files_except_ext(&test_book_dir, temp_dir.path(), true, None, None)
+            .expect("Error while copying test book to temp dir");
+
+        let book = MDBook::load(temp_dir.path()).expect("Unable to load book");
+        book.build().expect("Error while building book");
+
+        let book_dir = temp_dir.path().join("book");
+        assert!(book_dir.join("index.html").exists());
+        assert!(book_dir.join(".mdbookignore").exists());
+        assert!(!book_dir.join("ignored_file").exists());
     }
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::utils::fs::get_404_output_file;
 use handlebars::Handlebars;
+use ignore::gitignore::GitignoreBuilder;
 use log::{debug, trace, warn};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
@@ -589,7 +590,23 @@ impl Renderer for HtmlHandlebars {
             .context("Unable to emit redirects")?;
 
         // Copy all remaining files, avoid a recursive copy from/to the book build dir
-        utils::fs::copy_files_except_ext(&src_dir, destination, true, Some(&build_dir), &["md"])?;
+        let mut builder = GitignoreBuilder::new(&src_dir);
+        let mdbook_ignore = src_dir.join(".mdbookignore");
+        if mdbook_ignore.exists() {
+            if let Some(err) = builder.add(mdbook_ignore) {
+                warn!("Unable to load '.mdbookignore' file: {}", err);
+            }
+        }
+        builder.add_line(None, "*.md")?;
+        let ignore = builder.build()?;
+
+        utils::fs::copy_files_except_ext(
+            &src_dir,
+            destination,
+            true,
+            Some(&build_dir),
+            Some(&ignore),
+        )?;
 
         Ok(())
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -117,6 +117,14 @@ pub fn copy_files_except_ext(
             .metadata()
             .with_context(|| format!("Failed to read {:?}", entry.path()))?;
 
+        // Check if it is in the blacklist
+        if let Some(ignore) = ignore {
+            let path = entry.path();
+            if ignore.matched(&path, path.is_dir()).is_ignore() {
+                continue;
+            }
+        }
+
         // If the entry is a dir and the recursive option is enabled, call itself
         if metadata.is_dir() && recursive {
             if entry.path() == to.to_path_buf() {
@@ -125,13 +133,6 @@ pub fn copy_files_except_ext(
 
             if let Some(avoid) = avoid_dir {
                 if entry.path() == *avoid {
-                    continue;
-                }
-            }
-
-            if let Some(ignore) = ignore {
-                let path = entry.path();
-                if ignore.matched(&path, path.is_dir()).is_ignore() {
                     continue;
                 }
             }
@@ -149,14 +150,6 @@ pub fn copy_files_except_ext(
                 ignore,
             )?;
         } else if metadata.is_file() {
-            // Check if it is in the blacklist
-            if let Some(ignore) = ignore {
-                let path = entry.path();
-                if ignore.matched(&path, path.is_dir()).is_ignore() {
-                    continue;
-                }
-            }
-
             debug!(
                 "creating path for file: {:?}",
                 &to.join(

--- a/test_book/src/.mdbookignore
+++ b/test_book/src/.mdbookignore
@@ -1,0 +1,1 @@
+ignored_file

--- a/test_book/src/ignored_file
+++ b/test_book/src/ignored_file
@@ -1,0 +1,1 @@
+This will not be copied to the book directory.


### PR DESCRIPTION
Based on https://github.com/rust-lang/mdBook/pull/1908 by @Bergmann89.

This fixes the issues identified by @ehuss, except for the updated `copy_files_except_ext` function:

>Since this is a public API, the API can't change. I think you will need to create a new function. Also, the naming would no longer be appropriate (_ext was filtering on extensions, and this is now filtering on ignore).

I would like to discuss that.

>the naming would no longer be appropriate

Agreed, I'd call it just `copy_files`

>I think you will need to create a new function.

In which case `copy_files_except_ext` would be orphaned within the mdBook codebase - as far as I saw, it has a single caller.

Maybe some package that depends on `mdbook` uses this function, maybe none does; information flows the other way, so we have no way of knowing, and no way of addressing that, except, of course, for... semver (which Cargo helpfully enforces).

>Since this is a public API, the API can't change

As far as I understand the semver specification, public API can change as long as the change is denoted by incrementing the major version - except in the case of `0.x` versions, where anything goes. Generally, I'm a detractor of using `0.x` versions for prolonged periods of time, exactly for this reason.

Maybe, after adding much-awaited support for `.mdbookignore`, it would be a good time to release a `1.0.0`, and start harnessing the full benefits of the semver standard by tracking breaking changes in the major version? That's what it's for :shrug: 