### PR TITLE
Fix redundant imports.

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -339,7 +339,6 @@ impl Display for Chapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use tempfile::{Builder as TempFileBuilder, TempDir};
 
     const DUMMY_SRC: &str = "

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -18,7 +18,6 @@ use log::{debug, error, info, log_enabled, trace, warn};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-use std::string::ToString;
 use tempfile::Builder as TempFileBuilder;
 use toml::Value;
 use topological_sort::TopologicalSort;
@@ -605,7 +604,7 @@ fn preprocessor_should_run(
 mod tests {
     use super::*;
     use std::str::FromStr;
-    use toml::value::{Table, Value};
+    use toml::value::Table;
 
     #[test]
     fn config_defaults_to_html_renderer_if_empty() {

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -4,7 +4,6 @@ use memchr::Memchr;
 use pulldown_cmark::{DefaultBrokenLinkCallback, Event, HeadingLevel, Tag, TagEnd};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
-use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -1,7 +1,7 @@
 use super::command_prelude::*;
 use crate::get_book_dir;
 use clap::builder::NonEmptyStringValueParser;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::ArgAction;
 use mdbook::errors::Result;
 use mdbook::MDBook;
 use std::path::PathBuf;

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use toml::value::Table;
-use toml::{self, Value};
+use toml::Value;
 
 use crate::errors::*;
 use crate::utils::{self, toml_ext::TomlExt};

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -212,7 +212,6 @@ fn load_file_contents<P: AsRef<Path>>(filename: P, dest: &mut Vec<u8>) -> Result
 mod tests {
     use super::*;
     use std::fs;
-    use std::path::PathBuf;
     use tempfile::Builder as TempFileBuilder;
 
     #[test]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,6 +1,5 @@
 use crate::errors::*;
 use log::{debug, trace};
-use std::convert::Into;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};


### PR DESCRIPTION
Recent nightlies have started warning about redundant imports. This removes those unnecessary imports.