### PR TITLE
Add rel=edit attribute to "Suggest an edit" link

### DIFF
--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -181,7 +181,7 @@
                         </a>
                         {{/if}}
                         {{#if git_repository_edit_url}}
-                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
+                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit" rel="edit">
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
                         {{/if}}

--- a/tests/testsuite/rendering.rs
+++ b/tests/testsuite/rendering.rs
@@ -8,7 +8,7 @@ fn edit_url_template() {
     BookTest::from_dir("rendering/edit_url_template").check_file_contains(
         "book/index.html",
         "<a href=\"https://github.com/rust-lang/mdBook/edit/master/guide/src/README.md\" \
-         title=\"Suggest an edit\" aria-label=\"Suggest an edit\">",
+         title=\"Suggest an edit\" aria-label=\"Suggest an edit\" rel=\"edit\">",
     );
 }
 
@@ -18,7 +18,7 @@ fn edit_url_template_explicit_src() {
     BookTest::from_dir("rendering/edit_url_template_explicit_src").check_file_contains(
         "book/index.html",
         "<a href=\"https://github.com/rust-lang/mdBook/edit/master/guide/src2/README.md\" \
-         title=\"Suggest an edit\" aria-label=\"Suggest an edit\">",
+         title=\"Suggest an edit\" aria-label=\"Suggest an edit\" rel=\"edit\">",
     );
 }
 


### PR DESCRIPTION
This PR adds the rel="edit" attribute to the "Suggest an edit" edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.
