### PR TITLE
Enhanced wording for editable code blocks docs

### DIFF
--- a/guide/src/format/theme/editor.md
+++ b/guide/src/format/theme/editor.md
@@ -9,8 +9,8 @@ be added to the ***book.toml***:
 editable = true
 ```
 
-To make a specific block available for editing, the attribute `editable` needs
-to be added to it:
+After enabling editable code blocks, the `editable` attribute must be added to a
+code block to make it editable:
 
 ~~~markdown
 ```rust,editable


### PR DESCRIPTION
Corresponding URLO topic:

https://users.rust-lang.org/t/how-to-enable-editable-code-playgrounds-in-mdbook/126476

To me, it was not immediately clear from the docs that `output.html.playground.editable = true` only enables the `editable` attribute on code blocks. I thought it meant that every code block automatically becomes editable and if we only want a single code block to be editable, we use the `editable` attribute instead. I believe with minor changes to the second sentence it becomes clearer to the hasty reader that this is not the case.