### PR TITLE
Fix search not showing in sub-directories

### DIFF
--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -468,12 +468,12 @@ window.search = window.search || {};
         showResults(true);
     }
 
-    fetch('{{ resource "searchindex.json" }}')
+    fetch(path_to_root + '{{ resource "searchindex.json" }}')
         .then(response => response.json())
         .then(json => init(json))        
         .catch(error => { // Try to load searchindex.js if fetch failed
             var script = document.createElement('script');
-            script.src = '{{ resource "searchindex.js" }}';
+            script.src = path_to_root + '{{ resource "searchindex.js" }}';
             script.onload = () => init(window.search);
             document.head.appendChild(script);
         });

--- a/tests/gui/search.goml
+++ b/tests/gui/search.goml
@@ -1,0 +1,33 @@
+// This tests basic search behavior.
+
+// We disable the requests checks because `searchindex.json` will always fail
+// locally (due to CORS), but the searchindex.js will succeed.
+fail-on-request-error: false
+go-to: |DOC_PATH| + "index.html"
+
+define-function: (
+    "open-search",
+    [],
+    block {
+        assert-css: ("#search-wrapper", {"display": "none"})
+        press-key: 'S'
+        wait-for-css-false: ("#search-wrapper", {"display": "none"})
+    }
+)
+
+call-function: ("open-search", {})
+assert-text: ("#searchresults-header", "")
+write: "strikethrough"
+wait-for-text: ("#searchresults-header", "2 search results for 'strikethrough':")
+// Close the search display
+press-key: 'Escape'
+wait-for-css: ("#search-wrapper", {"display": "none"})
+// Reopening the search should show the last value
+call-function: ("open-search", {})
+assert-text: ("#searchresults-header", "2 search results for 'strikethrough':")
+// Navigate to a sub-chapter
+go-to: "./individual/strikethrough.html"
+assert-text: ("#searchresults-header", "")
+call-function: ("open-search", {})
+write: "strikethrough"
+wait-for-text: ("#searchresults-header", "2 search results for 'strikethrough':")


### PR DESCRIPTION
This fixes a problem where the search was not displaying in sub-directories. The problem was that `searcher.js` only exists in one place, and was loading `searchindex.json` with a relative path. However, when loading from a subdirectory, it needs the appropriate `..` to reach the root of the book.

Fixes https://github.com/rust-lang/mdBook/issues/2585