### PR TITLE
fix `init --title` option failure when git user is not configured

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -74,9 +74,9 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     if let Some(author) = get_author_name() {
         debug!("Obtained user name from gitconfig: {:?}", author);
         config.book.authors.push(author);
-        builder.with_config(config);
     }
 
+    builder.with_config(config);
     builder.build()?;
     println!("\nAll done, no errors...");
 

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -43,5 +43,5 @@ fn no_git_config_with_title() {
         .stdout(predicates::str::contains("\nAll done, no errors...\n"));
 
     let config = Config::from_disk(temp.path().join("book.toml")).unwrap();
-    assert_eq!(config.book.title, None);
+    assert_eq!(config.book.title.as_deref(), Some("Example title"));
 }

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -22,3 +22,26 @@ fn base_mdbook_init_can_skip_confirmation_prompts() {
 
     assert!(!temp.path().join(".gitignore").exists());
 }
+
+/// Run `mdbook init` with `--title` without git config.
+///
+/// Regression test for https://github.com/rust-lang/mdBook/issues/2485
+#[test]
+fn no_git_config_with_title() {
+    let temp = DummyBook::new().build().unwrap();
+
+    // doesn't exist before
+    assert!(!temp.path().join("book").exists());
+
+    let mut cmd = mdbook_cmd();
+    cmd.args(["init", "--title", "Example title"])
+        .current_dir(temp.path())
+        .env("GIT_CONFIG_GLOBAL", "")
+        .env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("\nAll done, no errors...\n"));
+
+    let config = Config::from_disk(temp.path().join("book.toml")).unwrap();
+    assert_eq!(config.book.title, None);
+}


### PR DESCRIPTION
Closes #2485

Moves the line that adds the config to the builder outside of the if statement that checks for the git user name so that the `init` options passed prior to that check don't silently fail when the git user is not configured.