### PR TITLE
feat: Upgrades to MathJax version 3 and supports setting different configuration files (defaults to 'tex-mml-chtml').

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -99,6 +99,7 @@ default-theme = "light"
 preferred-dark-theme = "navy"
 curly-quotes = true
 mathjax-support = false
+mathjax-config = "tex-mml-chtml"
 copy-fonts = true
 additional-css = ["custom.css", "custom2.css"]
 additional-js = ["custom.js"]
@@ -126,6 +127,8 @@ The following configuration options are available:
   that occur in code blocks and code spans. Defaults to `false`.
 - **mathjax-support:** Adds support for [MathJax](../mathjax.md). Defaults to
   `false`.
+- **mathjax-config:** The [configuration file](https://docs.mathjax.org/en/latest/web/components/combined.html)
+  used by MathJax. Defaults to `tex-mml-chtml`.
 - **copy-fonts:** (**Deprecated**) If `true` (the default), mdBook uses its built-in fonts which are copied to the output directory.
   If `false`, the built-in fonts will not be used.
   This option is deprecated. If you want to define your own custom fonts,

--- a/src/config.rs
+++ b/src/config.rs
@@ -530,6 +530,8 @@ pub struct HtmlConfig {
     pub curly_quotes: bool,
     /// Should mathjax be enabled?
     pub mathjax_support: bool,
+    /// The configuration file used by MathJax, defaults to 'tex-mml-chtml'.
+    pub mathjax_config: Option<String>,
     /// Whether to fonts.css and respective font files to the output directory.
     pub copy_fonts: bool,
     /// An optional google analytics code.
@@ -592,6 +594,7 @@ impl Default for HtmlConfig {
             preferred_dark_theme: None,
             curly_quotes: false,
             mathjax_support: false,
+            mathjax_config: Some(String::from("tex-mml-chtml")),
             copy_fonts: true,
             google_analytics: None,
             additional_css: Vec::new(),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -667,6 +667,10 @@ fn make_data(
     if html_config.mathjax_support {
         data.insert("mathjax_support".to_owned(), json!(true));
     }
+    data.insert(
+        "mathjax_config".to_owned(),
+        json!(html_config.mathjax_config.clone().unwrap_or_default()),
+    );
 
     // This `matches!` checks for a non-empty file.
     if html_config.copy_fonts || matches!(theme.fonts_css.as_deref(), Some([_, ..])) {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -50,7 +50,7 @@
 
         {{#if mathjax_support}}
         <!-- MathJax -->
-        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/{{ mathjax_config }}.js"></script>
         {{/if}}
     </head>
     <body class="sidebar-visible no-js">


### PR DESCRIPTION
## Introduction

This PR is used to upgrade to MathJax version 3 and supports setting different configuration files (defaults to `'tex-mml-chtml`).

It is inspired by the issue: [mdBook doesn't support `mathcal` symbols](https://github.com/rust-lang/mdBook/issues/2284).

Closes #2284.

## Background

This PR can fix a bug hidden in MathJax v2 introduced [here](https://meta.stackexchange.com/questions/384924/i-think-there-is-a-mathjax-bug-for-mathcal-typesetting-on-some-platforms/385789#385789).