### PR TITLE
Remove JSON search file

### DIFF
--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -60,7 +60,7 @@ pub fn create_files(
     let index = write_to_json(index, search_config, doc_urls)?;
     debug!("Writing search index ✓");
     if index.len() > 10_000_000 {
-        warn!("searchindex.json is very large ({} bytes)", index.len());
+        warn!("search index is very large ({} bytes)", index.len());
     }
 
     if search_config.copy_js {

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -64,7 +64,6 @@ pub fn create_files(
     }
 
     if search_config.copy_js {
-        static_files.add_builtin("searchindex.json", index.as_bytes());
         static_files.add_builtin(
             "searchindex.js",
             format!("Object.assign(window.search, {});", index).as_bytes(),

--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -363,7 +363,7 @@ window.search = window.search || {};
             }
         }
     }
-    
+
     function showSearch(yes) {
         if (yes) {
             search_wrap.classList.remove('hidden');
@@ -441,7 +441,6 @@ window.search = window.search || {};
     }
     
     function doSearch(searchterm) {
-
         // Don't search the same twice
         if (current_searchterm == searchterm) { return; }
         else { current_searchterm = searchterm; }
@@ -468,15 +467,18 @@ window.search = window.search || {};
         showResults(true);
     }
 
-    fetch(path_to_root + '{{ resource "searchindex.json" }}')
-        .then(response => response.json())
-        .then(json => init(json))        
-        .catch(error => { // Try to load searchindex.js if fetch failed
-            var script = document.createElement('script');
-            script.src = path_to_root + '{{ resource "searchindex.js" }}';
-            script.onload = () => init(window.search);
-            document.head.appendChild(script);
-        });
+    function loadScript(url, id) {
+        const script = document.createElement('script');
+        script.src = url;
+        script.id = id;
+        script.onload = () => init(window.search);
+        script.onerror = error => {
+            console.error(`Failed to load \`${url}\`: ${error}`);    
+        };
+        document.head.append(script);
+    }
+
+    loadScript(path_to_root + '{{ resource "searchindex.js" }}', 'search-index');
 
     // Exported functions
     search.hasFocus = hasFocus;

--- a/tests/gui/move-between-pages.goml
+++ b/tests/gui/move-between-pages.goml
@@ -1,7 +1,6 @@
 // This tests pressing the left and right arrows moving to previous and next page.
 
-// We disable the requests checks because `searchindex.json` will always fail
-// locally (due to CORS), but the searchindex.js will succeed.
+// We disable the requests checks because `mode-rust.js` is not found.
 fail-on-request-error: false
 
 go-to: |DOC_PATH| + "index.html"

--- a/tests/gui/search.goml
+++ b/tests/gui/search.goml
@@ -1,8 +1,5 @@
 // This tests basic search behavior.
 
-// We disable the requests checks because `searchindex.json` will always fail
-// locally (due to CORS), but the searchindex.js will succeed.
-fail-on-request-error: false
 go-to: |DOC_PATH| + "index.html"
 
 define-function: (

--- a/tests/gui/sidebar-nojs.goml
+++ b/tests/gui/sidebar-nojs.goml
@@ -2,9 +2,6 @@
 // an iframe (because of JS disabled).
 // Regression test for <https://github.com/rust-lang/mdBook/issues/2528>.
 
-// We disable the requests checks because `searchindex.json` will always fail
-// locally.
-fail-on-request-error: false
 // We disable javascript
 javascript: false
 go-to: |DOC_PATH| + "index.html"

--- a/tests/gui/sidebar.goml
+++ b/tests/gui/sidebar.goml
@@ -1,9 +1,6 @@
 // This GUI test checks sidebar hide/show and also its behaviour on smaller
 // width.
 
-// We disable the requests checks because `searchindex.json` will always fail
-// locally.
-fail-on-request-error: false
 go-to: |DOC_PATH| + "index.html"
 set-window-size: (1100, 600)
 // Need to reload for the new size to be taken account by the JS.


### PR DESCRIPTION
Why bother having the search index in both a JSON and JS file when it always work with the JS file after all. :)

I took over https://github.com/rust-lang/mdBook/pull/2425 to implement this.

cc @notriddle 