### PR TITLE
nicer style rules for margin around footnote defs

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -200,9 +200,11 @@ sup {
     line-height: 0;
 }
 
-:not(.footnote-definition) + .footnote-definition,
-.footnote-definition + :not(.footnote-definition) {
+:not(.footnote-definition) + .footnote-definition {
     margin-block-start: 2em;
+}
+.footnote-definition:not(:has(+ .footnote-definition)) {
+    margin-block-end: 2em;
 }
 .footnote-definition {
     font-size: 0.9em;


### PR DESCRIPTION
previous implementation used `:not(.footnote-definition) + .footnote-definition` and `.footnote-definition + :not(.footnote-definition)`.
the latter selector caused many problems:
- it doesn't select footnote definitions which are last children (this can be easily triggered in a blockquote)
- it changes the margin of the next sibling, rather than the footnote definition itself, which can also *shrink* margin for elements with big margins (this happens to headings)
- because it applies to the next sibling it is also quite hard to override in user styles, since it may apply to any element
  
this PR replaces the latter selector with `:not(:has(+ .fd))`, which fixes all of the mentioned problems.

see https://github.com/rust-lang/reference/pull/1710/commits/bc02bf95f937b2ea5675cd6eebf54f6ac989945d for concrete motivation.

See https://caniuse.com/mdn-css_selectors_not and https://caniuse.com/css-has for comparison of browser support of `:not` and `:has` (`:has` is slightly worse).

cc @ehuss