### PR TITLE
Speed up search index loading

### DIFF
--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -3,7 +3,7 @@
 /* global Mark, elasticlunr, path_to_root */
 
 window.search = window.search || {};
-(function search(search) {
+(function search() {
     // Search functionality
     //
     // You can use !hasFocus() to prevent keyhandling in your key
@@ -288,6 +288,9 @@ window.search = window.search || {};
 
         // If reloaded, do the search or mark again, depending on the current url parameters
         doSearchOrMarkFromUrl();
+
+        // Exported functions
+        config.hasFocus = hasFocus;
     }
 
     function unfocusSearchbar() {
@@ -521,6 +524,4 @@ window.search = window.search || {};
 
     loadScript(path_to_root + '{{ resource "searchindex.js" }}', 'search-index');
 
-    // Exported functions
-    search.hasFocus = hasFocus;
 })(window.search);

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -66,7 +66,13 @@ pub fn create_files(
     if search_config.copy_js {
         static_files.add_builtin(
             "searchindex.js",
-            format!("Object.assign(window.search, {});", index).as_bytes(),
+            // To reduce the size of the generated JSON by preventing all `"` characters to be
+            // escaped, we instead surround the string with much less common `'` character.
+            format!(
+                "window.search = JSON.parse('{}');",
+                index.replace("\\", "\\\\").replace("'", "\\'")
+            )
+            .as_bytes(),
         );
         static_files.add_builtin("searcher.js", searcher::JS);
         static_files.add_builtin("mark.min.js", searcher::MARK_JS);

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -773,9 +773,10 @@ mod search {
     fn read_book_index(root: &Path) -> serde_json::Value {
         let index = root.join("book/searchindex.js");
         let index = fs::read_to_string(index).unwrap();
-        let index = index.trim_start_matches("Object.assign(window.search, ");
-        let index = index.trim_end_matches(");");
-        serde_json::from_str(index).unwrap()
+        let index = index.trim_start_matches("window.search = JSON.parse('");
+        let index = index.trim_end_matches("');");
+        // We need unescape the string as it's supposed to be an escaped JS string.
+        serde_json::from_str(&index.replace("\\'", "'").replace("\\\\", "\\")).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/mdBook/pull/2552.

`JSON.parse()` is much faster than parsing JS code for JS engines. I missed this case when I removed the original JSON file. This is also how we do in rustdoc. The bigger the search index, the more noticeable it is.

As for the second commit, it fixes this JS error:

![Screenshot From 2025-04-02 11-14-15](https://github.com/user-attachments/assets/42c0a830-6321-4d48-972c-a7779d9939bf)

@ehuss Just to be sure: does this PR solves your 10+ seconds issue for search load?