### PR TITLE
[test] Check content of error message

### DIFF
--- a/tests/custom_preprocessors.rs
+++ b/tests/custom_preprocessors.rs
@@ -44,9 +44,16 @@ fn ask_the_preprocessor_to_blow_up() {
 
     assert!(got.is_err());
     let error_message = got.err().unwrap().to_string();
+    let status = if cfg!(windows) {
+        "exit code: 1"
+    } else {
+        "exit status: 1"
+    };
     assert_eq!(
         error_message,
-        r#"The "nop-preprocessor" preprocessor exited unsuccessfully with exit status: 1 status"#
+        format!(
+            r#"The "nop-preprocessor" preprocessor exited unsuccessfully with {status} status"#
+        )
     );
 }
 

--- a/tests/custom_preprocessors.rs
+++ b/tests/custom_preprocessors.rs
@@ -43,6 +43,11 @@ fn ask_the_preprocessor_to_blow_up() {
     let got = md.build();
 
     assert!(got.is_err());
+    let error_message = got.err().unwrap().to_string();
+    assert_eq!(
+        error_message,
+        r#"The "nop-preprocessor" preprocessor exited unsuccessfully with exit status: 1 status"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
testing error message of ask_the_preprocessor_to_blow_up

Apparently the `output.status` is different on windows and the rest of the OSes. That's why we need the `cfg!(windows)`
We could replace `output.status` by `output.status.code().unwrap_or(-1)` or by `output.status.code().unwrap()` thereby making sure the error message is the same on all (currently tested) OSes.

