### PR TITLE
Constrain `handlebars` version to satisfy MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.3.12", features = ["cargo", "wrap_help"] }
 clap_complete = "4.3.2"
 once_cell = "1.17.1"
 env_logger = "0.11.1"
-handlebars = "5.0"
+handlebars = "5.0, <5.1.2" # 5.1.2 raises MSRV to 1.72
 log = "0.4.17"
 memchr = "2.5.0"
 opener = "0.6.1"


### PR DESCRIPTION
`handlebars` [raised its MSRV to 1.72](https://github.com/sunng87/handlebars-rust/commit/6426df0389e56acfc6b488e875e58614004a3dce) in its 5.1.2 release, which is incompatible with `mdbook`'s 1.71 MSRV. This restricts version selection to `5.0, <5.1.2` to avoid the increase