### PR TITLE
Upgrade pulldown cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags 2.5.0",
  "memchr",
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ handlebars = "5.0"
 log = "0.4.17"
 memchr = "2.5.0"
 opener = "0.7.0"
-pulldown-cmark = { version = "0.10.0", default-features = false, features = ["html"] } # Do not update, part of the public api.
+pulldown-cmark = { version = "0.11.0", default-features = false, features = ["html"] } # Do not update, part of the public api.
 regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -184,6 +184,13 @@ fn render_item(
                 // blocks, and worse case you have some noise in the index.
                 body.push_str(&clean_html(&html));
             }
+            Event::InlineMath(text) | Event::DisplayMath(text) => {
+                if in_heading {
+                    heading.push_str(&text);
+                } else {
+                    body.push_str(&text);
+                }
+            }
             Event::Start(_) | Event::End(_) | Event::Rule | Event::SoftBreak | Event::HardBreak => {
                 // Insert spaces where HTML output would usually separate text
                 // to ensure words don't get merged together

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -168,7 +168,7 @@ fn render_item(
                 // in an HtmlBlock tag. We must collect consecutive Html events
                 // into a block ourselves.
                 while let Some(Event::Html(html)) = p.peek() {
-                    html_block.push_str(html);
+                    html_block.push_str(&html);
                     p.next();
                 }
                 body.push_str(&clean_html(&html_block));


### PR DESCRIPTION
Hi and thanks for this beautiful piece of tooling, I simply love it since the first time I discovered it!

I updated `pulldown-cmark` but noticed the comment saying not to in `Cargo.toml`, so feel free to dismiss this PR if this is not supposed to happen from an external contribution.

If however you do accept this PR, I'd like to add a mathematical expression to the tests for the sake of completeness but I'd appreciate that you point me which markdown is the most appropriate, so putting this under draft for now.

Thanks!