### PR TITLE
Enhance syntax highlighting

### DIFF
--- a/src/theme/highlight.css
+++ b/src/theme/highlight.css
@@ -16,6 +16,7 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-attribute,
+.hljs-attr,
 .hljs-tag,
 .hljs-name,
 .hljs-regexp,

--- a/src/theme/tomorrow-night.css
+++ b/src/theme/tomorrow-night.css
@@ -11,6 +11,7 @@
 /* Tomorrow Red */
 .hljs-variable,
 .hljs-attribute,
+.hljs-attr,
 .hljs-tag,
 .hljs-regexp,
 .ruby .hljs-constant,
@@ -54,6 +55,7 @@
 
 /* Tomorrow Aqua */
 .hljs-title,
+.hljs-section,
 .css .hljs-hexcolor {
   color: #8abeb7;
 }


### PR DESCRIPTION
Add syntax highlighting for `hljs-attr` and `hljs-section` CSS classes, consistent with the Ayu theme.

Fixes https://github.com/rust-lang/mdBook/issues/2447

Before:
<img width="228" alt="before" src="https://github.com/user-attachments/assets/9c82dd03-00e1-478e-a12e-da632c972427">

After:
<img width="228" alt="after" src="https://github.com/user-attachments/assets/08caa26d-594b-451a-9ab2-940ac3bd154f">

Affects syntax highlighting for the following languages: apache, ini, javascript, makefile, markdown, nginx, nix, properties, yaml.