### PR TITLE
Fix automatic dark mode

### DIFF
--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -258,7 +258,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .light.no-js {
+    html:has(.no-js) {
         --bg: hsl(200, 7%, 8%);
         --fg: #98a3ad;
 
@@ -298,6 +298,8 @@
         --searchresults-border-color: #98a3ad;
         --searchresults-li-bg: #2b2b2f;
         --search-mark-bg: #355c7d;
+
+        --color-scheme: dark;
 
         /* Same as `--icons` */
         --copy-button-filter: invert(26%) sepia(8%) saturate(575%) hue-rotate(169deg) brightness(87%) contrast(82%);


### PR DESCRIPTION
Automatic dark mode (in CSS) was implemented in #1069, then broken in  #1641 because it moved the `no-js` class to a different element. This PR restores the functionality. It also implements #2134 properly.

I also noticed that the original implementation depends on the `light` class to be set, which it is not if a different default theme has been chosen. I have also fixed this.

Closes #2440 