### PR TITLE
docs: Add missing `+` in diff code block

### DIFF
--- a/guide/src/for_developers/backends.md
+++ b/guide/src/for_developers/backends.md
@@ -287,7 +287,7 @@ like this:
 +             if cfg.deny_odds && num_words % 2 == 1 {
 +               eprintln!("{} has an odd number of words!", ch.name);
 +               process::exit(1);
-              }
++             }
           }
       }
   }


### PR DESCRIPTION
The closing bracket for the `if` statement is also newly added but the leading `+` to indicate that was forgotten.