### PR TITLE
Fix issue with None source_path

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -173,7 +173,8 @@ pub struct Chapter {
     /// `index.md` via the [`Chapter::path`] field. The `source_path` field
     /// exists if you need access to the true file path.
     ///
-    /// This is `None` for a draft chapter.
+    /// This is `None` for a draft chapter, or a synthetically generated
+    /// chapter that has no file on disk.
     pub source_path: Option<PathBuf>,
     /// An ordered list of the names of each chapter above this one in the hierarchy.
     pub parent_names: Vec<String>,

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -1034,7 +1034,6 @@ fn custom_header_attributes() {
 }
 
 #[test]
-#[should_panic]
 fn with_no_source_path() {
     // Test for a regression where search would fail if source_path is None.
     let temp = DummyBook::new().build().unwrap();

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -3,10 +3,11 @@ mod dummy_book;
 use crate::dummy_book::{assert_contains_strings, assert_doesnt_contain_strings, DummyBook};
 
 use anyhow::Context;
+use mdbook::book::Chapter;
 use mdbook::config::Config;
 use mdbook::errors::*;
 use mdbook::utils::fs::write_file;
-use mdbook::MDBook;
+use mdbook::{BookItem, MDBook};
 use pretty_assertions::assert_eq;
 use select::document::Document;
 use select::predicate::{Attr, Class, Name, Predicate};
@@ -1030,4 +1031,23 @@ fn custom_header_attributes() {
         r##"<h2 id="both" class="class1 class2"><a class="header" href="#both">Heading with id and classes</a></h2>"##,
     ];
     assert_contains_strings(&contents, summary_strings);
+}
+
+#[test]
+#[should_panic]
+fn with_no_source_path() {
+    // Test for a regression where search would fail if source_path is None.
+    let temp = DummyBook::new().build().unwrap();
+    let mut md = MDBook::load(temp.path()).unwrap();
+    let chapter = Chapter {
+        name: "Sample chapter".to_string(),
+        content: "".to_string(),
+        number: None,
+        sub_items: Vec::new(),
+        path: Some(PathBuf::from("sample.html")),
+        source_path: None,
+        parent_names: Vec::new(),
+    };
+    md.book.sections.push(BookItem::Chapter(chapter));
+    md.build().unwrap();
 }


### PR DESCRIPTION
This fixes an issue where mdbook would panic if a non-draft chapter has a None source_path when generating the search index. The code was assuming that only draft chapters would have that behavior. However, API users can inject synthetic chapters that have no path on disk.

This updates it to fall back to the path, or skip if neither is set.