### PR TITLE
Remove cargo-clippy unknown feature

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -206,7 +206,7 @@ impl HtmlHandlebars {
         Ok(())
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))]
+    #[allow(clippy::let_and_return)]
     fn post_process(
         &self,
         rendered: String,


### PR DESCRIPTION
I don't know why this `cfg_attr` is here, as I do not think it is needed for anything. Nightly now warns against these unknown configs, so remove it.