### PR TITLE
removes few more allocs

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -935,8 +935,9 @@ fn add_playground_pre(
 /// Modifies all `<code>` blocks to convert "hidden" lines and to wrap them in
 /// a `<span class="boring">`.
 fn hide_lines(html: &str, code_config: &Code) -> String {
-    let language_regex = Regex::new(r"\blanguage-(\w+)\b").unwrap();
-    let hidelines_regex = Regex::new(r"\bhidelines=(\S+)").unwrap();
+    static LANGUAGE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\blanguage-(\w+)\b").unwrap());
+    static HIDELINES_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\bhidelines=(\S+)").unwrap());
+
     CODE_BLOCK_RE
         .replace_all(html, |caps: &Captures<'_>| {
             let text = &caps[1];
@@ -951,12 +952,12 @@ fn hide_lines(html: &str, code_config: &Code) -> String {
                 )
             } else {
                 // First try to get the prefix from the code block
-                let hidelines_capture = hidelines_regex.captures(classes);
+                let hidelines_capture = HIDELINES_REGEX.captures(classes);
                 let hidelines_prefix = match &hidelines_capture {
                     Some(capture) => Some(&capture[1]),
                     None => {
                         // Then look up the prefix by language
-                        language_regex.captures(classes).and_then(|capture| {
+                        LANGUAGE_REGEX.captures(classes).and_then(|capture| {
                             code_config.hidelines.get(&capture[1]).map(|p| p.as_str())
                         })
                     }

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -103,7 +103,7 @@ fn find_chapter(
                     }
                 }
 
-                previous = Some(item.clone());
+                previous = Some(item);
             }
             _ => continue,
         }


### PR DESCRIPTION
On rust reference book this reduces total allocs from 490mb to 215mb,

from

```
==23272== Total:     490,538,699 bytes in 1,760,117 blocks
==23272== At t-gmax: 13,872,954 bytes in 4,655 blocks
==23272== At t-end:  488,516 bytes in 884 blocks
==23272== Reads:     830,509,060 bytes
==23272== Writes:    522,290,614 bytes
```
to
```
==57763== Total:     215,292,393 bytes in 1,161,048 blocks
==57763== At t-gmax: 13,872,954 bytes in 4,655 blocks
==57763== At t-end:  1,210,783 bytes in 1,274 blocks
==57763== Reads:     598,542,892 bytes
==57763== Writes:    229,841,910 bytes
```

when mdbook build with `--no-default-features`