### PR TITLE
Add read_to_string to the prelude

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -24,6 +24,6 @@ mod theme;
 mod toc;
 
 mod prelude {
-    pub use crate::book_test::BookTest;
+    pub use crate::book_test::{BookTest, read_to_string};
     pub use snapbox::str;
 }

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 fn read_book_index(root: &Path) -> serde_json::Value {
     let index = root.join("book/searchindex.js");
-    let index = std::fs::read_to_string(index).unwrap();
+    let index = read_to_string(index);
     let index =
         index.trim_start_matches("window.search = Object.assign(window.search, JSON.parse('");
     let index = index.trim_end_matches("'));");

--- a/tests/testsuite/toc.rs
+++ b/tests/testsuite/toc.rs
@@ -1,11 +1,9 @@
 //! Tests for table of contents (sidebar).
 
 use crate::prelude::*;
-use anyhow::Context;
 use anyhow::Result;
 use select::document::Document;
 use select::predicate::{Attr, Class, Name, Predicate};
-use std::fs;
 
 const TOC_TOP_LEVEL: &[&str] = &[
     "1. With Readme",
@@ -50,7 +48,7 @@ fn toc_fallback_html() -> Result<Document> {
     test.build();
 
     let toc_path = test.dir.join("book").join("toc.html");
-    let html = fs::read_to_string(toc_path).with_context(|| "Unable to read index.html")?;
+    let html = read_to_string(toc_path);
     Ok(Document::from(html.as_str()))
 }
 


### PR DESCRIPTION
This adds the `read_to_string` test helper to the test prelude so that it is easier to use.