### PR TITLE
Add support for fragment redirects

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -310,13 +310,21 @@ This is useful when you move, rename, or remove a page to ensure that links to t
 [output.html.redirect]
 "/appendices/bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
 "/other-installation-methods.html" = "../infra/other-installation-methods.html"
+
+# Fragment redirects also work.
+"/some-existing-page.html#old-fragment" = "some-existing-page.html#new-fragment"
+
+# Fragment redirects also work for deleted pages.
+"/old-page.html" = "new-page.html"
+"/old-page.html#old-fragment" = "new-page.html#new-fragment"
 ```
 
 The table contains key-value pairs where the key is where the redirect file needs to be created, as an absolute path from the build directory, (e.g. `/appendices/bibliography.html`).
 The value can be any valid URI the browser should navigate to (e.g. `https://rust-lang.org/`, `/overview.html`, or `../bibliography.html`).
 
 This will generate an HTML page which will automatically redirect to the given location.
-Note that the source location does not support `#` anchor redirects.
+
+When fragment redirects are specified, the page must use JavaScript to redirect to the correct location. This is useful if you rename or move a section header. Fragment redirects work with existing pages and deleted pages.
 
 ## Markdown Renderer
 

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -341,6 +341,21 @@
         {{/if}}
         {{/if}}
 
+        {{#if fragment_map}}
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const fragmentMap =
+                    {{{fragment_map}}}
+                ;
+                const target = fragmentMap[window.location.hash];
+                if (target) {
+                    let url = new URL(target, window.location.href);
+                    window.location.replace(url.href);
+                }
+            });
+        </script>
+        {{/if}}
+
     </div>
     </body>
 </html>

--- a/src/front-end/templates/redirect.hbs
+++ b/src/front-end/templates/redirect.hbs
@@ -8,5 +8,29 @@
   </head>
   <body>
       <p>Redirecting to... <a href="{{url}}">{{url}}</a>.</p>
+
+<script>
+    // This handles redirects that involve fragments.
+    document.addEventListener('DOMContentLoaded', function() {
+        const fragmentMap =
+            {{{fragment_map}}}
+        ;
+        const fragment = window.location.hash;
+        if (fragment) {
+            let redirectUrl = "{{url}}";
+            const target = fragmentMap[fragment];
+            if (target) {
+                let url = new URL(target, window.location.href);
+                redirectUrl = url.href;
+            } else {
+                let url = new URL(redirectUrl, window.location.href);
+                url.hash = window.location.hash;
+                redirectUrl = url.href;
+            }
+            window.location.replace(redirectUrl);
+        }
+        // else redirect handled by http-equiv
+    });
+</script>
   </body>
 </html>

--- a/test_book/book.toml
+++ b/test_book/book.toml
@@ -25,4 +25,27 @@ expand = true
 heading-split-level = 2
 
 [output.html.redirect]
-"/format/config.html" = "configuration/index.html"
+"/format/config.html" = "../prefix.html"
+
+# This is a source without a fragment, and one with a fragment that goes to
+# the same place. The redirect with the fragment is not necessary, since that
+# is the default behavior.
+"/pointless-fragment.html" = "prefix.html"
+"/pointless-fragment.html#foo" = "prefix.html#foo"
+
+"/rename-page-and-fragment.html" = "prefix.html"
+"/rename-page-and-fragment.html#orig" = "prefix.html#new"
+
+"/rename-page-fragment-elsewhere.html" = "prefix.html"
+"/rename-page-fragment-elsewhere.html#orig" = "suffix.html#new"
+
+# Rename fragment on an existing page.
+"/prefix.html#orig" = "prefix.html#new"
+# Rename fragment on an existing page to another page.
+"/prefix.html#orig-new-page" = "suffix.html#new"
+
+"/full-url-with-fragment.html" = "https://www.rust-lang.org/#fragment"
+
+"/full-url-with-fragment-map.html" = "https://www.rust-lang.org/"
+"/full-url-with-fragment-map.html#a" = "https://www.rust-lang.org/#new1"
+"/full-url-with-fragment-map.html#b" = "https://www.rust-lang.org/#new2"

--- a/tests/gui/redirect.goml
+++ b/tests/gui/redirect.goml
@@ -1,0 +1,51 @@
+go-to: |DOC_PATH| + "format/config.html"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
+
+// Check that it preserves fragments when redirecting.
+go-to: |DOC_PATH| + "format/config.html#fragment"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html#fragment"})
+
+// The fragment one here isn't necessary, but should still work.
+go-to: |DOC_PATH| + "pointless-fragment.html"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
+go-to: |DOC_PATH| + "pointless-fragment.html#foo"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html#foo"})
+
+// Page rename, and a fragment rename.
+go-to: |DOC_PATH| + "rename-page-and-fragment.html"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
+go-to: |DOC_PATH| + "rename-page-and-fragment.html#orig"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html#new"})
+
+// Page rename, and the fragment goes to a *different* page from the default.
+go-to: |DOC_PATH| + "rename-page-fragment-elsewhere.html"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
+go-to: |DOC_PATH| + "rename-page-fragment-elsewhere.html#orig"
+assert-window-property: ({"location": |DOC_PATH| + "suffix.html#new"})
+
+// Goes to an external site.
+go-to: |DOC_PATH| + "full-url-with-fragment.html"
+assert-window-property: ({"location": "https://www.rust-lang.org/#fragment"})
+
+// External site with fragment renames.
+go-to: |DOC_PATH| + "full-url-with-fragment-map.html#a"
+assert-window-property: ({"location": "https://www.rust-lang.org/#new1"})
+go-to: |DOC_PATH| + "full-url-with-fragment-map.html#b"
+assert-window-property: ({"location": "https://www.rust-lang.org/#new2"})
+
+// Rename fragment on an existing page.
+go-to: |DOC_PATH| + "prefix.html#orig"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html#new"})
+
+// Other fragments aren't affected.
+go-to: |DOC_PATH| + "index.html" // Reset page since redirects are processed on load.
+go-to: |DOC_PATH| + "prefix.html"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
+go-to: |DOC_PATH| + "index.html" // Reset page since redirects are processed on load.
+go-to: |DOC_PATH| + "prefix.html#dont-change"
+assert-window-property: ({"location": |DOC_PATH| + "prefix.html#dont-change"})
+
+// Rename fragment on an existing page to another page.
+go-to: |DOC_PATH| + "index.html" // Reset page since redirects are processed on load.
+go-to: |DOC_PATH| + "prefix.html#orig-new-page"
+assert-window-property: ({"location": |DOC_PATH| + "suffix.html#new"})

--- a/tests/testsuite/redirects.rs
+++ b/tests/testsuite/redirects.rs
@@ -16,3 +16,34 @@ fn redirects_are_emitted_correctly() {
             file!["redirects/redirects_are_emitted_correctly/expected/nested/page.html"],
         );
 }
+
+// Invalid redirect with only fragments.
+#[test]
+fn redirect_removed_with_fragments_only() {
+    BookTest::from_dir("redirects/redirect_removed_with_fragments_only").run("build", |cmd| {
+        cmd.expect_failure().expect_stderr(str![[r#"
+[TIMESTAMP] [INFO] (mdbook::book): Book building has started
+[TIMESTAMP] [INFO] (mdbook::book): Running the html backend
+[TIMESTAMP] [ERROR] (mdbook::utils): Error: Rendering failed
+[TIMESTAMP] [ERROR] (mdbook::utils): [TAB]Caused By: Unable to emit redirects
+[TIMESTAMP] [ERROR] (mdbook::utils): [TAB]Caused By: redirect entry for `old-file.html` only has source paths with `#` fragments
+There must be an entry without the `#` fragment to determine the default destination.
+
+"#]]);
+    });
+}
+
+// Invalid redirect for an existing page.
+#[test]
+fn redirect_existing_page() {
+    BookTest::from_dir("redirects/redirect_existing_page").run("build", |cmd| {
+        cmd.expect_failure().expect_stderr(str![[r#"
+[TIMESTAMP] [INFO] (mdbook::book): Book building has started
+[TIMESTAMP] [INFO] (mdbook::book): Running the html backend
+[TIMESTAMP] [ERROR] (mdbook::utils): Error: Rendering failed
+[TIMESTAMP] [ERROR] (mdbook::utils): [TAB]Caused By: redirect found for existing chapter at `/chapter_1.html`
+Either delete the redirect or remove the chapter.
+
+"#]]);
+    });
+}

--- a/tests/testsuite/redirects/redirect_existing_page/book.toml
+++ b/tests/testsuite/redirects/redirect_existing_page/book.toml
@@ -1,0 +1,5 @@
+[book]
+title = "redirect_existing_page"
+
+[output.html.redirect]
+"/chapter_1.html" = "other-page.html"

--- a/tests/testsuite/redirects/redirect_existing_page/src/SUMMARY.md
+++ b/tests/testsuite/redirects/redirect_existing_page/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/tests/testsuite/redirects/redirect_existing_page/src/chapter_1.md
+++ b/tests/testsuite/redirects/redirect_existing_page/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/tests/testsuite/redirects/redirect_removed_with_fragments_only/book.toml
+++ b/tests/testsuite/redirects/redirect_removed_with_fragments_only/book.toml
@@ -1,0 +1,5 @@
+[book]
+title = "redirect_removed_with_fragments_only"
+
+[output.html.redirect]
+"/old-file.html#foo" = "chapter_1.html"

--- a/tests/testsuite/redirects/redirect_removed_with_fragments_only/src/SUMMARY.md
+++ b/tests/testsuite/redirects/redirect_removed_with_fragments_only/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/tests/testsuite/redirects/redirect_removed_with_fragments_only/src/chapter_1.md
+++ b/tests/testsuite/redirects/redirect_removed_with_fragments_only/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/tests/testsuite/redirects/redirects_are_emitted_correctly/book.toml
+++ b/tests/testsuite/redirects/redirects_are_emitted_correctly/book.toml
@@ -3,4 +3,5 @@ title = "redirects_are_emitted_correctly"
 
 [output.html.redirect]
 "/overview.html" = "index.html"
+"/overview.html#old" = "index.html#new"
 "/nested/page.html" = "https://rust-lang.org/"

--- a/tests/testsuite/redirects/redirects_are_emitted_correctly/expected/nested/page.html
+++ b/tests/testsuite/redirects/redirects_are_emitted_correctly/expected/nested/page.html
@@ -8,5 +8,29 @@
   </head>
   <body>
       <p>Redirecting to... <a href="https://rust-lang.org/">https://rust-lang.org/</a>.</p>
+
+<script>
+    // This handles redirects that involve fragments.
+    document.addEventListener('DOMContentLoaded', function() {
+        const fragmentMap =
+            {}
+        ;
+        const fragment = window.location.hash;
+        if (fragment) {
+            let redirectUrl = "https://rust-lang.org/";
+            const target = fragmentMap[fragment];
+            if (target) {
+                let url = new URL(target, window.location.href);
+                redirectUrl = url.href;
+            } else {
+                let url = new URL(redirectUrl, window.location.href);
+                url.hash = window.location.hash;
+                redirectUrl = url.href;
+            }
+            window.location.replace(redirectUrl);
+        }
+        // else redirect handled by http-equiv
+    });
+</script>
   </body>
 </html>

--- a/tests/testsuite/redirects/redirects_are_emitted_correctly/expected/overview.html
+++ b/tests/testsuite/redirects/redirects_are_emitted_correctly/expected/overview.html
@@ -8,5 +8,29 @@
   </head>
   <body>
       <p>Redirecting to... <a href="index.html">index.html</a>.</p>
+
+<script>
+    // This handles redirects that involve fragments.
+    document.addEventListener('DOMContentLoaded', function() {
+        const fragmentMap =
+            {"#old":"index.html#new"}
+        ;
+        const fragment = window.location.hash;
+        if (fragment) {
+            let redirectUrl = "index.html";
+            const target = fragmentMap[fragment];
+            if (target) {
+                let url = new URL(target, window.location.href);
+                redirectUrl = url.href;
+            } else {
+                let url = new URL(redirectUrl, window.location.href);
+                url.hash = window.location.hash;
+                redirectUrl = url.href;
+            }
+            window.location.replace(redirectUrl);
+        }
+        // else redirect handled by http-equiv
+    });
+</script>
   </body>
 </html>

--- a/tests/testsuite/redirects/redirects_are_emitted_correctly/src/SUMMARY.md
+++ b/tests/testsuite/redirects/redirects_are_emitted_correctly/src/SUMMARY.md
@@ -1,3 +1,4 @@
 # Redirects
 
 - [Chapter 1](chapter_1.md)
+- [Chapter 2](chapter_2.md)

--- a/tests/testsuite/redirects/redirects_are_emitted_correctly/src/chapter_2.md
+++ b/tests/testsuite/redirects/redirects_are_emitted_correctly/src/chapter_2.md
@@ -1,0 +1,1 @@
+# Chapter 2


### PR DESCRIPTION
This adds the ability to redirect URLs with `#` fragments. This is useful when section headers get renamed or moved to other pages.

This works both for deleted pages and existing pages.

The implementation requires the use of JavaScript in order to manipulate the location. (Ideally this would be handled on the server side.)

This also makes it so that deleted page redirects preserve the fragment ID. Previously if you had a deleted page redirect, and the user went to something like `page.html#foo`, it would redirect to `bar.html` without the fragment. I think preserving the fragment is probably a better behavior. If the new page doesn't have the fragment ID, then no harm is really done. This is technically an open redirect, but I don't think that there is too much danger with preserving a fragment ID?

Closes https://github.com/rust-lang/mdBook/issues/2256