### PR TITLE
Add clear_renderers / clear_preprocessors

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -256,6 +256,16 @@ impl MDBook {
         self
     }
 
+    /// Clear all registered renderers.
+    pub fn clear_renderers(&mut self) {
+        self.renderers.clear();
+    }
+
+    /// Clear all registered preprocessors.
+    pub fn clear_preprocessors(&mut self) {
+        self.preprocessors.clear();
+    }
+
     /// Run `rustdoc` tests on the book, linking against the provided libraries.
     pub fn test(&mut self, library_paths: Vec<&str>) -> Result<()> {
         // test_chapter with chapter:None will run all tests.


### PR DESCRIPTION
Now `Renderer` and `Preprocessor` can be added by `with_renderer` and `with_preprocessor`.
But there is no way to disable the existing renderers and preprocessors.
So this PR add `clear_renderers` and `clear_preprocessors`.
This addition enables the customization of renderer and preprocessor without modifying the original `book.toml`.