### PR TITLE
Make sure page wrapper transform is removed in print mode

### DIFF
--- a/src/theme/css/print.css
+++ b/src/theme/css/print.css
@@ -7,7 +7,7 @@
 }
 
 #page-wrapper.page-wrapper {
-    transform: none;
+    transform: none !important;
     margin-inline-start: 0px;
     overflow-y: initial;
 }


### PR DESCRIPTION
resolves #1932 - this bug was actually present in all browsers (chrome, chromium, brave, firefox), not just firefox as stated in the issue.