### PR TITLE
disincentivize usage of functions that expose toml::Table in Config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -240,15 +240,37 @@ impl Config {
     }
 
     /// Get the table associated with a particular renderer.
+    #[deprecated = "prefer get_renderer_deserialized over get_renderer"]
     pub fn get_renderer<I: AsRef<str>>(&self, index: I) -> Option<&Table> {
         let key = format!("output.{}", index.as_ref());
         self.get(&key).and_then(Value::as_table)
     }
 
+    /// Convenience function to fetch the renderer section from the config and deserialize it
+    /// into some arbitrary type.
+    pub fn get_renderer_deserialized<'de, T: Deserialize<'de>, I: AsRef<str>>(
+        &self,
+        index: I,
+    ) -> Result<Option<T>> {
+        let key = format!("output.{}", index.as_ref());
+        self.get_deserialized_opt(key)
+    }
+
     /// Get the table associated with a particular preprocessor.
+    #[deprecated = "prefer get_preprocessor_deserialized over get_preprocessor"]
     pub fn get_preprocessor<I: AsRef<str>>(&self, index: I) -> Option<&Table> {
         let key = format!("preprocessor.{}", index.as_ref());
         self.get(&key).and_then(Value::as_table)
+    }
+
+    /// Convenience function to fetch the preprocessor section from the config and deserialize it
+    /// into some arbitrary type.
+    pub fn get_preprocessor_deserialized<'de, T: Deserialize<'de>, I: AsRef<str>>(
+        &self,
+        index: I,
+    ) -> Result<Option<T>> {
+        let key = format!("preprocessor.{}", index.as_ref());
+        self.get_deserialized_opt(key)
     }
 
     fn from_legacy(mut table: Value) -> Config {

--- a/tests/testsuite/preprocessor/failing_preprocessor/book.toml
+++ b/tests/testsuite/preprocessor/failing_preprocessor/book.toml
@@ -1,4 +1,4 @@
 [preprocessor.nop-preprocessor]
 command = "cargo run --quiet --example nop-preprocessor --"
-blow-up = true
+blow_up = true
 


### PR DESCRIPTION
hi there,

firstly, thank you for your continued work on mdbook, it's a great tool :)

This is related to #2037, which I encountered while [trying to deserialize the exposed `Map`/`Table` into a user defined struct](https://github.com/toml-rs/toml/discussions/744) in a preprocessor I'm writing.

Using `get_deserialized_opt` seems much more preferable to `get_preprocessor` (and `get_renderer` for that matter).
However, I merely happend to stumble across that function while looking through `config.rs`.  
I don't think I'm alone with this, I did a brief search over the preprocessors listed in [the third party plugins page](https://github.com/rust-lang/mdBook/wiki/Third-party-plugins) and the ones that do have options use `get_preprocessor`.

The one caveat for `get_deserialized_opt` is that you have to pass `"preprocessor.my_thing"` instead of `"my_thing"`, so I made `get_renderer_deserialized` and `get_preprocessor_deserialized` for convenience.
I added that to the example to incentivize people writing new preprocessors to use it.

I also marked `get_renderer` and `get_preprocessor` as deprecated. However this might be bold. There are probably valid use cases for these functions, unless mdbook were to remove the exposed toml type(s) like #2037 describes (which would significantly change `mdbook::config::Config`'s interface).

Note that this also results in 3 deprecation warnings in the tests.  
I haven't addresses these, because I think the decision whether to deprecate them at all should be done by the maintainers, I'm just a user of the library/tool.