### PR TITLE
docs: Fix broken link

### DIFF
--- a/guide/src/format/markdown.md
+++ b/guide/src/format/markdown.md
@@ -232,4 +232,4 @@ Example:
 
 This makes the level 1 heading with the content `Example heading`, ID `first`, and classes `class1` and `class2`. Note that the attributes should be space-separated.
 
-More information can be found in the [heading attrs spec page](https://github.com/raphlinus/pulldown-cmark/blob/master/specs/heading_attrs.txt).
+More information can be found in the [heading attrs spec page](https://github.com/raphlinus/pulldown-cmark/blob/master/pulldown-cmark/specs/heading_attrs.txt).


### PR DESCRIPTION
The location in pulldown-cmark's repository was changed a couple of days ago in [this commit](https://github.com/raphlinus/pulldown-cmark/commit/a917492af3b82e8283a3ec37b4f438259c7cc5a2#diff-d93f0540e6c0db8d5623c385b2d2c19898746f77b83aca1c49b0251cdf4815be)