### PR TITLE
CI: Test more targets.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,16 +12,9 @@ permissions:
 
 jobs:
   release:
-    name: Deploy Release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target:
-          - aarch64-unknown-linux-musl
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
         include:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-20.04
@@ -33,6 +26,7 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+    name: Deploy ${{ matrix.target }}
     steps:
     - uses: actions/checkout@master
     - name: Install Rust

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
             os: windows-latest
     name: Deploy ${{ matrix.target }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: ci/install-rust.sh stable ${{ matrix.target }}
     - name: Build asset
@@ -41,7 +41,7 @@ jobs:
     name: GitHub Pages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust (rustup)
       run: rustup update stable --no-self-update && rustup default stable
     - name: Build book
@@ -58,7 +58,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Install Rust (rustup)
         run: rustup update stable --no-self-update && rustup default stable
       - name: Publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
     name: ${{ matrix.name }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: bash ci/install-rust.sh ${{ matrix.rust }} ${{ matrix.target }}
     - name: Build and run tests
@@ -55,7 +55,7 @@ jobs:
   aarch64-cross-builds:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: bash ci/install-rust.sh stable aarch64-unknown-linux-musl
     - name: Build
@@ -65,7 +65,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,39 +5,61 @@ on:
 
 jobs:
   test:
-    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, macos, windows, msrv]
         include:
-          - build: stable
+          - name: stable linux
             os: ubuntu-latest
             rust: stable
-          - build: beta
+            target: x86_64-unknown-linux-gnu
+          - name: beta linux
             os: ubuntu-latest
             rust: beta
-          - build: nightly
+            target: x86_64-unknown-linux-gnu
+          - name: nightly linux
             os: ubuntu-latest
             rust: nightly
-          - build: macos
+            target: x86_64-unknown-linux-gnu
+          - name: stable x86_64-unknown-linux-musl
+            os: ubuntu-20.04
+            rust: stable
+            target: x86_64-unknown-linux-musl
+          - name: stable x86_64 macos
             os: macos-latest
             rust: stable
-          - build: windows
+            target: x86_64-apple-darwin
+          - name: stable aarch64 macos
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-darwin
+          - name: stable windows-msvc
             os: windows-latest
             rust: stable
-          - build: msrv
+            target: x86_64-pc-windows-msvc
+          - name: msrv
             os: ubuntu-20.04
             # sync MSRV with docs: guide/src/guide/installation.md and Cargo.toml
             rust: 1.74.0
+            target: x86_64-unknown-linux-gnu
+    name: ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: bash ci/install-rust.sh ${{ matrix.rust }}
+      run: bash ci/install-rust.sh ${{ matrix.rust }} ${{ matrix.target }}
     - name: Build and run tests
-      run: cargo test --locked
+      run: cargo test --locked --target ${{ matrix.target }}
     - name: Test no default
-      run: cargo test --no-default-features
+      run: cargo test --no-default-features --target ${{ matrix.target }}
+
+  aarch64-cross-builds:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust
+      run: bash ci/install-rust.sh stable aarch64-unknown-linux-musl
+    - name: Build
+      run: cargo build --locked --target aarch64-unknown-linux-musl
 
   rustfmt:
     name: Rustfmt

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -22,6 +22,19 @@ then
         rustup component add llvm-tools-preview --toolchain=$TOOLCHAIN
         rustup component add rust-std-$TARGET --toolchain=$TOOLCHAIN
     fi
+    if [[ $TARGET == *"musl" ]]
+    then
+        # This is needed by libdbus-sys.
+        sudo apt update -y && sudo apt install musl-dev musl-tools -y
+    fi
+    if [[ $TARGET == "aarch64-unknown-linux-musl" ]]
+    then
+        echo CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld >> $GITHUB_ENV
+        # This `CC` is some nonsense needed for libdbus-sys (via opener).
+        # I don't know if this is really the right thing to do, but it seems to work.
+        sudo apt install gcc-aarch64-linux-gnu -y
+        echo CC=aarch64-linux-gnu-gcc >> $GITHUB_ENV
+    fi
 fi
 
 rustup default $TOOLCHAIN

--- a/ci/make-release-asset.sh
+++ b/ci/make-release-asset.sh
@@ -12,10 +12,6 @@ TAG=${GITHUB_REF#*/tags/}
 
 host=$(rustc -Vv | grep ^host: | sed -e "s/host: //g")
 target=$2
-if [ "$host" != "$target" ]
-then
-  export "CARGO_TARGET_$(echo $target | tr a-z- A-Z_)_LINKER"=rust-lld
-fi
 export CARGO_PROFILE_RELEASE_LTO=true
 cargo build --locked --bin mdbook --release --target $target
 cd target/$target/release


### PR DESCRIPTION
This updates the PR checks to:
- Verify x86_64-unknown-linux-musl passes tests
- Verify aarch64-unknown-linux-musl can be built via cross-compilation
- Test x86_64-apple-darwin (under Rosetta2)

There were some problems with the last release due to some changes with libdbus-sys.