### PR TITLE
Remove warning check for theme directory as ./src/theme

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -478,25 +478,6 @@ impl HtmlHandlebars {
     }
 }
 
-// TODO(mattico): Remove some time after the 0.1.8 release
-fn maybe_wrong_theme_dir(dir: &Path) -> Result<bool> {
-    fn entry_is_maybe_book_file(entry: fs::DirEntry) -> Result<bool> {
-        Ok(entry.file_type()?.is_file()
-            && entry.path().extension().map_or(false, |ext| ext == "md"))
-    }
-
-    if dir.is_dir() {
-        for entry in fs::read_dir(dir)? {
-            if entry_is_maybe_book_file(entry?).unwrap_or(false) {
-                return Ok(false);
-            }
-        }
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
 impl Renderer for HtmlHandlebars {
     fn name(&self) -> &str {
         "html"
@@ -528,16 +509,6 @@ impl Renderer for HtmlHandlebars {
             }
             None => ctx.root.join("theme"),
         };
-
-        if html_config.theme.is_none()
-            && maybe_wrong_theme_dir(&src_dir.join("theme")).unwrap_or(false)
-        {
-            warn!(
-                "Previous versions of mdBook erroneously accepted `./src/theme` as an automatic \
-                 theme directory"
-            );
-            warn!("Please move your theme files to `./theme` for them to continue being used");
-        }
 
         let theme = theme::Theme::new(theme_dir);
 


### PR DESCRIPTION
This was causing an unnecessary warning if `&src_dir` was the same as `ctx.root`.

Also, this code had a `TODO` to "remove some time after the 0.1.8 release".