### PR TITLE
Add `build.static-files-dir` config option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -496,6 +496,8 @@ pub struct BuildConfig {
     pub use_default_preprocessors: bool,
     /// Extra directories to trigger rebuild when watching/serving
     pub extra_watch_dirs: Vec<PathBuf>,
+    /// Directory where to store static files.
+    pub static_files_dir: Option<PathBuf>,
 }
 
 impl Default for BuildConfig {
@@ -505,6 +507,7 @@ impl Default for BuildConfig {
             create_missing: true,
             use_default_preprocessors: true,
             extra_watch_dirs: Vec::new(),
+            static_files_dir: None,
         }
     }
 }
@@ -872,6 +875,7 @@ mod tests {
             create_missing: false,
             use_default_preprocessors: true,
             extra_watch_dirs: Vec::new(),
+            static_files_dir: None,
         };
         let rust_should_be = RustConfig { edition: None };
         let playground_should_be = Playground {
@@ -1083,6 +1087,7 @@ mod tests {
             create_missing: true,
             use_default_preprocessors: true,
             extra_watch_dirs: Vec::new(),
+            static_files_dir: None,
         };
 
         let html_should_be = HtmlConfig {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -415,12 +415,16 @@ impl Renderer for HtmlHandlebars {
         }
 
         if html_config.hash_files {
-            static_files.hash_files()?;
+            static_files.hash_files(ctx.config.build.static_files_dir.as_deref())?;
         }
 
         debug!("Copy static files");
+        if let Some(ref path) = ctx.config.build.static_files_dir {
+            fs::create_dir_all(path)
+                .with_context(|| "Unexpected error when constructing static files directory")?;
+        }
         let resource_helper = static_files
-            .write_files(&destination)
+            .write_files(destination)
             .with_context(|| "Unable to copy across static files")?;
 
         handlebars.register_helper("resource", Box::new(resource_helper));


### PR DESCRIPTION
This PR adds support for a new `build.static-files-dir` config option. It only targets static files, not custom ones. The goal is, when rustdoc officially supports to generate mdbook alongside the API docs, to make this integration easier for docs.rs:
1. To prevent static files duplication.
2. To prevent needing to rewrite URLs like we do with rustdoc files.

I tested this feature locally with:

```diff
diff --git a/test_book/book.toml b/test_book/book.toml
index 854b5e7d3..ad5b183af 100644
--- a/test_book/book.toml
+++ b/test_book/book.toml
@@ -7,6 +7,9 @@ language = "en"
 [rust]
 edition = "2018"
 
+[build]
+static-files-dir = "/tmp/static"
+
 [output.html]
 mathjax-support = true
 hash-files = true
```

It's working as expected, files were generated in `/tmp/static` and URLs were pointing to this folder.

Now, some questions: what would be the best way to test it in a unit test?

And finally: @syphar, would it be ok for docs.rs (speaking hypothetically for something that hopefully will be supported by rustdoc in the future) to use this new static folder option to generate static files directly in a `/-/mdbook` folder (since we use docker, I suppose we can cheat by creating a `/-` folder in any case)? Like that the URLs are already all valid so no need to update them when serving the book files and files are hashed.