### PR TITLE
Fix dead_code warning for arg_watcher

### DIFF
--- a/src/cmd/command_prelude.rs
+++ b/src/cmd/command_prelude.rs
@@ -37,6 +37,7 @@ pub trait CommandExt: Sized {
         self._arg(arg!(-o --open "Opens the compiled book in a web browser"))
     }
 
+    #[cfg(any(feature = "watch", feature = "serve"))]
     fn arg_watcher(self) -> Self {
         #[cfg(feature = "watch")]
         return self._arg(


### PR DESCRIPTION
When built with `--no-default-features`, it shows a warning because neither watch or serve are enabled.
