### PR TITLE
Remove the book.multilingual field

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -395,11 +395,6 @@ pub struct BookConfig {
     pub description: Option<String>,
     /// Location of the book source relative to the book's root directory.
     pub src: PathBuf,
-    /// Does this book support more than one language?
-    // TODO: Remove this field in 0.5, it is unused:
-    // https://github.com/rust-lang/mdBook/issues/2636
-    #[serde(skip_serializing)]
-    pub multilingual: bool,
     /// The main language of the book.
     pub language: Option<String>,
     /// The direction of text in the book: Left-to-right (LTR) or Right-to-left (RTL).
@@ -414,7 +409,6 @@ impl Default for BookConfig {
             authors: Vec::new(),
             description: None,
             src: PathBuf::from("src"),
-            multilingual: false,
             language: Some(String::from("en")),
             text_direction: None,
         }
@@ -798,7 +792,6 @@ mod tests {
         title = "Some Book"
         authors = ["Michael-F-Bryan <michaelfbryan@gmail.com>"]
         description = "A completely useless book"
-        multilingual = true
         src = "source"
         language = "ja"
 
@@ -837,7 +830,6 @@ mod tests {
             title: Some(String::from("Some Book")),
             authors: vec![String::from("Michael-F-Bryan <michaelfbryan@gmail.com>")],
             description: Some(String::from("A completely useless book")),
-            multilingual: true,
             src: PathBuf::from("source"),
             language: Some(String::from("ja")),
             text_direction: None,

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -123,7 +123,6 @@ mod nop_lib {
                         "book": {
                             "authors": ["AUTHOR"],
                             "language": "en",
-                            "multilingual": false,
                             "src": "src",
                             "title": "TITLE"
                         },

--- a/tests/testsuite/includes/all_includes/book.toml
+++ b/tests/testsuite/includes/all_includes/book.toml
@@ -1,6 +1,2 @@
 [book]
-authors = ["Eric Huss"]
-language = "en"
-multilingual = false
-src = "src"
 title = "all_includes"


### PR DESCRIPTION
As it is seems it has never been in real use.

This is a repost of https://github.com/rust-lang/mdBook/pull/2646

Closes https://github.com/rust-lang/mdBook/issues/2636
