### PR TITLE
Ignore SVG text elements in search highlighting

### DIFF
--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -29,7 +29,8 @@ window.search = window.search || {};
         searchicon = document.getElementById('search-toggle'),
         content = document.getElementById('content'),
 
-        mark_exclude = [],
+        // SVG text elements don't render if inside a <mark> tag.
+        mark_exclude = ["text"],
         marker = new Mark(content),
         URL_SEARCH_PARAM = 'search',
         URL_MARK_PARAM = 'highlight',


### PR DESCRIPTION
The SVG `<text>` tag does not seem to like having HTML tags mixed in, and the `<mark>` tag seems to prevent rendering. This adds it to the exclude list so that it doesn't try to mark content inside `<text>`.