### PR TITLE
Add aarch64-apple-darwin release target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
             os: ubuntu-20.04
           - target: x86_64-apple-darwin
             os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     name: Deploy ${{ matrix.target }}


### PR DESCRIPTION
we are now 4 generations into apples aarch64 desktop/laptop hardware, so we should definitely be providing builds for aarch64 macos.

We already test aarch64 macos as part of CI checks gating every checkin: https://github.com/rust-lang/mdBook/blob/74b2c79d46df45ab9c196646f98339dd7e0c00c3/.github/workflows/main.yml#L35