### PR TITLE
Enable unreachable_pub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ complexity = { level = "warn", priority = -1 }
 [workspace.lints.rust]
 missing_docs = "warn"
 rust_2018_idioms = "warn"
+unreachable_pub = "warn"
 
 [workspace.package]
 edition = "2024"

--- a/crates/mdbook-driver/src/load.rs
+++ b/crates/mdbook-driver/src/load.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 /// Load a book into memory from its `src/` directory.
-pub fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> {
+pub(crate) fn load_book<P: AsRef<Path>>(src_dir: P, cfg: &BuildConfig) -> Result<Book> {
     let src_dir = src_dir.as_ref();
     let summary_md = src_dir.join("SUMMARY.md");
 

--- a/crates/mdbook-html/src/html_handlebars/helpers/mod.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/mod.rs
@@ -1,4 +1,4 @@
-pub mod navigation;
-pub mod resources;
-pub mod theme;
-pub mod toc;
+pub(crate) mod navigation;
+pub(crate) mod resources;
+pub(crate) mod theme;
+pub(crate) mod toc;

--- a/crates/mdbook-html/src/html_handlebars/helpers/navigation.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/navigation.rs
@@ -169,7 +169,7 @@ fn render(
     t.render(r, &local_ctx, &mut local_rc, out)
 }
 
-pub fn previous(
+pub(crate) fn previous(
     _h: &Helper<'_>,
     r: &Handlebars<'_>,
     ctx: &Context,
@@ -185,7 +185,7 @@ pub fn previous(
     Ok(())
 }
 
-pub fn next(
+pub(crate) fn next(
     _h: &Helper<'_>,
     r: &Handlebars<'_>,
     ctx: &Context,

--- a/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
@@ -8,7 +8,7 @@ use handlebars::{
 
 // Handlebars helper to find filenames with hashes in them
 #[derive(Clone)]
-pub struct ResourceHelper {
+pub(crate) struct ResourceHelper {
     pub hash_map: HashMap<String, String>,
 }
 

--- a/crates/mdbook-html/src/html_handlebars/helpers/theme.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/theme.rs
@@ -3,7 +3,7 @@ use handlebars::{
 };
 use log::trace;
 
-pub fn theme_option(
+pub(crate) fn theme_option(
     h: &Helper<'_>,
     _r: &Handlebars<'_>,
     ctx: &Context,

--- a/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
@@ -8,7 +8,7 @@ use mdbook_markdown::special_escape;
 
 // Handlebars helper to construct TOC
 #[derive(Clone, Copy)]
-pub struct RenderToc {
+pub(crate) struct RenderToc {
     pub no_section_label: bool,
 }
 

--- a/crates/mdbook-html/src/html_handlebars/search.rs
+++ b/crates/mdbook-html/src/html_handlebars/search.rs
@@ -26,7 +26,7 @@ fn tokenize(text: &str) -> Vec<String> {
 }
 
 /// Creates all files required for search.
-pub fn create_files(
+pub(super) fn create_files(
     search_config: &Search,
     static_files: &mut StaticFiles,
     book: &Book,

--- a/crates/mdbook-html/src/html_handlebars/static_files.rs
+++ b/crates/mdbook-html/src/html_handlebars/static_files.rs
@@ -20,7 +20,7 @@ use std::sync::LazyLock;
 /// and interprets the `{{ resource }}` directives to allow assets to name each other.
 ///
 /// [fingerprinting]: https://guides.rubyonrails.org/asset_pipeline.html#fingerprinting-versioning-with-digest-based-urls
-pub struct StaticFiles {
+pub(super) struct StaticFiles {
     static_files: Vec<StaticFile>,
     hash_map: HashMap<String, String>,
 }
@@ -37,7 +37,7 @@ enum StaticFile {
 }
 
 impl StaticFiles {
-    pub fn new(theme: &Theme, html_config: &HtmlConfig, root: &Path) -> Result<StaticFiles> {
+    pub(super) fn new(theme: &Theme, html_config: &HtmlConfig, root: &Path) -> Result<StaticFiles> {
         let static_files = Vec::new();
         let mut this = StaticFiles {
             hash_map: HashMap::new(),
@@ -156,7 +156,7 @@ impl StaticFiles {
         Ok(this)
     }
 
-    pub fn add_builtin(&mut self, filename: &str, data: &[u8]) {
+    pub(super) fn add_builtin(&mut self, filename: &str, data: &[u8]) {
         self.static_files.push(StaticFile::Builtin {
             filename: filename.to_owned(),
             data: data.to_owned(),
@@ -165,7 +165,7 @@ impl StaticFiles {
 
     /// Updates this [`StaticFiles`] to hash the contents for determining the
     /// filename for each resource.
-    pub fn hash_files(&mut self) -> Result<()> {
+    pub(super) fn hash_files(&mut self) -> Result<()> {
         use sha2::{Digest, Sha256};
         use std::io::Read;
         for static_file in &mut self.static_files {
@@ -224,7 +224,7 @@ impl StaticFiles {
         Ok(())
     }
 
-    pub fn write_files(self, destination: &Path) -> Result<ResourceHelper> {
+    pub(super) fn write_files(self, destination: &Path) -> Result<ResourceHelper> {
         use mdbook_core::utils::fs::write_file;
         use regex::bytes::{Captures, Regex};
         // The `{{ resource "name" }}` directive in static resources look like

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -71,6 +71,7 @@ fn handle_supports(pre: &dyn Preprocessor, sub_args: &ArgMatches) -> ! {
 
 /// The actual implementation of the `Nop` preprocessor. This would usually go
 /// in your main `lib.rs` file.
+#[allow(unreachable_pub, reason = "wouldn't be a problem in a proper lib.rs")]
 mod nop_lib {
     use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 //! The mdbook CLI.
 
+#![allow(unreachable_pub, reason = "not needed in a bin crate")]
+
 #[macro_use]
 extern crate clap;
 #[macro_use]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -2,6 +2,8 @@
 //!
 //! See README.md for documentation.
 
+#![allow(unreachable_pub, reason = "not needed in an integration test crate")]
+
 mod book_test;
 mod build;
 mod cli;


### PR DESCRIPTION
This lint can help make it clearer which items are actually exposed in the public API.