### PR TITLE
Disable sidebar-resizing transition animation

### DIFF
--- a/src/front-end/css/general.css
+++ b/src/front-end/css/general.css
@@ -86,13 +86,6 @@ h6:target::before {
     box-sizing: border-box;
     background-color: var(--bg);
 }
-.no-js .page-wrapper,
-.js:not(.sidebar-resizing) .page-wrapper {
-    transition: margin-left 0.3s ease, transform 0.3s ease; /* Animation: slide away */
-}
-[dir=rtl] .js:not(.sidebar-resizing) .page-wrapper {
-    transition: margin-right 0.3s ease, transform 0.3s ease; /* Animation: slide away */
-}
 
 .content {
     overflow-y: auto;


### PR DESCRIPTION
This animation causes visual bugs (#2697) and makes the whole resize process appear less smooth (compared to not having this animation at all).

### Before this MR (with animation):

https://github.com/user-attachments/assets/25f24654-f4e4-4e28-aa29-c24174edfdd0

### After this MR (without animation):

https://github.com/user-attachments/assets/18814161-5124-4faf-8d97-ea693f4dfa4e