### PR TITLE
add `rendered_path` in the template

### DIFF
--- a/guide/src/format/theme/index-hbs.md
+++ b/guide/src/format/theme/index-hbs.md
@@ -23,6 +23,7 @@ Here is a list of the properties that are exposed:
 - ***book_title*** Title of the book, as specified in `book.toml`
 - ***chapter_title*** Title of the current chapter, as listed in `SUMMARY.md`
 
+- ***rendered_path*** Relative path to the rendered path from the source directory
 - ***path*** Relative path to the original markdown file from the source
   directory
 - ***content*** This is the rendered markdown.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -95,6 +95,10 @@ impl HtmlHandlebars {
             ch.name.clone() + " - " + book_title
         };
 
+        let rendered_path = path.with_extension("html");
+
+        ctx.data
+            .insert("rendered_path".to_owned(), json!(rendered_path));
         ctx.data.insert("path".to_owned(), json!(path));
         ctx.data.insert("content".to_owned(), json!(content));
         ctx.data.insert("chapter_title".to_owned(), json!(ch.name));
@@ -124,6 +128,8 @@ impl HtmlHandlebars {
         utils::fs::write_file(&ctx.destination, &filepath, rendered.as_bytes())?;
 
         if ctx.is_index {
+            ctx.data
+                .insert("rendered_path".to_owned(), json!("index.html"));
             ctx.data.insert("path".to_owned(), json!("index.md"));
             ctx.data.insert("path_to_root".to_owned(), json!(""));
             ctx.data.insert("is_index".to_owned(), json!(true));
@@ -182,6 +188,7 @@ impl HtmlHandlebars {
             "/"
         };
         data_404.insert("base_url".to_owned(), json!(base_url));
+        data_404.insert("rendered_path".to_owned(), json!("404.html"));
         // Set a dummy path to ensure other paths (e.g. in the TOC) are generated correctly
         data_404.insert("path".to_owned(), json!("404.md"));
         data_404.insert("content".to_owned(), json!(html_content_404));
@@ -360,6 +367,7 @@ impl HtmlHandlebars {
         // the last rendered chapter by removing it from its context
         data.remove("title");
         data.insert("is_print".to_owned(), json!(true));
+        data.insert("rendered_path".to_owned(), json!("print.html"));
         data.insert("path".to_owned(), json!("print.md"));
         data.insert("content".to_owned(), json!(print_content));
         data.insert(


### PR DESCRIPTION
pass the rendered path in the template, as suggested here https://github.com/rust-lang/mdBook/issues/1238#issuecomment-636270351

which allows to add the canonical URL https://gitlab.com/pinage404/git-gamble/-/commit/c7c2e601f9d42f1d2f88e81654787c4d0ba82545#4e2dfdde34a65a1bb4b51a5effb6635b41af0fbc_59_60

the intention of this PR is just to help the subject to advance, i don't care if it is not merged because prefered to another solution

the intention of this PR is just to help the topic move forward, i don't care if it is not merged because it is preferred to another solution