### PR TITLE
Fix `mdbook serve` unexpected panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.36"
+version = "0.4.35"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "notify-debouncer-mini",
  "once_cell",
  "opener",
+ "pathdiff",
  "predicates",
  "pretty_assertions",
  "pulldown-cmark",
@@ -1150,6 +1151,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4.17"
 memchr = "2.5.0"
 opener = "0.6.1"
 pulldown-cmark = { version = "0.9.3", default-features = false }
+pathdiff = "0.2.1"
 regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.4.36"
+version = "0.4.35"
 authors = [
     "Mathieu David <mathieudavid@mathieudavid.org>",
     "Michael-F-Bryan <michaelfbryan@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.4.35"
+version = "0.4.36"
 authors = [
     "Mathieu David <mathieudavid@mathieudavid.org>",
     "Michael-F-Bryan <michaelfbryan@gmail.com>",

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -4,6 +4,7 @@ use ignore::gitignore::Gitignore;
 use mdbook::errors::Result;
 use mdbook::utils;
 use mdbook::MDBook;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
 use std::thread::sleep;
@@ -87,11 +88,16 @@ fn find_gitignore(book_root: &Path) -> Option<PathBuf> {
 }
 
 fn filter_ignored_files(ignore: Gitignore, paths: &[PathBuf]) -> Vec<PathBuf> {
+    let current_dir = env::current_dir().expect("Unable to determine the current directory");
+
     paths
         .iter()
         .filter(|path| {
+            let normalized_path = path
+                .strip_prefix(&current_dir)
+                .expect("Could not normalize path");
             !ignore
-                .matched_path_or_any_parents(path, path.is_dir())
+                .matched_path_or_any_parents(normalized_path, normalized_path.is_dir())
                 .is_ignore()
         })
         .map(|path| path.to_path_buf())

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -87,8 +87,8 @@ fn find_gitignore(book_root: &Path) -> Option<PathBuf> {
         .find(|p| p.exists())
 }
 
-// Using `canonicalize` can fail on Windows sometimes, might be a potential risk.
-// see ([https://github.com/rust-lang/mdBook/pull/2229#discussion_r1408665981).
+// Note: The usage of `canonicalize` may encounter occasional failures on the Windows platform, presenting a potential risk.
+// For more details, refer to [Pull Request #2229](https://github.com/rust-lang/mdBook/pull/2229#discussion_r1408665981).
 fn filter_ignored_files(ignore: Gitignore, paths: &[PathBuf]) -> Vec<PathBuf> {
     let ignore_root = ignore
         .path()

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -87,6 +87,8 @@ fn find_gitignore(book_root: &Path) -> Option<PathBuf> {
         .find(|p| p.exists())
 }
 
+// Using `canonicalize` can fail on Windows sometimes, might be a potential risk.
+// see ([https://github.com/rust-lang/mdBook/pull/2229#discussion_r1408665981).
 fn filter_ignored_files(ignore: Gitignore, paths: &[PathBuf]) -> Vec<PathBuf> {
     let ignore_root = ignore
         .path()

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -4,6 +4,7 @@ use ignore::gitignore::Gitignore;
 use mdbook::errors::Result;
 use mdbook::utils;
 use mdbook::MDBook;
+use pathdiff::diff_paths;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
@@ -93,11 +94,10 @@ fn filter_ignored_files(ignore: Gitignore, paths: &[PathBuf]) -> Vec<PathBuf> {
     paths
         .iter()
         .filter(|path| {
-            let normalized_path = path
-                .strip_prefix(&current_dir)
-                .expect("Could not normalize path");
+            let relative_path =
+                diff_paths(&current_dir, &path).expect("One of the paths should be an absolute");
             !ignore
-                .matched_path_or_any_parents(normalized_path, normalized_path.is_dir())
+                .matched_path_or_any_parents(&relative_path, relative_path.is_dir())
                 .is_ignore()
         })
         .map(|path| path.to_path_buf())

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -194,12 +194,6 @@ mod tests {
     use ignore::gitignore::GitignoreBuilder;
     use std::env;
 
-    fn path_to_buf(root: &str, file_name: &str) -> PathBuf {
-        let mut path = PathBuf::from(root);
-        path.push(file_name);
-        path
-    }
-
     #[test]
     fn test_filter_ignored_files() {
         let current_dir = env::current_dir().unwrap();
@@ -209,8 +203,8 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        let should_remain = path_to_buf(current_dir.to_str().unwrap(), "record.text");
-        let should_filter = path_to_buf(current_dir.to_str().unwrap(), "index.html");
+        let should_remain = current_dir.join("record.text");
+        let should_filter = current_dir.join("index.html");
 
         let remain = filter_ignored_files(ignore, &[should_remain.clone(), should_filter]);
         assert_eq!(remain, vec![should_remain])
@@ -226,9 +220,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let parent_dir = format!("{}/../", current_dir.to_str().unwrap());
-        let should_remain = path_to_buf(&parent_dir, "record.text");
-        let should_filter = path_to_buf(&parent_dir, "index.html");
+        let parent_dir = current_dir.join("..");
+        let should_remain = parent_dir.join("record.text");
+        let should_filter = parent_dir.join("index.html");
 
         let remain = filter_ignored_files(ignore, &[should_remain.clone(), should_filter]);
         assert_eq!(remain, vec![should_remain])


### PR DESCRIPTION
Currently the `paths` input of `filter_ignored_files` is absolute while `.matched_path_or_any_parents(path, path.is_dir())` has an assertion which requires path can not have root. This will break down the `mdbook serve`(#2228).
I have tested this issue locally with different path scope and this change ensures we convert the input path into a relative path so that won't break down `mdbook serve`.



https://github.com/rust-lang/mdBook/blob/94e0a44e152d8d7c62620e83e0632160977b1dd5/src/cmd/watch.rs#L89-L99