### PR TITLE
de-duplicate the search index

### DIFF
--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -46,7 +46,6 @@ pub fn create_files(search_config: &Search, destination: &Path, book: &Book) -> 
     }
 
     if search_config.copy_js {
-        utils::fs::write_file(destination, "searchindex.json", index.as_bytes())?;
         utils::fs::write_file(
             destination,
             "searchindex.js",

--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -468,9 +468,17 @@ window.search = window.search || {};
         showResults(true);
     }
 
-    fetch(path_to_root + 'searchindex.json')
-        .then(response => response.json())
-        .then(json => init(json))        
+    fetch(path_to_root + 'searchindex.js')
+        .then(response => response.text())
+        .then(text => {
+            const jsonMatch = text.match(/Object\.assign\(window\.search,\s*(\{[\s\S]*\})\s*\)/);
+            if (jsonMatch && jsonMatch[1]) {
+                return JSON.parse(jsonMatch[1]);
+            } else {
+                throw new Error('Unable to extract JSON from the script');
+            }
+        })
+        .then(json => init(json))
         .catch(error => { // Try to load searchindex.js if fetch failed
             var script = document.createElement('script');
             script.src = path_to_root + 'searchindex.js';


### PR DESCRIPTION
Currently, the search index is duplicated in `searchindex.js` and `searchindex.json`. It seems the reason for the duplication is that the `.json` allows for async loading via `fetch()` and the `.js` provides a fallback in case CORS causes issues with the `fetch()`.

The problem with having the duplicated index is that for large books, the index becomes quite large (2.5MB for my company's book!). It would be nice if the index didn't have to be duplicated.

This PR removes `searchindex.json` from the site output. It replicates the async functionality by reading in the `searchindex.js` file and parsing out the JSON within. The fallback remains unchanged.