### PR TITLE
Fix loading of mode-rust.js

### DIFF
--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -297,8 +297,8 @@
 
         {{#if playground_js}}
         <script src="{{ resource "ace.js" }}"></script>
-        <script src="{{ resource "editor.js" }}"></script>
         <script src="{{ resource "mode-rust.js" }}"></script>
+        <script src="{{ resource "editor.js" }}"></script>
         <script src="{{ resource "theme-dawn.js" }}"></script>
         <script src="{{ resource "theme-tomorrow_night.js" }}"></script>
         {{/if}}

--- a/tests/gui/move-between-pages.goml
+++ b/tests/gui/move-between-pages.goml
@@ -1,8 +1,5 @@
 // This tests pressing the left and right arrows moving to previous and next page.
 
-// We disable the requests checks because `mode-rust.js` is not found.
-fail-on-request-error: false
-
 go-to: |DOC_PATH| + "index.html"
 
 // default page is the first numbered page


### PR DESCRIPTION
The reason the ACE editor was failing to load the rust syntax highlighting is because the syntax highlighting was being created *after* the editor was created. If the editor is created first, then ACE tries to load `ace/mode/rust`. Since it isn't already defined, it tried to compute the URL and load it manually. However, since the URLs now have a hash in it (via https://github.com/rust-lang/mdBook/pull/1368), it was unable to load.

The solution here is to make sure `ace/mode/rust` is defined before creating the editors. Then ACE knows that it can just load the module directly instead of trying to fetch it from the server.

Fixes https://github.com/rust-lang/mdBook/issues/2700