### PR TITLE
Fix clippy lint for 1.88

### DIFF
--- a/examples/remove-emphasis/mdbook-remove-emphasis/src/main.rs
+++ b/examples/remove-emphasis/mdbook-remove-emphasis/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     }
 
     if let Err(e) = handle_preprocessing() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
This fixes the clippy::uninlined_format_args lint which looks like it was moved to "style" in https://github.com/rust-lang/rust-clippy/pull/14160.