### PR TITLE
Sidebar improvements

### DIFF
--- a/src/front-end/js/book.js
+++ b/src/front-end/js/book.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global default_theme, default_dark_theme, default_light_theme, hljs, ClipboardJS */
+/* global default_theme, default_dark_theme, default_light_theme, hljs, ClipboardJS, mdBook */
 
 // Fix back button cache problem
 window.onunload = function() { };

--- a/src/front-end/js/book.js
+++ b/src/front-end/js/book.js
@@ -514,19 +514,6 @@ aria-label="Show hidden lines"></button>';
     });
 })();
 
-function setConfig(key, value, storage = localStorage) {
-    const fullKey = 'mdbook-' + key;
-    try {
-        storage.setItem(fullKey, value);
-    } catch (e) {
-        // Ignore error.
-        //  It can only be a security exception (if the user has disabled cookies/storage)
-        //  TODO: maybe display some warning to the user that the setting they are trying
-        //      to change will not be kept across page changes/reloads because they disabled
-        //      storage for this site/origin?
-    }
-}
-
 (function sidebar() {
     const body = document.querySelector('body');
     const sidebar = document.getElementById('sidebar');
@@ -549,7 +536,7 @@ function setConfig(key, value, storage = localStorage) {
         //  specific to the current browser window and tab (since different windows can have
         //  different sizes), unlike the theme which is a global preference (ie. if you want
         //  a dark theme, you probably want it on all your windows)
-        setConfig('sidebar', isVisible ? 'visible' : 'hidden', sessionStorage);
+        mdBook.setConfig('sidebar', isVisible ? 'visible' : 'hidden', sessionStorage);
     }
 
     function showSidebar() {
@@ -604,7 +591,7 @@ function setConfig(key, value, storage = localStorage) {
             const sidebarWidth = startSidebarWidth +
                 Math.min(e.clientX, window.innerWidth - 100) -
                 startClientX;
-            setConfig('sidebarWidth', sidebarWidth, sessionStorage);
+            mdBook.setConfig('sidebarWidth', sidebarWidth, sessionStorage);
             document.documentElement.style.setProperty('--sidebar-width', sidebarWidth + 'px');
         }
     }

--- a/src/front-end/js/book.js
+++ b/src/front-end/js/book.js
@@ -515,13 +515,15 @@ aria-label="Show hidden lines"></button>';
 })();
 
 function setConfig(key, value, storage = localStorage) {
-    const fullKey = "mdbook-" + key;
+    const fullKey = 'mdbook-' + key;
     try {
         storage.setItem(fullKey, value);
     } catch (e) {
         // Ignore error.
         //  It can only be a security exception (if the user has disabled cookies/storage)
-        //  TODO: maybe display some warning to the user that the setting they are trying to change will not be kept across page changes/reloads because they disabled storage for this site/origin?
+        //  TODO: maybe display some warning to the user that the setting they are trying
+        //      to change will not be kept across page changes/reloads because they disabled
+        //      storage for this site/origin?
     }
 }
 
@@ -543,8 +545,11 @@ function setConfig(key, value, storage = localStorage) {
         sidebarToggleButton.setAttribute('aria-expanded', isVisible);
         sidebar.setAttribute('aria-hidden', !isVisible);
 
-        //  We use sessionStorage for the sidebar visibility setting, as we want it to be specific to the browser window and tab (since different windows can have different sizes), unlike the theme which is a global preference (ie. if you want a dark theme, you probably want it on all your windows)
-        setConfig("sidebar", isVisible ? 'visible' : 'hidden', sessionStorage);
+        //  We use sessionStorage for the sidebar visibility setting, as we want it to be
+        //  specific to the current browser window and tab (since different windows can have
+        //  different sizes), unlike the theme which is a global preference (ie. if you want
+        //  a dark theme, you probably want it on all your windows)
+        setConfig('sidebar', isVisible ? 'visible' : 'hidden', sessionStorage);
     }
 
     function showSidebar() {
@@ -576,23 +581,30 @@ function setConfig(key, value, storage = localStorage) {
     function initResize(e) {
         window.addEventListener('mousemove', resize, false);
         window.addEventListener('mouseup', stopResize, false);
-        
+
         body.classList.add('sidebar-resizing');
 
         startClientX = e.clientX;
-        startSidebarWidth = parseInt(getComputedStyle(document.body).getPropertyValue('--sidebar-width')?.replace(/px$/, ""), 10);
+        startSidebarWidth = parseInt(
+            getComputedStyle(document.body)
+                .getPropertyValue('--sidebar-width')
+                ?.replace(/px$/, ''),
+            10,
+        );
     }
 
     function resize(e) {
-        let pos = e.clientX - sidebar.offsetLeft;
+        const pos = e.clientX - sidebar.offsetLeft;
         if (pos < 20) {
             hideSidebar();
         } else {
             if (body.classList.contains('sidebar-hidden')) {
                 showSidebar();
             }
-            let sidebarWidth = startSidebarWidth + Math.min(e.clientX, window.innerWidth - 100) - startClientX;
-            setConfig("sidebarWidth", sidebarWidth, sessionStorage);
+            const sidebarWidth = startSidebarWidth +
+                Math.min(e.clientX, window.innerWidth - 100) -
+                startClientX;
+            setConfig('sidebarWidth', sidebarWidth, sessionStorage);
             document.documentElement.style.setProperty('--sidebar-width', sidebarWidth + 'px');
         }
     }

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -79,15 +79,7 @@
             getConfig(key, storage = localStorage) {
                 const fullKey = "mdbook-" + key;
                 try {
-                    let value = storage.getItem(fullKey);
-
-                    if(value && value.startsWith('"')) {
-                        //  Work around some values being stored in localStorage wrapped in quotes
-                        //  Probably for legacy reasons?
-                        value = value.replace(/^"|"$/g, "");
-                        storage.setItem(fullKey, value);
-                    }
-                    return value;
+                    return storage.getItem(fullKey);
                 } catch(e) {
                     //  It can only be a security exception (if the user has disabled cookies/storage)
                     //  TODO: we could warn the user that we won’t be able to persist their settings, but maybe it would be better to do it only if/when they try to change them? (ie when they try to hide or show the sidebar, or change the theme)
@@ -114,7 +106,15 @@
 
             //  Set the theme before any content is loaded, prevents flash
 
-            let theme = mdBook.getConfig("theme") ?? default_theme;
+            let theme = mdBook.getConfig('theme');
+            //  Work around some values being stored in localStorage wrapped in quotes
+            //  Probably for legacy reasons?
+            if(theme && theme.startsWith('"')) {
+                theme = theme.replace(/^"|"$/g, "");
+                mdBook.setConfig('theme', theme);
+            }
+            theme = theme ?? default_theme;
+
             html.classList.remove('{{ default_theme }}')
             html.classList.add(theme);
             html.classList.add("js");

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -73,8 +73,10 @@
         const html = document.documentElement;
         const sidebar_toggle = document.getElementById("sidebar-toggle-anchor");
 
-        (function(){
-            function getConfig(key, storage = localStorage) {
+
+        //  Global “namespace” object to keep some of our helper functions and utils
+        const mdBook = {
+            getConfig(key, storage = localStorage) {
                 const fullKey = "mdbook-" + key;
                 try {
                     let value = storage.getItem(fullKey);
@@ -91,26 +93,49 @@
                     //  TODO: we could warn the user that we won’t be able to persist their settings, but maybe it would be better to do it only if/when they try to change them? (ie when they try to hide or show the sidebar, or change the theme)
                     return null;
                 }
-            }
+            },
+
+            setConfig(key, value, storage = localStorage) {
+                const fullKey = 'mdbook-' + key;
+                try {
+                    storage.setItem(fullKey, value);
+                } catch (e) {
+                    // Ignore error.
+                    //  It can only be a security exception (if the user has disabled cookies/storage)
+                    //  TODO: maybe display some warning to the user that the setting they are trying
+                    //      to change will not be kept across page changes/reloads because they disabled
+                    //      storage for this site/origin?
+                }
+            },
+        };
+
+
+        (function(){
 
             //  Set the theme before any content is loaded, prevents flash
 
-            let theme = getConfig("theme") ?? default_theme;
+            let theme = mdBook.getConfig("theme") ?? default_theme;
             html.classList.remove('{{ default_theme }}')
             html.classList.add(theme);
             html.classList.add("js");
 
             //  Hide / unhide sidebar before it is displayed, and restore its width if it was manually resized
 
-            let sidebar = getConfig("sidebar", sessionStorage) ??
-                ((document.body.clientWidth >= 1080) ? "visible" : "hidden");
+            let sidebar = mdBook.getConfig("sidebar", sessionStorage);
+            if(!sidebar) {
+                //  No value, this must be the first time this page is open.
+                //  By default, show or hide the sidebar depending on the window width.
+                sidebar = (document.body.clientWidth >= 1080) ? "visible" : "hidden";
+                //  Then we need to *store* the visibility of the sidebar, because without that, if the user resized the window then navigated to another page, the sidebar visibility could change unexpectedly
+                mdBook.setConfig('sidebar', sidebar, sessionStorage);
+            }
 
             sidebar_toggle.checked = sidebar === 'visible';
             html.classList.remove('sidebar-visible');
             html.classList.add("sidebar-" + sidebar);
 
             //  We need parseInt() because storage only stores strings
-            let sidebarWidth = parseInt(getConfig("sidebarWidth", sessionStorage), 10);
+            let sidebarWidth = parseInt(mdBook.getConfig("sidebarWidth", sessionStorage), 10);
             if(sidebarWidth && Number.isFinite(sidebarWidth)) {
                 document.documentElement.style.setProperty('--sidebar-width', Math.min(sidebarWidth, window.innerWidth - 100) + 'px');
             }

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -64,50 +64,58 @@
     </head>
     <body>
     <div id="body-container">
-        <!-- Work around some values being stored in localStorage wrapped in quotes -->
+        <input type="checkbox" id="sidebar-toggle-anchor" class="hidden">
+
         <script>
-            try {
-                let theme = localStorage.getItem('mdbook-theme');
-                let sidebar = localStorage.getItem('mdbook-sidebar');
+        //  First declare the global constants needed everywhere, outside of the function wrapper
+        //  TODO refactoring: maybe all variables that are currently global could be moved to a single global object (window.mdBook) to avoid cluttering the global namespace?
+        const default_theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? default_dark_theme : default_light_theme;
+        const html = document.documentElement;
+        const sidebar_toggle = document.getElementById("sidebar-toggle-anchor");
 
-                if (theme.startsWith('"') && theme.endsWith('"')) {
-                    localStorage.setItem('mdbook-theme', theme.slice(1, theme.length - 1));
+        (function(){
+            function getConfig(key, storage = localStorage) {
+                const fullKey = "mdbook-" + key;
+                try {
+                    let value = storage.getItem(fullKey);
+
+                    if(value && value.startsWith('"')) {
+                        //  Work around some values being stored in localStorage wrapped in quotes
+                        //  Probably for legacy reasons?
+                        value = value.replace(/^"|"$/g, "");
+                        storage.setItem(fullKey, value);
+                    }
+                    return value;
+                } catch(e) {
+                    //  It can only be a security exception (if the user has disabled cookies/storage)
+                    //  TODO: we could warn the user that we won’t be able to persist their settings, but maybe it would be better to do it only if/when they try to change them? (ie when they try to hide or show the sidebar, or change the theme)
+                    return null;
                 }
+            }
 
-                if (sidebar.startsWith('"') && sidebar.endsWith('"')) {
-                    localStorage.setItem('mdbook-sidebar', sidebar.slice(1, sidebar.length - 1));
-                }
-            } catch (e) { }
-        </script>
+            //  Set the theme before any content is loaded, prevents flash
 
-        <!-- Set the theme before any content is loaded, prevents flash -->
-        <script>
-            const default_theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? default_dark_theme : default_light_theme;
-            let theme;
-            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
-            if (theme === null || theme === undefined) { theme = default_theme; }
-            const html = document.documentElement;
+            let theme = getConfig("theme") ?? default_theme;
             html.classList.remove('{{ default_theme }}')
             html.classList.add(theme);
             html.classList.add("js");
-        </script>
 
-        <input type="checkbox" id="sidebar-toggle-anchor" class="hidden">
+            //  Hide / unhide sidebar before it is displayed, and restore its width if it was manually resized
 
-        <!-- Hide / unhide sidebar before it is displayed -->
-        <script>
-            let sidebar = null;
-            const sidebar_toggle = document.getElementById("sidebar-toggle-anchor");
-            if (document.body.clientWidth >= 1080) {
-                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
-                sidebar = sidebar || 'visible';
-            } else {
-                sidebar = 'hidden';
-            }
+            let sidebar = getConfig("sidebar", sessionStorage) ??
+                ((document.body.clientWidth >= 1080) ? "visible" : "hidden");
+
             sidebar_toggle.checked = sidebar === 'visible';
             html.classList.remove('sidebar-visible');
             html.classList.add("sidebar-" + sidebar);
-        </script>
+
+            //  We need parseInt() because storage only stores strings
+            let sidebarWidth = parseInt(getConfig("sidebarWidth", sessionStorage), 10);
+            if(sidebarWidth && Number.isFinite(sidebarWidth)) {
+                document.documentElement.style.setProperty('--sidebar-width', Math.min(sidebarWidth, window.innerWidth - 100) + 'px');
+            }
+
+        })();</script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
             <!-- populated by js -->


### PR DESCRIPTION
Sidebar status is now moved to sessionStorage instead of localStorage.

Fix: sidebar visibility was not correctly loaded from storage when the browser window was smaller than 1080 pixels wide.

Sidebar width is now saved too.

Remove too large try-catch block that would hide some errors.

Resolves #2665