### PR TITLE
Mark more font files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.ttf binary
 *.otf binary
 *.png binary
+*.eot binary
+*.woff2 binary


### PR DESCRIPTION
Not having these files marked as binary causes problems for older versions of git (like 1.8.3.1 on CentOS/RHEL 7).