### PR TITLE
Stabilize 2024 flag

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -346,7 +346,7 @@ impl MDBook {
                             cmd.args(["--edition", "2021"]);
                         }
                         RustEdition::E2024 => {
-                            cmd.args(["--edition", "2024", "-Zunstable-options"]);
+                            cmd.args(["--edition", "2024"]);
                         }
                     }
                 }


### PR DESCRIPTION
The 2024 edition is now stable on nightly, so the `-Z` flag is no longer necessary.