### PR TITLE
Fix GUI tests not being run if no filter is used

### DIFF
--- a/tests/gui/runner.rs
+++ b/tests/gui/runner.rs
@@ -75,7 +75,7 @@ fn main() {
 
     let mut no_headless = false;
     let mut filters = Vec::new();
-    for arg in std::env::args() {
+    for arg in std::env::args().skip(1) {
         if arg == "--disable-headless-test" {
             no_headless = true;
         } else {


### PR DESCRIPTION
Fixes #2601.

Forgot to skip the binary argument.