### PR TITLE
Show where the book was generated

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -16,7 +16,7 @@ use std::sync::LazyLock;
 
 use crate::utils::fs::get_404_output_file;
 use handlebars::Handlebars;
-use log::{debug, trace, warn};
+use log::{debug, info, trace, warn};
 use regex::{Captures, Regex};
 use serde_json::json;
 
@@ -481,6 +481,8 @@ impl Renderer for HtmlHandlebars {
 
         // Copy all remaining files, avoid a recursive copy from/to the book build dir
         utils::fs::copy_files_except_ext(&src_dir, destination, true, Some(&build_dir), &["md"])?;
+
+        info!("Book has been generated into `{}`", build_dir.display());
 
         Ok(())
     }


### PR DESCRIPTION
It now looks like this:

```
$ cargo run -- build test_book/
   Compiling mdbook v0.4.51 (/somewhere/mdBook)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.48s
     Running `target/debug/mdbook build test_book/`
2025-06-12 21:33:28 [INFO] (mdbook::book): Book building has started
2025-06-12 21:33:28 [INFO] (mdbook::book): Running the html backend
2025-06-12 21:33:28 [INFO] (mdbook::renderer::html_handlebars::hbs_renderer): Book has been generated into `/somewhere/mdBook/test_book/book`
```

It's very convenient to see where the book is actually generated (even more when working on mdbook :laughing:).