### PR TITLE
Add context when `rustdoc` command is not found

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -356,7 +356,9 @@ impl MDBook {
                 }
 
                 debug!("running {:?}", cmd);
-                let output = cmd.output()?;
+                let output = cmd
+                    .output()
+                    .with_context(|| "failed to execute `rustdoc`")?;
 
                 if !output.status.success() {
                     failed = true;


### PR DESCRIPTION
Before, the output is rather confusing:

```
2025-02-03 10:01:14 [INFO] (mdbook::book): Testing chapter 'Chapter 1': "chapter_1.md"
2025-02-03 10:01:14 [ERROR] (mdbook::utils): Error: No such file or directory (os error 2)
```

after it looks something like:

```
2025-02-03 11:01:42 [INFO] (mdbook::book): Testing chapter 'Chapter 1': "chapter_1.md"
2025-02-03 11:01:42 [ERROR] (mdbook::utils): Error: failed to execute `rustdoc`
2025-02-03 11:01:42 [ERROR] (mdbook::utils): 	Caused By: No such file or directory (os error 2)
```

Fixes #2544