### PR TITLE
fix list ordering

### DIFF
--- a/guide/src/format/markdown.md
+++ b/guide/src/format/markdown.md
@@ -54,8 +54,8 @@ Lists can be unordered or ordered. Ordered lists will order automatically:
 * butter
 
 1. carrots
-1. celery
-1. radishes
+2. celery
+3. radishes
 ```
 
 * milk
@@ -63,8 +63,8 @@ Lists can be unordered or ordered. Ordered lists will order automatically:
 * butter
 
 1. carrots
-1. celery
-1. radishes
+2. celery
+3. radishes
 
 ## Links
 


### PR DESCRIPTION
In the deployed docs [markdown page](https://rust-lang.github.io/mdBook/format/markdown.html#lists) is example as 1.,2.,3., while output 1.,1.,1.. 

Corrected ordering to 1.,2.,3. in both cases. 