### PR TITLE
gate few deps only used in bin by cli feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ rust-version = "1.74"
 
 [dependencies]
 anyhow = "1.0.71"
-chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock"], optional = true }
 clap = { version = "4.3.12", features = ["cargo", "wrap_help"] }
-clap_complete = "4.3.2"
+clap_complete = { version = "4.3.2", optional = true }
 once_cell = "1.17.1"
-env_logger = "0.11.1"
+env_logger = { version = "0.11.1", optional = true }
 handlebars = "5.0"
 log = "0.4.17"
 memchr = "2.5.0"
-opener = "0.7.0"
+opener = { version = "0.7.0", optional = true }
 pulldown-cmark = { version = "0.10.0", default-features = false, features = ["html"] } # Do not update, part of the public api.
 regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }
@@ -54,6 +54,7 @@ ammonia = { version = "4.0.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.11"
+env_logger = "0.11.1"
 predicates = "3.0.3"
 select = "0.6.0"
 semver = "1.0.17"
@@ -61,14 +62,16 @@ pretty_assertions = "1.3.0"
 walkdir = "2.3.3"
 
 [features]
-default = ["watch", "serve", "search"]
+default = ["watch", "serve", "search", "cli"]
 watch = ["dep:notify", "dep:notify-debouncer-mini", "dep:ignore", "dep:pathdiff", "dep:walkdir"]
 serve = ["dep:futures-util", "dep:tokio", "dep:warp"]
 search = ["dep:elasticlunr-rs", "dep:ammonia"]
+cli = ["dep:chrono", "dep:clap_complete", "dep:env_logger", "dep:opener"]
 
 [[bin]]
 doc = false
 name = "mdbook"
+required-features = ["cli"]
 
 [[example]]
 name = "nop-preprocessor"


### PR DESCRIPTION
This adds `cli` feature (added to `default` list to prevent possible break) which gates deps used only by `mdbook` bin. This technically breaks users of bin with `default-features = false`, are they exist?