### PR TITLE
Set line-height of superscripts to 0

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -190,6 +190,16 @@ kbd {
     vertical-align: middle;
 }
 
+sup {
+    /* Set the line-height for superscript and footnote references so that there
+       isn't an awkward space appearing above lines that contain the footnote.
+
+       See https://github.com/rust-lang/mdBook/pull/2443#discussion_r1813773583
+       for an explanation.
+    */
+    line-height: 0;
+}
+
 :not(.footnote-definition) + .footnote-definition,
 .footnote-definition + :not(.footnote-definition) {
     margin-block-start: 2em;


### PR DESCRIPTION
This changes it so that superscript (and in particular footnote tags) do not bump the line spacing of previous lines.

Before:
<img width="226" alt="image" src="https://github.com/user-attachments/assets/fa9ee83d-da9d-40f0-b4e8-067f7299fdd5">

After:
<img width="229" alt="image" src="https://github.com/user-attachments/assets/539077e3-0ba5-42b7-bc1c-b340a81f54d4">

This is a repost of #2443, thanks @loliceo, and @notriddle for the explanation.

Closes #2437