### PR TITLE
Warn on and ignore duplicate footnote definitions

### DIFF
--- a/tests/testsuite/markdown.rs
+++ b/tests/testsuite/markdown.rs
@@ -17,10 +17,22 @@ fn custom_header_attributes() {
 // Test for a variety of footnote renderings.
 #[test]
 fn footnotes() {
-    BookTest::from_dir("markdown/footnotes").check_main_file(
-        "book/footnotes.html",
-        file!["markdown/footnotes/expected/footnotes.html"],
-    );
+    BookTest::from_dir("markdown/footnotes")
+        .run("build", |cmd| {
+            cmd.expect_stderr(str![[r#"
+[TIMESTAMP] [INFO] (mdbook::book): Book building has started
+[TIMESTAMP] [INFO] (mdbook::book): Running the html backend
+[TIMESTAMP] [WARN] (mdbook::utils): footnote `multiple-definitions` in <unknown> defined multiple times - not updating to new definition
+[TIMESTAMP] [WARN] (mdbook::utils): footnote `unused` in `<unknown>` is defined but not referenced
+[TIMESTAMP] [WARN] (mdbook::utils): footnote `multiple-definitions` in footnotes.md defined multiple times - not updating to new definition
+[TIMESTAMP] [WARN] (mdbook::utils): footnote `unused` in `footnotes.md` is defined but not referenced
+
+"#]]);
+        })
+        .check_main_file(
+            "book/footnotes.html",
+            file!["markdown/footnotes/expected/footnotes.html"],
+        );
 }
 
 // Basic table test.

--- a/tests/testsuite/markdown.rs
+++ b/tests/testsuite/markdown.rs
@@ -1,6 +1,7 @@
 //! Tests for special markdown rendering.
 
 use crate::prelude::*;
+use snapbox::file;
 
 // Checks custom header id and classes.
 #[test]
@@ -16,47 +17,10 @@ fn custom_header_attributes() {
 // Test for a variety of footnote renderings.
 #[test]
 fn footnotes() {
-    BookTest::from_dir("markdown/footnotes")
-        .check_main_file("book/footnotes.html", str![[r##"
-<h1 id="footnote-tests"><a class="header" href="#footnote-tests">Footnote tests</a></h1>
-<p>Footnote example<sup class="footnote-reference" id="fr-1-1"><a href="#footnote-1">1</a></sup>, or with a word<sup class="footnote-reference" id="fr-word-1"><a href="#footnote-word">2</a></sup>.</p>
-<p>There are multiple references to word<sup class="footnote-reference" id="fr-word-2"><a href="#footnote-word">2</a></sup>.</p>
-<p>Footnote without a paragraph<sup class="footnote-reference" id="fr-para-1"><a href="#footnote-para">3</a></sup></p>
-<p>Footnote with multiple paragraphs<sup class="footnote-reference" id="fr-multiple-1"><a href="#footnote-multiple">4</a></sup></p>
-<p>Footnote name with wacky characters<sup class="footnote-reference" id="fr-&quot;wacky&quot;-1"><a href="#footnote-&quot;wacky&quot;">5</a></sup></p>
-<p>Testing when referring to something earlier.<sup class="footnote-reference" id="fr-define-before-use-1"><a href="#footnote-define-before-use">6</a></sup></p>
-<hr>
-<ol class="footnote-definition"><li id="footnote-1">
-<p>This is a footnote. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>
-</li>
-<li id="footnote-word">
-<p>A longer footnote.
-With multiple lines. <a href="other.html">Link to other</a>.
-With a reference inside.<sup class="footnote-reference" id="fr-1-2"><a href="#footnote-1">1</a></sup> <a href="#fr-word-1">↩</a> <a href="#fr-word-2">↩2</a></p>
-</li>
-<li id="footnote-para">
-<ol>
-<li>Item one
-<ol>
-<li>Sub-item</li>
-</ol>
-</li>
-<li>Item two</li>
-</ol>
- <a href="#fr-para-1">↩</a></li>
-<li id="footnote-multiple">
-<p>One</p>
-<p>Two</p>
-<p>Three <a href="#fr-multiple-1">↩</a></p>
-</li>
-<li id="footnote-&quot;wacky&quot;">
-<p>Testing footnote id with special characters. <a href="#fr-&quot;wacky&quot;-1">↩</a></p>
-</li>
-<li id="footnote-define-before-use">
-<p>This is defined before it is referred to. <a href="#fr-define-before-use-1">↩</a></p>
-</li>
-</ol>
-"##]]);
+    BookTest::from_dir("markdown/footnotes").check_main_file(
+        "book/footnotes.html",
+        file!["markdown/footnotes/expected/footnotes.html"],
+    );
 }
 
 // Basic table test.

--- a/tests/testsuite/markdown/footnotes/expected/footnotes.html
+++ b/tests/testsuite/markdown/footnotes/expected/footnotes.html
@@ -40,9 +40,6 @@ With a reference inside.<sup class="footnote-reference" id="fr-1-2"><a href="#fo
 <li id="footnote-multiple-definitions">
 <p>This is the first definition of the footnote with tag multiple-definitions <a href="#fr-multiple-definitions-1">↩</a> <a href="#fr-multiple-definitions-2">↩2</a></p>
 </li>
-<li id="footnote-multiple-definitions">
-<p>This is the second definition of the footnote with tag multiple-definitions <a href="#fr-multiple-definitions-1">↩</a> <a href="#fr-multiple-definitions-2">↩2</a></p>
-</li>
 <li id="footnote-in-between">
 <p>Footnote between duplicates. <a href="#fr-in-between-1">↩</a></p>
 </li>

--- a/tests/testsuite/markdown/footnotes/expected/footnotes.html
+++ b/tests/testsuite/markdown/footnotes/expected/footnotes.html
@@ -5,6 +5,8 @@
 <p>Footnote with multiple paragraphs<sup class="footnote-reference" id="fr-multiple-1"><a href="#footnote-multiple">4</a></sup></p>
 <p>Footnote name with wacky characters<sup class="footnote-reference" id="fr-&quot;wacky&quot;-1"><a href="#footnote-&quot;wacky&quot;">5</a></sup></p>
 <p>Testing when referring to something earlier.<sup class="footnote-reference" id="fr-define-before-use-1"><a href="#footnote-define-before-use">6</a></sup></p>
+<p>Footnote that is defined multiple times.<sup class="footnote-reference" id="fr-multiple-definitions-1"><a href="#footnote-multiple-definitions">7</a></sup></p>
+<p>And another<sup class="footnote-reference" id="fr-in-between-1"><a href="#footnote-in-between">8</a></sup> that references the duplicate again.<sup class="footnote-reference" id="fr-multiple-definitions-2"><a href="#footnote-multiple-definitions">7</a></sup></p>
 <hr>
 <ol class="footnote-definition"><li id="footnote-1">
 <p>This is a footnote. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>
@@ -34,5 +36,14 @@ With a reference inside.<sup class="footnote-reference" id="fr-1-2"><a href="#fo
 </li>
 <li id="footnote-define-before-use">
 <p>This is defined before it is referred to. <a href="#fr-define-before-use-1">↩</a></p>
+</li>
+<li id="footnote-multiple-definitions">
+<p>This is the first definition of the footnote with tag multiple-definitions <a href="#fr-multiple-definitions-1">↩</a> <a href="#fr-multiple-definitions-2">↩2</a></p>
+</li>
+<li id="footnote-multiple-definitions">
+<p>This is the second definition of the footnote with tag multiple-definitions <a href="#fr-multiple-definitions-1">↩</a> <a href="#fr-multiple-definitions-2">↩2</a></p>
+</li>
+<li id="footnote-in-between">
+<p>Footnote between duplicates. <a href="#fr-in-between-1">↩</a></p>
 </li>
 </ol>

--- a/tests/testsuite/markdown/footnotes/expected/footnotes.html
+++ b/tests/testsuite/markdown/footnotes/expected/footnotes.html
@@ -1,0 +1,38 @@
+<h1 id="footnote-tests"><a class="header" href="#footnote-tests">Footnote tests</a></h1>
+<p>Footnote example<sup class="footnote-reference" id="fr-1-1"><a href="#footnote-1">1</a></sup>, or with a word<sup class="footnote-reference" id="fr-word-1"><a href="#footnote-word">2</a></sup>.</p>
+<p>There are multiple references to word<sup class="footnote-reference" id="fr-word-2"><a href="#footnote-word">2</a></sup>.</p>
+<p>Footnote without a paragraph<sup class="footnote-reference" id="fr-para-1"><a href="#footnote-para">3</a></sup></p>
+<p>Footnote with multiple paragraphs<sup class="footnote-reference" id="fr-multiple-1"><a href="#footnote-multiple">4</a></sup></p>
+<p>Footnote name with wacky characters<sup class="footnote-reference" id="fr-&quot;wacky&quot;-1"><a href="#footnote-&quot;wacky&quot;">5</a></sup></p>
+<p>Testing when referring to something earlier.<sup class="footnote-reference" id="fr-define-before-use-1"><a href="#footnote-define-before-use">6</a></sup></p>
+<hr>
+<ol class="footnote-definition"><li id="footnote-1">
+<p>This is a footnote. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>
+</li>
+<li id="footnote-word">
+<p>A longer footnote.
+With multiple lines. <a href="other.html">Link to other</a>.
+With a reference inside.<sup class="footnote-reference" id="fr-1-2"><a href="#footnote-1">1</a></sup> <a href="#fr-word-1">↩</a> <a href="#fr-word-2">↩2</a></p>
+</li>
+<li id="footnote-para">
+<ol>
+<li>Item one
+<ol>
+<li>Sub-item</li>
+</ol>
+</li>
+<li>Item two</li>
+</ol>
+ <a href="#fr-para-1">↩</a></li>
+<li id="footnote-multiple">
+<p>One</p>
+<p>Two</p>
+<p>Three <a href="#fr-multiple-1">↩</a></p>
+</li>
+<li id="footnote-&quot;wacky&quot;">
+<p>Testing footnote id with special characters. <a href="#fr-&quot;wacky&quot;-1">↩</a></p>
+</li>
+<li id="footnote-define-before-use">
+<p>This is defined before it is referred to. <a href="#fr-define-before-use-1">↩</a></p>
+</li>
+</ol>

--- a/tests/testsuite/markdown/footnotes/src/footnotes.md
+++ b/tests/testsuite/markdown/footnotes/src/footnotes.md
@@ -35,3 +35,13 @@ Footnote name with wacky characters[^"wacky"]
 [^"wacky"]: Testing footnote id with special characters.
 
 Testing when referring to something earlier.[^define-before-use]
+
+Footnote that is defined multiple times.[^multiple-definitions]
+
+[^multiple-definitions]: This is the first definition of the footnote with tag multiple-definitions
+
+And another[^in-between] that references the duplicate again.[^multiple-definitions]
+
+[^in-between]: Footnote between duplicates.
+
+[^multiple-definitions]: This is the second definition of the footnote with tag multiple-definitions


### PR DESCRIPTION
Rework the footnote rendering logic to handle cases where the same footnote tag is defined multiple times in a document.

When multiple definitions of the same footnote tag are encountered:
- a warning is logged
- only the _first_ definition for the tag is used for rendering
- subsequent definitions for the tag are ignored

Fixes #2649 