### PR TITLE
Remove clippy needless-lifetimes workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [".", "examples/remove-emphasis/mdbook-remove-emphasis"]
 all = { level = "allow", priority = -2 }
 correctness = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }
-needless-lifetimes = "allow"  # Remove once 1.87 is stable, https://github.com/rust-lang/rust-clippy/issues/13514
 
 [package]
 name = "mdbook"


### PR DESCRIPTION
This is no longer needed now that 1.87 has reached the stable channel.