### PR TITLE
Fix text from menu bar in Google Search

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -144,7 +144,7 @@
             <div class="page">
                 {{> header}}
                 <div id="menu-bar-hover-placeholder"></div>
-                <div id="menu-bar" class="menu-bar sticky">
+                <header id="menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
                         <label id="sidebar-toggle" class="icon-button" for="sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
                             <i class="fa fa-bars"></i>
@@ -186,7 +186,7 @@
                         {{/if}}
 
                     </div>
-                </div>
+                </header>
 
                 {{#if search_enabled}}
                 <div id="search-wrapper" class="hidden">


### PR DESCRIPTION
I noticed an issue that Google for some mdBooks in the search results shows a list of themes and the title of the book. It's a small thing, but an eyesore.

![image](https://github.com/rust-lang/mdBook/assets/60278551/9d4cc546-edb6-4e60-aada-a8b7315ccaa5)

My guess is that Google thought `#menu-bar` is the part of the page content and indexed it. To prevent this, I replaced the tag of menu with `<header>`.
