### PR TITLE
Add resize indicator to the sidebar

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -269,6 +269,11 @@ pre > .buttons button {
         /* On mobile, make it easier to tap buttons. */
         padding: 0.3rem 1rem;
     }
+
+    .sidebar-resize-indicator {
+        /* Hide resize indicator on devices with limited accuracy */
+        display: none;
+    }
 }
 pre > code {
     padding: 1rem;

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -450,7 +450,7 @@ ul#searchresults span.teaser em {
     z-index: -1;
 }
 [dir=rtl] #sidebar-toggle-anchor:not(:checked) ~ .sidebar {
-    transform: translateX(var(--sidebar-width) + var(--sidebar-resize-indicator-width));
+    transform: translateX(calc(var(--sidebar-width) + var(--sidebar-resize-indicator-width)));
 }
 .sidebar::-webkit-scrollbar {
     background: var(--sidebar-bg);
@@ -461,7 +461,7 @@ ul#searchresults span.teaser em {
 
 /* sidebar-visible */
 #sidebar-toggle-anchor:checked ~ .page-wrapper {
-    transform: translateX(var(--sidebar-width) + var(--sidebar-resize-indicator-width));
+    transform: translateX(calc(var(--sidebar-width) + var(--sidebar-resize-indicator-width)));
 }
 [dir=rtl] #sidebar-toggle-anchor:checked ~ .page-wrapper {
     transform: translateX(calc(0px - var(--sidebar-width) - var(--sidebar-resize-indicator-width)));

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -422,22 +422,35 @@ ul#searchresults span.teaser em {
     position: absolute;
     cursor: col-resize;
     width: 0;
-    right: 0;
+    right: calc(var(--sidebar-resize-indicator-width) * -1);
     top: 0;
     bottom: 0;
+    display: flex;
+    align-items: center;
 }
-[dir=rtl] .sidebar .sidebar-resize-handle { right:  unset; left: 0; }
+
+.sidebar-resize-handle .sidebar-resize-indicator {
+    width: 100%;
+    height: 12px;
+    background-color: var(--icons);
+    margin-inline-start: var(--sidebar-resize-indicator-space);
+}
+
+[dir=rtl] .sidebar .sidebar-resize-handle {
+    left: calc(var(--sidebar-resize-indicator-width) * -1);
+    right: unset;
+}
 .js .sidebar .sidebar-resize-handle {
     cursor: col-resize;
-    width: 5px;
+    width: calc(var(--sidebar-resize-indicator-width) - var(--sidebar-resize-indicator-space));
 }
 /* sidebar-hidden */
 #sidebar-toggle-anchor:not(:checked) ~ .sidebar {
-    transform: translateX(calc(0px - var(--sidebar-width)));
+    transform: translateX(calc(0px - var(--sidebar-width) - var(--sidebar-resize-indicator-width)));
     z-index: -1;
 }
 [dir=rtl] #sidebar-toggle-anchor:not(:checked) ~ .sidebar {
-    transform: translateX(var(--sidebar-width));
+    transform: translateX(var(--sidebar-width) + var(--sidebar-resize-indicator-width));
 }
 .sidebar::-webkit-scrollbar {
     background: var(--sidebar-bg);
@@ -448,15 +461,15 @@ ul#searchresults span.teaser em {
 
 /* sidebar-visible */
 #sidebar-toggle-anchor:checked ~ .page-wrapper {
-    transform: translateX(var(--sidebar-width));
+    transform: translateX(var(--sidebar-width) + var(--sidebar-resize-indicator-width));
 }
 [dir=rtl] #sidebar-toggle-anchor:checked ~ .page-wrapper {
-    transform: translateX(calc(0px - var(--sidebar-width)));
+    transform: translateX(calc(0px - var(--sidebar-width) - var(--sidebar-resize-indicator-width)));
 }
 @media only screen and (min-width: 620px) {
     #sidebar-toggle-anchor:checked ~ .page-wrapper {
         transform: none;
-        margin-inline-start: var(--sidebar-width);
+        margin-inline-start: calc(var(--sidebar-width) + var(--sidebar-resize-indicator-width));
     }
     [dir=rtl] #sidebar-toggle-anchor:checked ~ .page-wrapper {
         transform: none;

--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -3,6 +3,8 @@
 
 :root {
     --sidebar-width: 300px;
+    --sidebar-resize-indicator-width: 8px;
+    --sidebar-resize-indicator-space: 2px;
     --page-padding: 15px;
     --content-max-width: 750px;
     --menu-bar-height: 50px;

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -112,7 +112,9 @@
             <div class="sidebar-scrollbox">
                 {{#toc}}{{/toc}}
             </div>
-            <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>
+            <div id="sidebar-resize-handle" class="sidebar-resize-handle">
+                <div class="sidebar-resize-indicator"></div>
+            </div>
         </nav>
 
         <!-- Track and set sidebar scroll position -->


### PR DESCRIPTION
It fixes #2186.

Indicator has the same color as icons, which is theme-dependent. On devices with limited accuracy ( tablets and smartphones most of the time) indicator is hidden.