### PR TITLE
Improved the user guide documentation for installing mdBook

### DIFF
--- a/guide/src/guide/installation.md
+++ b/guide/src/guide/installation.md
@@ -12,7 +12,7 @@ Executable binaries are available for download on the [GitHub Releases page][rel
 Download the binary for your platform (Windows, macOS, or Linux) and extract the archive.
 The archive contains an `mdbook` executable which you can run to build your books.
 
-To make it easier to run, put the path to the binary into your `PATH`.
+To make it easier to run, put the path to the binary into your `PATH`. If you have an installation of Rust, you can move the binary to [Cargo's global installation directory](#cargos-global-installation-directory).
 
 [releases]: https://github.com/rust-lang/mdBook/releases
 
@@ -28,7 +28,7 @@ Once you have installed Rust, the following command can be used to build and ins
 cargo install mdbook
 ```
 
-This will automatically download mdBook from [crates.io], build it, and install it in Cargo's global binary directory (`~/.cargo/bin/` by default).
+This will automatically download mdBook from [crates.io], build it, and install it in [Cargo's global binary directory](#cargos-global-installation-directory).
 
 You can run `cargo install mdbook` again whenever you want to update to a new version.
 That command will check if there is a newer version, and re-install mdBook if a newer version is found.
@@ -49,6 +49,15 @@ cargo install --git https://github.com/rust-lang/mdBook.git mdbook
 ```
 
 Again, make sure to add the Cargo bin directory to your `PATH`.
+
+## Cargo's global installation directory
+
+In order to use mdBook, you don't need an installation of Rust. However, if you do, you can find it convenient to store the mdBook binary in the Cargo's global installation directory.
+
+* **On Linux/macOS**, it is located at `~/.cargo/bin`.
+* **On Windows**, it is located at `%USERPROFILE%\.cargo\bin`.
+
+If you have an installation of Rust, this directory is most likely already in your `PATH`.
 
 ## Modifying and contributing
 


### PR DESCRIPTION
I specified the location of Cargo's global installation directory depending on the operating system. Notably, it specifies the Windows-path, which is slightly distinct from the Linux and macOS paths.