### PR TITLE
Add configuration option to disable the default hidelines feature for rust

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -605,12 +605,23 @@ impl Default for Playground {
 }
 
 /// Configuration for tweaking how the HTML renderer handles code blocks.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Code {
+    /// Enable or disable the default line hiding with '#' for rust. Default: `true`.
+    pub default_hidelines: bool,
     /// A prefix string to hide lines per language (one or more chars).
     pub hidelines: HashMap<String, String>,
+}
+
+impl Default for Code {
+    fn default() -> Code {
+        Code {
+            default_hidelines: true,
+            hidelines: HashMap::<String, String>::default(),
+        }
+    }
 }
 
 /// Configuration of the search functionality of the HTML renderer.

--- a/crates/mdbook-html/src/html/hide_lines.rs
+++ b/crates/mdbook-html/src/html/hide_lines.rs
@@ -11,6 +11,7 @@ pub(crate) fn hide_lines(
     tree: &mut Tree<Node>,
     code_id: NodeId,
     hidelines: &HashMap<String, String>,
+    default_hidelines: bool,
 ) {
     let mut node = tree.get_mut(code_id).unwrap();
     let el = node.value().as_element().unwrap();
@@ -31,7 +32,7 @@ pub(crate) fn hide_lines(
     if let Some(mut child) = node.first_child()
         && let Node::Text(text) = child.value()
     {
-        if language == "rust" {
+        if language == "rust" && default_hidelines {
             let new_nodes = hide_lines_rust(text);
             child.detach();
             let root = tree.extend_tree(new_nodes);

--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -930,7 +930,12 @@ where
         }
 
         for code_id in code_ids {
-            hide_lines(&mut self.tree, code_id, &self.options.config.code.hidelines);
+            hide_lines(
+                &mut self.tree,
+                code_id,
+                &self.options.config.code.hidelines,
+                self.options.config.code.default_hidelines,
+            );
         }
     }
 


### PR DESCRIPTION
Simple change that adds a configuration option to disable the default hidelines feature for rust:

Usage:

```
[output.html.code]
default-hidelines = false
```

I need this in my book since I have several multi-line strings that have lines starting with `#`. (Embedded code snippets with preprocessor directives.)

~~Let me know if this needs a test.~~

If you want I can also add a line to the manual, but since this is a niche feature, the doc string  might just be enough. :)


[Edit: Added a test]