### PR TITLE
footnote backreference links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "examples/remove-emphasis/mdbook-remove-emphasis"]
 
 [package]
 name = "mdbook"
-version = "0.4.42"
+version = "0.4.43"
 authors = [
     "Mathieu David <mathieudavid@mathieudavid.org>",
     "Michael-F-Bryan <michaelfbryan@gmail.com>",

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -98,6 +98,7 @@ theme = "my-theme"
 default-theme = "light"
 preferred-dark-theme = "navy"
 smart-punctuation = true
+footnote-backrefs = true
 mathjax-support = false
 copy-fonts = true
 additional-css = ["custom.css", "custom2.css"]
@@ -126,6 +127,7 @@ The following configuration options are available:
   See [Smart Punctuation](../markdown.md#smart-punctuation).
   Defaults to `false`.
 - **curly-quotes:** Deprecated alias for `smart-punctuation`.
+- **footnote-backrefs:** Add backreference links to footnote definitions.
 - **mathjax-support:** Adds support for [MathJax](../mathjax.md). Defaults to
   `false`.
 - **copy-fonts:** (**Deprecated**) If `true` (the default), mdBook uses its built-in fonts which are copied to the output directory.

--- a/guide/src/format/markdown.md
+++ b/guide/src/format/markdown.md
@@ -221,6 +221,13 @@ To enable it, see the [`output.html.smart-punctuation`] config option.
 [task list extension]: https://github.github.com/gfm/#task-list-items-extension-
 [`output.html.smart-punctuation`]: configuration/renderers.md#html-renderer-options
 
+### Footnote backreference links
+
+Add backreference links to footnote definitions.
+
+This feature is disabled by default.
+To enable it, see the [`output.html.footnote-backrefs`] config option.
+
 ### Heading attributes
 
 Headings can have a custom HTML ID and classes. This lets you maintain the same ID even if you change the heading's text, it also lets you add multiple classes in the heading.

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,6 +531,8 @@ pub struct HtmlConfig {
     pub preferred_dark_theme: Option<String>,
     /// Supports smart quotes, apostrophes, ellipsis, en-dash, and em-dash.
     pub smart_punctuation: bool,
+    /// Add backreference links to footnote definitions.
+    pub footnote_backrefs: bool,
     /// Deprecated alias for `smart_punctuation`.
     pub curly_quotes: bool,
     /// Should mathjax be enabled?
@@ -596,6 +598,7 @@ impl Default for HtmlConfig {
             default_theme: None,
             preferred_dark_theme: None,
             smart_punctuation: false,
+            footnote_backrefs: false,
             curly_quotes: false,
             mathjax_support: false,
             copy_fonts: true,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -54,11 +54,14 @@ impl HtmlHandlebars {
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));
         }
 
-        let content = utils::render_markdown(&ch.content, ctx.html_config.smart_punctuation());
+        let content = utils::render_markdown(&ch.content,
+                                             ctx.html_config.smart_punctuation(),
+                                             ctx.html_config.footnote_backrefs);
 
         let fixed_content = utils::render_markdown_with_path(
             &ch.content,
             ctx.html_config.smart_punctuation(),
+            ctx.html_config.footnote_backrefs,
             Some(path),
         );
         if !ctx.is_index && ctx.html_config.print.page_break {
@@ -168,7 +171,9 @@ impl HtmlHandlebars {
             }
         };
         let html_content_404 =
-            utils::render_markdown(&content_404, html_config.smart_punctuation());
+            utils::render_markdown(&content_404,
+                                   html_config.smart_punctuation(),
+                                   html_config.footnote_backrefs);
 
         let mut data_404 = data.clone();
         let base_url = if let Some(site_url) = &html_config.site_url {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -54,9 +54,11 @@ impl HtmlHandlebars {
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));
         }
 
-        let content = utils::render_markdown(&ch.content,
-                                             ctx.html_config.smart_punctuation(),
-                                             ctx.html_config.footnote_backrefs);
+        let content = utils::render_markdown(
+            &ch.content,
+            ctx.html_config.smart_punctuation(),
+            ctx.html_config.footnote_backrefs,
+        );
 
         let fixed_content = utils::render_markdown_with_path(
             &ch.content,
@@ -170,10 +172,11 @@ impl HtmlHandlebars {
                     .to_string()
             }
         };
-        let html_content_404 =
-            utils::render_markdown(&content_404,
-                                   html_config.smart_punctuation(),
-                                   html_config.footnote_backrefs);
+        let html_content_404 = utils::render_markdown(
+            &content_404,
+            html_config.smart_punctuation(),
+            html_config.footnote_backrefs,
+        );
 
         let mut data_404 = data.clone();
         let base_url = if let Some(site_url) = &html_config.site_url {


### PR DESCRIPTION
This adds an option to add backreference links at the end of footnote definitions, so that the user can return and continue reading the main body of the text.

The code is based on the [footnote-rewrite.rs](https://github.com/pulldown-cmark/pulldown-cmark/blob/master/pulldown-cmark/examples/footnote-rewrite.rs) example.

It can be enabled with a TOML option:

    [output.html]
    footnote-backrefs = true

This feature has been requested before in https://github.com/rust-lang/mdBook/issues/1927