### PR TITLE
preprocess/links: fail for invalid links

### DIFF
--- a/src/preprocess/index.rs
+++ b/src/preprocess/index.rs
@@ -41,7 +41,8 @@ impl Preprocessor for IndexPreprocessor {
                     }
                 }
             }
-        });
+            Ok(())
+        })?;
 
         Ok(book)
     }

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -136,10 +136,10 @@ fn recursive_copy<A: AsRef<Path>, B: AsRef<Path>>(from: A, to: B) -> Result<()> 
 
 pub fn new_copy_of_example_book() -> Result<TempDir> {
     let temp = TempFileBuilder::new().prefix("guide").tempdir()?;
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let guide = Path::new(env!("CARGO_MANIFEST_DIR")).join("guide");
-
-    recursive_copy(guide, temp.path())?;
+    recursive_copy(manifest_dir.join("guide"), temp.path().join("guide"))?;
+    recursive_copy(manifest_dir.join("examples"), temp.path().join("examples"))?;
 
     Ok(temp)
 }

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -420,7 +420,7 @@ Around the world, around the world"];
 fn example_book_can_build() {
     let example_book_dir = dummy_book::new_copy_of_example_book().unwrap();
 
-    let md = MDBook::load(example_book_dir.path()).unwrap();
+    let md = MDBook::load(example_book_dir.path().join("guide")).unwrap();
 
     md.build().unwrap();
 }
@@ -484,7 +484,7 @@ fn first_chapter_is_copied_as_index_even_if_not_first_elem() {
 #[test]
 fn theme_dir_overrides_work_correctly() {
     let book_dir = dummy_book::new_copy_of_example_book().unwrap();
-    let book_dir = book_dir.path();
+    let book_dir = &book_dir.path().join("guide");
     let theme_dir = book_dir.join("theme");
 
     let mut index = mdbook::theme::INDEX.to_vec();


### PR DESCRIPTION
Before, `mdbook` would continue processing even when errors, such as invalid links, are encountered. Moreover, it would exit with a `0` return code. Such behavior is unexpected and leads to confusion when run in CI.

Now, when links that don't point to existing files are encounter and error is returned which yields to `mdbook` exiting with an error code. The change in behavior has revealed that some tests were run with invalid links.

Closes #1094