### PR TITLE
feat(renderer): add no-header-link option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -550,6 +550,8 @@ pub struct HtmlConfig {
     pub print: Print,
     /// Don't render section labels.
     pub no_section_label: bool,
+    /// Don't render header links.
+    pub no_header_link: bool,
     /// Search settings. If `None`, the default will be used.
     pub search: Option<Search>,
     /// Git repository url. If `None`, the git button will not be shown.
@@ -601,6 +603,7 @@ impl Default for HtmlConfig {
             code: Code::default(),
             print: Print::default(),
             no_section_label: false,
+            no_header_link: false,
             search: None,
             git_repository_url: None,
             git_repository_icon: None,


### PR DESCRIPTION
Add no-header-link option. If set to true, the renderer will not render header links. Defaults to false.