### PR TITLE
feat: Allow selective running of backends/renderers.

### DIFF
--- a/examples/remove-emphasis/test.rs
+++ b/examples/remove-emphasis/test.rs
@@ -1,11 +1,12 @@
 #[test]
 fn remove_emphasis_works() {
     // Tests that the remove-emphasis example works as expected.
+    use mdbook::book::ActiveBackends;
 
     // Workaround for https://github.com/rust-lang/mdBook/issues/1424
     std::env::set_current_dir("examples/remove-emphasis").unwrap();
     let book = mdbook::MDBook::load(".").unwrap();
-    book.build().unwrap();
+    book.render(&ActiveBackends::AllAvailable).unwrap();
     let ch1 = std::fs::read_to_string("book/chapter_1.html").unwrap();
     assert!(ch1.contains("This has light emphasis and bold emphasis."));
 }

--- a/guide/src/cli/build.md
+++ b/guide/src/cli/build.md
@@ -34,6 +34,14 @@ book. Relative paths are interpreted relative to the book's root directory. If
 not specified it will default to the value of the `build.build-dir` key in
 `book.toml`, or to `./book`.
 
+#### `--backend`
+
+By default, all backends configured in the `book.toml` config file will be executed.
+If this flag is given, only the specified backend will be run. This flag 
+may be given multiple times to run multiple backends. Providing a name of
+a backend that is not configured results in an error. For more information
+about backends, see [here](./format/configuration/renderers.md).
+
 -------------------
 
 ***Note:*** *The build command copies all files (excluding files with `.md` extension) from the source directory

--- a/guide/src/cli/serve.md
+++ b/guide/src/cli/serve.md
@@ -56,3 +56,11 @@ ignoring temporary files created by some editors.
 
 ***Note:*** *Only the `.gitignore` from the book root directory is used. Global
 `$HOME/.gitignore` or `.gitignore` files in parent directories are not used.*
+
+#### `--backend`
+
+By default, all backends configured in the `book.toml` config file will be executed.
+If this flag is given, only the specified backend will be run. This flag 
+may be given multiple times to run multiple backends. Providing a name of
+a backend that is not configured results in an error. For more information
+about backends, see [here](./format/configuration/renderers.md).

--- a/guide/src/cli/watch.md
+++ b/guide/src/cli/watch.md
@@ -39,3 +39,11 @@ ignoring temporary files created by some editors.
 
 _Note: Only `.gitignore` from book root directory is used. Global
 `$HOME/.gitignore` or `.gitignore` files in parent directories are not used._
+
+#### `--backend`
+
+By default, all backends configured in the `book.toml` config file will be executed.
+If this flag is given, only the specified backend will be run. This flag 
+may be given multiple times to run multiple backends. Providing a name of
+a backend that is not configured results in an error. For more information
+about backends, see [here](./format/configuration/renderers.md).

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,5 +1,5 @@
 use super::command_prelude::*;
-use crate::{get_book_dir, open};
+use crate::{get_backends, get_book_dir, open};
 use mdbook::errors::Result;
 use mdbook::MDBook;
 use std::path::PathBuf;
@@ -10,6 +10,7 @@ pub fn make_subcommand() -> Command {
         .about("Builds a book from its markdown files")
         .arg_dest_dir()
         .arg_root_dir()
+        .arg_backends()
         .arg_open()
 }
 
@@ -22,7 +23,8 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         book.config.build.build_dir = dest_dir.into();
     }
 
-    book.build()?;
+    let active_backends = get_backends(args);
+    book.render(&active_backends)?;
 
     if args.get_flag("open") {
         // FIXME: What's the right behaviour if we don't use the HTML renderer?

--- a/src/cmd/command_prelude.rs
+++ b/src/cmd/command_prelude.rs
@@ -37,6 +37,22 @@ pub trait CommandExt: Sized {
         self._arg(arg!(-o --open "Opens the compiled book in a web browser"))
     }
 
+    fn arg_backends(self) -> Self {
+        self._arg(
+            Arg::new("backend")
+                .short('b')
+                .long("backend")
+                .value_name("backend")
+                .action(clap::ArgAction::Append)
+                .value_parser(clap::value_parser!(String))
+                .help(
+                    "Backend to use.\n\
+                    This option may be given multiple times to run multiple backends.\n\
+                    If omitted, mdBook uses all configured backends.",
+                ),
+        )
+    }
+
     #[cfg(any(feature = "watch", feature = "serve"))]
     fn arg_watcher(self) -> Self {
         #[cfg(feature = "watch")]

--- a/src/cmd/watch/native.rs
+++ b/src/cmd/watch/native.rs
@@ -1,6 +1,7 @@
 //! A filesystem watcher using native operating system facilities.
 
 use ignore::gitignore::Gitignore;
+use mdbook::book::ActiveBackends;
 use mdbook::MDBook;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
@@ -10,6 +11,7 @@ use std::time::Duration;
 pub fn rebuild_on_change(
     book_dir: &Path,
     update_config: &dyn Fn(&mut MDBook),
+    backends: &ActiveBackends,
     post_build: &dyn Fn(),
 ) {
     use notify::RecursiveMode::*;
@@ -90,7 +92,7 @@ pub fn rebuild_on_change(
             match MDBook::load(book_dir) {
                 Ok(mut b) => {
                     update_config(&mut b);
-                    if let Err(e) = b.build() {
+                    if let Err(e) = b.render(backends) {
                         error!("failed to build the book: {e:?}");
                     } else {
                         post_build();

--- a/src/cmd/watch/poller.rs
+++ b/src/cmd/watch/poller.rs
@@ -5,6 +5,7 @@
 //! had problems correctly reporting changes.
 
 use ignore::gitignore::Gitignore;
+use mdbook::book::ActiveBackends;
 use mdbook::MDBook;
 use pathdiff::diff_paths;
 use std::collections::HashMap;
@@ -17,6 +18,7 @@ use walkdir::WalkDir;
 pub fn rebuild_on_change(
     book_dir: &Path,
     update_config: &dyn Fn(&mut MDBook),
+    backends: &ActiveBackends,
     post_build: &dyn Fn(),
 ) {
     let mut book = MDBook::load(book_dir).unwrap_or_else(|e| {
@@ -60,7 +62,7 @@ pub fn rebuild_on_change(
             match MDBook::load(book_dir) {
                 Ok(mut b) => {
                     update_config(&mut b);
-                    if let Err(e) = b.build() {
+                    if let Err(e) = b.render(backends) {
                         error!("failed to build the book: {e:?}");
                     } else {
                         post_build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! let mut md = MDBook::load(root_dir)
 //!     .expect("Unable to load the book");
-//! md.build().expect("Building failed");
+//! md.render_all().expect("Building failed");
 //! ```
 //!
 //! ## Implementing a new Backend

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use clap::{Arg, ArgMatches, Command};
 use clap_complete::Shell;
 use env_logger::Builder;
 use log::LevelFilter;
+use mdbook::book::ActiveBackends;
 use mdbook::utils;
 use std::env;
 use std::ffi::OsStr;
@@ -130,6 +131,14 @@ fn get_book_dir(args: &ArgMatches) -> PathBuf {
         }
     } else {
         env::current_dir().expect("Unable to determine the current directory")
+    }
+}
+
+fn get_backends(args: &ArgMatches) -> ActiveBackends {
+    if let Some(backends_iter) = args.get_many("backend") {
+        ActiveBackends::Specific(backends_iter.cloned().collect())
+    } else {
+        ActiveBackends::AllAvailable
     }
 }
 

--- a/tests/testsuite/book_test.rs
+++ b/tests/testsuite/book_test.rs
@@ -206,7 +206,7 @@ impl BookTest {
     /// Builds the book in the temp directory.
     pub fn build(&mut self) -> &mut Self {
         let book = self.load_book();
-        book.build()
+        book.render_all()
             .unwrap_or_else(|e| panic!("book failed to build: {e:?}"));
         self.built = true;
         self

--- a/tests/testsuite/preprocessor.rs
+++ b/tests/testsuite/preprocessor.rs
@@ -34,7 +34,7 @@ fn runs_preprocessors() {
     let spy: Arc<Mutex<Inner>> = Default::default();
     let mut book = test.load_book();
     book.with_preprocessor(Spy(Arc::clone(&spy)));
-    book.build().unwrap();
+    book.render_all().unwrap();
 
     let inner = spy.lock().unwrap();
     assert_eq!(inner.run_count, 1);

--- a/tests/testsuite/renderer.rs
+++ b/tests/testsuite/renderer.rs
@@ -33,7 +33,7 @@ fn runs_renderers() {
     let spy: Arc<Mutex<Inner>> = Default::default();
     let mut book = test.load_book();
     book.with_renderer(Spy(Arc::clone(&spy)));
-    book.build().unwrap();
+    book.render_all().unwrap();
 
     let inner = spy.lock().unwrap();
     assert_eq!(inner.run_count, 1);

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -124,7 +124,7 @@ fn with_no_source_path() {
         parent_names: Vec::new(),
     };
     book.book.sections.push(BookItem::Chapter(chapter));
-    book.build().unwrap();
+    book.render_all().unwrap();
 }
 
 // Checks that invalid settings in search chapter is rejected.


### PR DESCRIPTION
Adds an optional `--backend`/`-b` flag to `build`, `serve`, and `watch`, which, when given, causes only the specified back-ends to run, as supposed to all configured back ends. This flag may be given multiple times.

This is a fully backwards-compatible change: The default behavior of all the commands listed above is not changed.

Requested here:

https://github.com/rust-lang/mdBook/issues/2648

This is useful for backends such as `linkcheck`, allowing them to be temporarily disabled while developing documentation.

First-time contributor. Let me know if you want things changed or done differently :)

Cheers!