### PR TITLE
fix: remove double imports of css

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -1,7 +1,5 @@
 /* CSS for UI elements (a.k.a. chrome) */
 
-@import 'variables.css';
-
 html {
     scrollbar-color: var(--scrollbar) var(--bg);
 }

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -1,7 +1,5 @@
 /* Base styles and content styles */
 
-@import 'variables.css';
-
 :root {
     /* Browser default font-size is 16px, this way 1 rem = 10px */
     font-size: 62.5%;


### PR DESCRIPTION
Currently, the CSS stylesheets that are already imported from the parent HTML are also imported from the CSS stylesheets. As far as I can tell, it doesn't cause any major bugs, but it's just messy and causes minor issues (for example, Firefox doesn't fire extra requests to fetch CSS twice, but it loads it twice which makes navigating developer menu harder).

From my not-very-extensive testing, it should also allows us to remove this script: https://github.com/rust-lang/mdBook/blob/b7f46213c7df8f499eca0c82e7b41804cc15e369/src/theme/index.hbs#L80-L91