### PR TITLE
Allow disable header links

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -550,6 +550,8 @@ pub struct HtmlConfig {
     pub print: Print,
     /// Don't render section labels.
     pub no_section_label: bool,
+    /// Whether to insert jumpable links into the headers.
+    pub header_link: bool,
     /// Search settings. If `None`, the default will be used.
     pub search: Option<Search>,
     /// Git repository url. If `None`, the git button will not be shown.
@@ -601,6 +603,7 @@ impl Default for HtmlConfig {
             code: Code::default(),
             print: Print::default(),
             no_section_label: false,
+            header_link: true,
             search: None,
             git_repository_url: None,
             git_repository_icon: None,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -840,8 +840,7 @@ fn insert_link_into_header(
 
     if html_config.header_link {
         format!(
-            r##"<h{level} id="{id}"{classes}><a class="header" href="#{id}">
-        {text}</a></h{level}>"##,
+            r##"<h{level} id="{id}"{classes}><a class="header" href="#{id}">{text}</a></h{level}>"##,
             level = level,
             id = id,
             text = content,
@@ -1089,6 +1088,7 @@ mod tests {
 
     #[test]
     fn original_build_header_links() {
+        let html_config = HtmlConfig::default();
         let inputs = vec![
             (
                 "blah blah <h1>Foo</h1>",
@@ -1132,7 +1132,7 @@ mod tests {
         ];
 
         for (src, should_be) in inputs {
-            let got = build_header_links(src);
+            let got = build_header_links(src, &html_config);
             assert_eq!(got, should_be);
         }
     }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -817,7 +817,7 @@ fn build_header_links(html: &str, html_config: &HtmlConfig) -> String {
                 caps.get(2).map(|x| x.as_str().to_string()),
                 caps.get(3).map(|x| x.as_str().to_string()),
                 &mut id_counter,
-                &html_config
+                &html_config,
             )
         })
         .into_owned()


### PR DESCRIPTION
Add a new option `header-link` to control whether insert links to headers.