### PR TITLE
Fix incorrect theme documentation: Next/Previous should use `title`

### DIFF
--- a/guide/src/format/theme/index-hbs.md
+++ b/guide/src/format/theme/index-hbs.md
@@ -79,7 +79,7 @@ var chapters = {{chapters}};
 
 ### 2. previous / next
 
-The previous and next helpers expose a `link` and `name` property to the
+The previous and next helpers expose a `link` and `title` property to the
 previous and next chapters.
 
 They are used like this
@@ -87,7 +87,7 @@ They are used like this
 ```handlebars
 {{#previous}}
     <a href="{{link}}" class="nav-chapters previous">
-        <i class="fa fa-angle-left"></i>
+        <i class="fa fa-angle-left"></i> {{title}}
     </a>
 {{/previous}}
 ```


### PR DESCRIPTION
The theme documentation for next and previous used name instead of title.

Per the code (and using it) `title` is the correct value.

https://github.com/rust-lang/mdBook/blob/5a4ac03c0de866c4cf30d41dd0c7ea02d8429a7a/src/renderer/html_handlebars/helpers/navigation.rs#L209