### PR TITLE
Remove curly-quotes

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -424,8 +424,6 @@ pub struct HtmlConfig {
     pub preferred_dark_theme: Option<String>,
     /// Supports smart quotes, apostrophes, ellipsis, en-dash, and em-dash.
     pub smart_punctuation: bool,
-    /// Deprecated alias for `smart_punctuation`.
-    pub curly_quotes: bool,
     /// Should mathjax be enabled?
     pub mathjax_support: bool,
     /// Whether to fonts.css and respective font files to the output directory.
@@ -490,7 +488,6 @@ impl Default for HtmlConfig {
             default_theme: None,
             preferred_dark_theme: None,
             smart_punctuation: false,
-            curly_quotes: false,
             mathjax_support: false,
             copy_fonts: true,
             additional_css: Vec::new(),
@@ -522,11 +519,6 @@ impl HtmlConfig {
             Some(ref d) => root.join(d),
             None => root.join("theme"),
         }
-    }
-
-    /// Returns `true` if smart punctuation is enabled.
-    pub fn smart_punctuation(&self) -> bool {
-        self.smart_punctuation || self.curly_quotes
     }
 }
 
@@ -1116,38 +1108,5 @@ mod tests {
         let html_config = got.html_config().unwrap();
         assert!(html_config.print.enable);
         assert!(!html_config.print.page_break);
-    }
-
-    #[test]
-    fn curly_quotes_or_smart_punctuation() {
-        let src = r#"
-        [book]
-        title = "mdBook Documentation"
-
-        [output.html]
-        smart-punctuation = true
-        "#;
-        let config = Config::from_str(src).unwrap();
-        assert_eq!(config.html_config().unwrap().smart_punctuation(), true);
-
-        let src = r#"
-        [book]
-        title = "mdBook Documentation"
-
-        [output.html]
-        curly-quotes = true
-        "#;
-        let config = Config::from_str(src).unwrap();
-        assert_eq!(config.html_config().unwrap().smart_punctuation(), true);
-
-        let src = r#"
-        [book]
-        title = "mdBook Documentation"
-        "#;
-        let config = Config::from_str(src).unwrap();
-        assert_eq!(
-            config.html_config().unwrap_or_default().smart_punctuation(),
-            false
-        );
     }
 }

--- a/crates/mdbook-driver/src/mdbook.rs
+++ b/crates/mdbook-driver/src/mdbook.rs
@@ -63,16 +63,6 @@ impl MDBook {
 
         config.update_from_env();
 
-        if let Some(html_config) = config.html_config() {
-            if html_config.curly_quotes {
-                warn!(
-                    "The output.html.curly-quotes field has been renamed to \
-                     output.html.smart-punctuation.\n\
-                     Use the new name in book.toml to remove this warning."
-                );
-            }
-        }
-
         if log_enabled!(log::Level::Trace) {
             for line in format!("Config: {config:#?}").lines() {
                 trace!("{}", line);

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -57,10 +57,10 @@ impl HtmlHandlebars {
                 .insert("git_repository_edit_url".to_owned(), json!(edit_url));
         }
 
-        let content = render_markdown(&ch.content, ctx.html_config.smart_punctuation());
+        let content = render_markdown(&ch.content, ctx.html_config.smart_punctuation);
 
         let fixed_content =
-            render_markdown_with_path(&ch.content, ctx.html_config.smart_punctuation(), Some(path));
+            render_markdown_with_path(&ch.content, ctx.html_config.smart_punctuation, Some(path));
         if !ctx.is_index && ctx.html_config.print.page_break {
             // Add page break between chapters
             // See https://developer.mozilla.org/en-US/docs/Web/CSS/break-before and https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-before
@@ -175,7 +175,7 @@ impl HtmlHandlebars {
                     .to_string()
             }
         };
-        let html_content_404 = render_markdown(&content_404, html_config.smart_punctuation());
+        let html_content_404 = render_markdown(&content_404, html_config.smart_punctuation);
 
         let mut data_404 = data.clone();
         let base_url = if let Some(site_url) = &html_config.site_url {

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -125,7 +125,6 @@ The following configuration options are available:
 - **smart-punctuation:** Converts quotes to curly quotes, `...` to `…`, `--` to en-dash, and `---` to em-dash.
   See [Smart Punctuation](../markdown.md#smart-punctuation).
   Defaults to `false`.
-- **curly-quotes:** Deprecated alias for `smart-punctuation`.
 - **mathjax-support:** Adds support for [MathJax](../mathjax.md). Defaults to
   `false`.
 - **copy-fonts:** (**Deprecated**) If `true` (the default), mdBook uses its built-in fonts which are copied to the output directory.


### PR DESCRIPTION
This removes the deprecated alias `curly-quotes` for `smart-punctuation`.