### PR TITLE
sidebar: use the same resize grip as rustdoc and playground

### DIFF
--- a/src/front-end/css/chrome.css
+++ b/src/front-end/css/chrome.css
@@ -474,9 +474,24 @@ html:not(.sidebar-resizing) .sidebar {
 
 .sidebar-resize-handle .sidebar-resize-indicator {
     width: 100%;
-    height: 12px;
-    background-color: var(--icons);
+    height: 16px;
+    color: var(--icons);
     margin-inline-start: var(--sidebar-resize-indicator-space);
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+.sidebar-resize-handle .sidebar-resize-indicator::before {
+    content: "";
+    width: 2px;
+    height: 12px;
+    border-left: dotted 2px currentColor;
+}
+.sidebar-resize-handle .sidebar-resize-indicator::after {
+    content: "";
+    width: 2px;
+    height: 16px;
+    border-left: dotted 2px currentColor;
 }
 
 [dir=rtl] .sidebar .sidebar-resize-handle {


### PR DESCRIPTION
Follow up #2209 and https://github.com/rust-lang/rust/pull/139562

Since rustdoc and the playground both use similar resizing indicators, it only makes sense that mdbook should, too.

Before:

![image](https://github.com/user-attachments/assets/0c2cbedf-9145-41e7-a1b0-d43186b4b16d)

After:

![image](https://github.com/user-attachments/assets/a946dcaa-7fe0-44c2-9ca8-87e53da8cd9c)
