### PR TITLE
Remove direct search index reference from searcher

### DIFF
--- a/src/front-end/searcher/searcher.js
+++ b/src/front-end/searcher/searcher.js
@@ -434,7 +434,7 @@ window.search = window.search || {};
 
     function showSearch(yes) {
         if (yes) {
-            loadSearchScript(path_to_root + '{{ resource "searchindex.js" }}', 'search-index');
+            loadSearchScript(window.path_to_searchindex_js, 'search-index');
             search_wrap.classList.remove('hidden');
             searchicon.setAttribute('aria-expanded', 'true');
         } else {

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -58,6 +58,9 @@
             const path_to_root = "{{ path_to_root }}";
             const default_light_theme = "{{ default_theme }}";
             const default_dark_theme = "{{ preferred_dark_theme }}";
+        {{#if search_js}}
+            window.path_to_searchindex_js = "{{ resource "searchindex.js" }}";
+        {{/if}}
         </script>
         <!-- Start loading toc.js asap -->
         <script src="{{ resource "toc.js" }}"></script>


### PR DESCRIPTION
Fixes #2741

Because `{{resource}}` references don't affect the hash[^1], we need to avoid referencing dynamic content from within static content. Otherwise, you get a cached searcher.js referencing a searchindex that no longer exists.

[^1]: if we made it affect the hash, we'd have to do full dependency
      tracking, and we'd no longer be able to support circular refs