### PR TITLE
Improve ergonomics of search

### DIFF
--- a/guide/src/guide/reading.md
+++ b/guide/src/guide/reading.md
@@ -42,7 +42,7 @@ Tapping the menu bar will scroll the page to the top.
 ## Search
 
 Each book has a built-in search system.
-Pressing the search icon (<i class="fa fa-search"></i>) in the menu bar, or pressing the `S` key on the keyboard will open an input box for entering search terms.
+Pressing the search icon (<i class="fa fa-search"></i>) in the menu bar, or pressing the `/` or `S` key on the keyboard will open an input box for entering search terms.
 Typing some terms will show matching chapters and sections in real time.
 
 Clicking any of the results will jump to that section.

--- a/guide/src/guide/reading.md
+++ b/guide/src/guide/reading.md
@@ -42,14 +42,14 @@ Tapping the menu bar will scroll the page to the top.
 ## Search
 
 Each book has a built-in search system.
-Pressing the search icon (<i class="fa fa-search"></i>) in the menu bar, or pressing the `/` or `S` key on the keyboard will open an input box for entering search terms.
+Pressing the search icon (<i class="fa fa-search"></i>) in the menu bar, or pressing the <kbd>/</kbd> or <kbd>S</kbd> key on the keyboard will open an input box for entering search terms.
 Typing some terms will show matching chapters and sections in real time.
 
 Clicking any of the results will jump to that section.
 The up and down arrow keys can be used to navigate the results, and enter will open the highlighted section.
 
 After loading a search result, the matching search terms will be highlighted in the text.
-Clicking a highlighted word or pressing the `Esc` key will remove the highlighting.
+Clicking a highlighted word or pressing the <kbd>Escape</kbd> key will remove the highlighting.
 
 ## Code blocks
 

--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -367,12 +367,16 @@ window.search = window.search || {};
             showSearch(true);
             window.scrollTo(0, 0);
             searchbar.select();
-        } else if (hasFocus() && e.keyCode === DOWN_KEYCODE) {
+        } else if (hasFocus() && (e.keyCode === DOWN_KEYCODE
+                               || e.keyCode === SELECT_KEYCODE)) {
             e.preventDefault();
             const first = searchresults.firstElementChild;
             if (first !== null) {
                 unfocusSearchbar();
                 first.classList.add('focus');
+                if (e.keyCode === SELECT_KEYCODE) {
+                    window.location.assign(first.querySelector('a'));
+                }
             }
         } else if (!hasFocus() && (e.keyCode === DOWN_KEYCODE
                                 || e.keyCode === UP_KEYCODE

--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -369,8 +369,11 @@ window.search = window.search || {};
             searchbar.select();
         } else if (hasFocus() && e.keyCode === DOWN_KEYCODE) {
             e.preventDefault();
-            unfocusSearchbar();
-            searchresults.firstElementChild.classList.add('focus');
+            const first = searchresults.firstElementChild;
+            if (first !== null) {
+                unfocusSearchbar();
+                first.classList.add('focus');
+            }
         } else if (!hasFocus() && (e.keyCode === DOWN_KEYCODE
                                 || e.keyCode === UP_KEYCODE
                                 || e.keyCode === SELECT_KEYCODE)) {

--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -35,7 +35,7 @@ window.search = window.search || {};
         URL_SEARCH_PARAM = 'search',
         URL_MARK_PARAM = 'highlight',
 
-        SEARCH_HOTKEY_KEYCODE = 83,
+        SEARCH_HOTKEY_KEYCODES = [83, 191], // `s` or `/`.
         ESCAPE_KEYCODE = 27,
         DOWN_KEYCODE = 40,
         UP_KEYCODE = 38,
@@ -362,7 +362,7 @@ window.search = window.search || {};
             }
             showSearch(false);
             marker.unmark();
-        } else if (!hasFocus() && e.keyCode === SEARCH_HOTKEY_KEYCODE) {
+        } else if (!hasFocus() && SEARCH_HOTKEY_KEYCODES.includes(e.keyCode)) {
             e.preventDefault();
             showSearch(true);
             window.scrollTo(0, 0);

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -142,7 +142,7 @@
                             <li role="none"><button role="menuitem" class="theme" id="ayu">Ayu</button></li>
                         </ul>
                         {{#if search_enabled}}
-                        <button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
+                        <button id="search-toggle" class="icon-button" type="button" title="Search (`/`)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="/ s" aria-controls="searchbar">
                             <i class="fa fa-search"></i>
                         </button>
                         {{/if}}


### PR DESCRIPTION
This PR improves the ergonomics of search by doing the following, and is best reviewed commit by commit:

- Allows for search by `/` as well as `s`.
- Fixes an uncaught exception when pressing `down` when there are no search results.
- Navigates automatically to the first search result when pressing `enter`.
- Uses `<kbd>` to render shortcut keys in the guide.

The commit messages contain more details and motivation.

Closes https://github.com/rust-lang/mdBook/issues/2379