### PR TITLE
fix: themes broken when localStorage has invalid theme id stored

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -289,6 +289,10 @@ function playground_text(playground, hidden = true) {
     var themeToggleButton = document.getElementById('theme-toggle');
     var themePopup = document.getElementById('theme-list');
     var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
+    var themeIds = [];
+    themePopup.querySelectorAll('button.theme').forEach(function (el) {
+        themeIds.push(el.id);
+    });
     var stylesheets = {
         ayuHighlight: document.querySelector("[href$='ayu-highlight.css']"),
         tomorrowNight: document.querySelector("[href$='tomorrow-night.css']"),
@@ -317,7 +321,7 @@ function playground_text(playground, hidden = true) {
     function get_theme() {
         var theme;
         try { theme = localStorage.getItem('mdbook-theme'); } catch (e) { }
-        if (theme === null || theme === undefined) {
+        if (theme === null || theme === undefined || !themeIds.includes(theme)) {
             return default_theme;
         } else {
             return theme;


### PR DESCRIPTION
Closes #2461

Check if stored theme is valid in `get_theme()` and defaults to default theme if not valid.

Validation steps:
- `cargo run -- build guide` and serve the book
- In browser devtools, run `localStorage.setItem("mdbook-theme", "foo")` to set an invalid theme `foo`
- Refresh the page, themes should work properly:
    -  the default theme should load
    - the theme popup functions properly
 
Manually tested in Google Chrome, MS Edge and Firefox (I don't have access to safari :(

Other:
- `localStorage` won't be updated (i.e. keeps the invalid value) until user manually changes the theme