### PR TITLE
add the help (?) button to the menu

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -301,6 +301,18 @@ The [`output.html.search.chapter`] table provides the ability to modify search s
 
 - **enable:** Enables or disables search indexing for the given chapters. Defaults to `true`. This does not override the overall `output.html.search.enable` setting; that must be `true` for any search functionality to be enabled. Be cautious when disabling indexing for chapters because that can potentially lead to user confusion when they search for terms and expect them to be found. This should only be used in exceptional circumstances where keeping the chapter in the index will cause issues with the quality of the search results.
 
+### `[output.html.help]`
+
+The `[output.html.help]` table provides a way to configre the help menu.
+
+It currently has one field to disable the `?` icon on the menu by including the following:
+
+```toml
+[output.html.help]
+show-icon = false
+```
+
+
 ### `[output.html.redirect]`
 
 The `[output.html.redirect]` table provides a way to add redirects.

--- a/src/config.rs
+++ b/src/config.rs
@@ -569,6 +569,8 @@ pub struct HtmlConfig {
     pub code: Code,
     /// Print settings.
     pub print: Print,
+    /// Help settings.
+    pub help: Help,
     /// Don't render section labels.
     pub no_section_label: bool,
     /// Search settings. If `None`, the default will be used.
@@ -625,6 +627,7 @@ impl Default for HtmlConfig {
             playground: Playground::default(),
             code: Code::default(),
             print: Print::default(),
+            help: Help::default(),
             no_section_label: false,
             search: None,
             git_repository_url: None,
@@ -653,6 +656,21 @@ impl HtmlConfig {
     /// Returns `true` if smart punctuation is enabled.
     pub fn smart_punctuation(&self) -> bool {
         self.smart_punctuation || self.curly_quotes
+    }
+}
+/// Configuration for how to handle help
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct Help {
+    /// Whether help icon should be displayed.
+    pub show_icon: bool,
+}
+
+impl Default for Help {
+    fn default() -> Self {
+        Self {
+            show_icon: true,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -668,9 +668,7 @@ pub struct Help {
 
 impl Default for Help {
     fn default() -> Self {
-        Self {
-            show_icon: true,
-        }
+        Self { show_icon: true }
     }
 }
 

--- a/src/front-end/js/book.js
+++ b/src/front-end/js/book.js
@@ -643,6 +643,50 @@ aria-label="Show hidden lines"></button>';
 })();
 
 (function chapterNavigation() {
+    function showHelp() {
+        const container = document.getElementById('mdbook-help-container');
+        const overlay = document.getElementById('mdbook-help-popup');
+        container.style.display = 'flex';
+
+        // Clicking outside the popup will dismiss it.
+        const mouseHandler = event => {
+            if (overlay.contains(event.target)) {
+                return;
+            }
+            if (event.button !== 0) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            document.removeEventListener('mousedown', mouseHandler);
+            hideHelp();
+        };
+
+        // Pressing esc will dismiss the popup.
+        const escapeKeyHandler = event => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                event.stopPropagation();
+                document.removeEventListener('keydown', escapeKeyHandler, true);
+                hideHelp();
+            }
+        };
+        document.addEventListener('keydown', escapeKeyHandler, true);
+        document.getElementById('mdbook-help-container')
+            .addEventListener('mousedown', mouseHandler);
+    }
+    function hideHelp() {
+        document.getElementById('mdbook-help-container').style.display = 'none';
+    }
+
+
+    const helpicon = document.getElementById('show-help');
+    if (helpicon) {
+        helpicon.addEventListener('click', () => {
+            showHelp();
+        }, false);
+    }
+
     document.addEventListener('keydown', function(e) {
         if (e.altKey || e.ctrlKey || e.metaKey) {
             return;
@@ -663,41 +707,6 @@ aria-label="Show hidden lines"></button>';
             if (previousButton) {
                 window.location.href = previousButton.href;
             }
-        }
-        function showHelp() {
-            const container = document.getElementById('mdbook-help-container');
-            const overlay = document.getElementById('mdbook-help-popup');
-            container.style.display = 'flex';
-
-            // Clicking outside the popup will dismiss it.
-            const mouseHandler = event => {
-                if (overlay.contains(event.target)) {
-                    return;
-                }
-                if (event.button !== 0) {
-                    return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                document.removeEventListener('mousedown', mouseHandler);
-                hideHelp();
-            };
-
-            // Pressing esc will dismiss the popup.
-            const escapeKeyHandler = event => {
-                if (event.key === 'Escape') {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    document.removeEventListener('keydown', escapeKeyHandler, true);
-                    hideHelp();
-                }
-            };
-            document.addEventListener('keydown', escapeKeyHandler, true);
-            document.getElementById('mdbook-help-container')
-                .addEventListener('mousedown', mouseHandler);
-        }
-        function hideHelp() {
-            document.getElementById('mdbook-help-container').style.display = 'none';
         }
 
         // Usually needs the Shift key to be pressed

--- a/src/front-end/templates/index.hbs
+++ b/src/front-end/templates/index.hbs
@@ -165,6 +165,11 @@
                             <i class="fa fa-search"></i>
                         </button>
                         {{/if}}
+                        {{#if help_show_icon}}
+                        <button id="show-help" class="icon-button" type="button" title="Help. (Shortkey: ?)" aria-label="Show Help popup" aria-expanded="false" aria-keyshortcuts="?" aria-controls="helpbutton">
+                            <i class="fa fa-question"></i>
+                        </button>
+                        {{/if}}
                     </div>
 
                     <h1 class="menu-title">{{ book_title }}</h1>

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -608,6 +608,7 @@ fn make_data(
     data.insert("print_enable".to_owned(), json!(html_config.print.enable));
     data.insert("fold_enable".to_owned(), json!(html_config.fold.enable));
     data.insert("fold_level".to_owned(), json!(html_config.fold.level));
+    data.insert("help_show_icon".to_owned(), json!(html_config.help.show_icon));
 
     let search = html_config.search.clone();
     if cfg!(feature = "search") {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -608,7 +608,10 @@ fn make_data(
     data.insert("print_enable".to_owned(), json!(html_config.print.enable));
     data.insert("fold_enable".to_owned(), json!(html_config.fold.enable));
     data.insert("fold_level".to_owned(), json!(html_config.fold.level));
-    data.insert("help_show_icon".to_owned(), json!(html_config.help.show_icon));
+    data.insert(
+        "help_show_icon".to_owned(),
+        json!(html_config.help.show_icon),
+    );
 
     let search = html_config.search.clone();
     if cfg!(feature = "search") {


### PR DESCRIPTION
Make it easier for the first-time reader to find the available keyboard shortcuts.

* connect to the help popup trigger code
* add the configuration option to show the help icon
* only set the event listener if the icon is there