### PR TITLE
Add FAQ to the documentation

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -38,6 +38,7 @@
     - [Preprocessors](for_developers/preprocessors.md)
     - [Alternative Backends](for_developers/backends.md)
 
+- [FAQ](faq.md)
 -----------
 
 [Contributors](misc/contributors.md)

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -1,0 +1,7 @@
+# FAQ - Frequently Asked Questions
+
+
+## Exclude pages from the search bar
+
+See the [configuration of the HTML renderer](./format/configuration/renderers.html#outputhtmlsearchchapter).
+


### PR DESCRIPTION
Allow us to use different words to describe certain features to make it easier for people to find it using their own vocabulary. Without the need to sneak in the documentation all the possible words.

e.g. In this case searching for "exclude" could not help the user as that word was not used in our documentation.

See #2218