### PR TITLE
Select all the GUI tests if no filter was provided

### DIFF
--- a/tests/gui/runner.rs
+++ b/tests/gui/runner.rs
@@ -75,7 +75,7 @@ fn main() {
 
     let mut no_headless = false;
     let mut filters = Vec::new();
-    for arg in std::env::args() {
+    for arg in std::env::args().skip(1) {
         if arg == "--disable-headless-test" {
             no_headless = true;
         } else {


### PR DESCRIPTION
The name of executable was taken as a filter and because of that nothing was selected by default.

Fixing #2601 