### PR TITLE
Fix line-height for footnote-reference

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -202,6 +202,10 @@ kbd {
     display: inline;
 }
 
+.footnote-reference{
+    line-height: 0;
+}
+
 .tooltiptext {
     position: absolute;
     visibility: hidden;


### PR DESCRIPTION
### ISSUE
#2437 Footnote reference adding some extra vertical space to the line


### FIX
Changed general.css file to include custom styling for footnote reference, removing inheritance of line height from parent class.
Tested for various different browsers. (Chrome, Firefox, mobile chrome, mobile firefox)

## Before
![before](https://github.com/user-attachments/assets/d404d84f-7b6c-442d-b10d-09849a7191d3)

## After
![after](https://github.com/user-attachments/assets/1a321837-e83d-4722-9b3f-89612bbbfceb)

