### PR TITLE
Don't rebuild books in tests

### DIFF
--- a/tests/testsuite/book_test.rs
+++ b/tests/testsuite/book_test.rs
@@ -230,6 +230,12 @@ impl BookTest {
         };
         f(&mut cmd);
         cmd.run();
+        // Ensure that `built` gets set if a build command is used so that all
+        // the `check` methods do not overwrite the contents of what was just
+        // built.
+        if cmd.args.first().map(String::as_str) == Some("build") {
+            self.built = true
+        }
         self
     }
 


### PR DESCRIPTION
This fixes an issue where the `check` methods would inadvertently rebuild the books if the `mdbook build` command is run. Normally this isn't too much of an issue unless the `build` command is run with options that affect the output.