### PR TITLE
Change CmdPreprocessor to use paths relative to the book root

### DIFF
--- a/crates/mdbook-driver/src/lib.rs
+++ b/crates/mdbook-driver/src/lib.rs
@@ -64,5 +64,34 @@ pub mod init;
 mod load;
 mod mdbook;
 
+use anyhow::{Result, bail};
 pub use mdbook::MDBook;
 pub use mdbook_core::{book, config, errors};
+use shlex::Shlex;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Creates a [`Command`] for command renderers and preprocessors.
+fn compose_command(cmd: &str, root: &Path) -> Result<Command> {
+    let mut words = Shlex::new(cmd);
+    let exe = match words.next() {
+        Some(e) => PathBuf::from(e),
+        None => bail!("Command string was empty"),
+    };
+
+    let exe = if exe.components().count() == 1 {
+        // Search PATH for the executable.
+        exe
+    } else {
+        // Relative path is relative to book root.
+        root.join(&exe)
+    };
+
+    let mut cmd = Command::new(exe);
+
+    for arg in words {
+        cmd.arg(arg);
+    }
+
+    Ok(cmd)
+}

--- a/crates/mdbook-driver/src/mdbook.rs
+++ b/crates/mdbook-driver/src/mdbook.rs
@@ -70,7 +70,7 @@ impl MDBook {
         let book = load_book(src_dir, &config.build)?;
 
         let renderers = determine_renderers(&config)?;
-        let preprocessors = determine_preprocessors(&config)?;
+        let preprocessors = determine_preprocessors(&config, &root)?;
 
         Ok(MDBook {
             root,
@@ -93,7 +93,7 @@ impl MDBook {
         let book = load_book_from_disk(&summary, src_dir)?;
 
         let renderers = determine_renderers(&config)?;
-        let preprocessors = determine_preprocessors(&config)?;
+        let preprocessors = determine_preprocessors(&config, &root)?;
 
         Ok(MDBook {
             root,
@@ -258,7 +258,7 @@ impl MDBook {
 
         // Index Preprocessor is disabled so that chapter paths
         // continue to point to the actual markdown files.
-        self.preprocessors = determine_preprocessors(&self.config)?
+        self.preprocessors = determine_preprocessors(&self.config, &self.root)?
             .into_iter()
             .filter(|pre| pre.name() != IndexPreprocessor::NAME)
             .collect();
@@ -440,7 +440,7 @@ struct PreprocessorConfig {
 }
 
 /// Look at the `MDBook` and try to figure out what preprocessors to run.
-fn determine_preprocessors(config: &Config) -> Result<Vec<Box<dyn Preprocessor>>> {
+fn determine_preprocessors(config: &Config, root: &Path) -> Result<Vec<Box<dyn Preprocessor>>> {
     // Collect the names of all preprocessors intended to be run, and the order
     // in which they should be run.
     let mut preprocessor_names = TopologicalSort::<String>::new();
@@ -513,7 +513,7 @@ fn determine_preprocessors(config: &Config) -> Result<Vec<Box<dyn Preprocessor>>
                         .command
                         .to_owned()
                         .unwrap_or_else(|| format!("mdbook-{name}"));
-                    Box::new(CmdPreprocessor::new(name, command))
+                    Box::new(CmdPreprocessor::new(name, command, root.to_owned()))
                 }
             };
             preprocessors.push(preprocessor);

--- a/crates/mdbook-driver/src/mdbook/tests.rs
+++ b/crates/mdbook-driver/src/mdbook/tests.rs
@@ -47,7 +47,7 @@ fn config_defaults_to_link_and_index_preprocessor_if_not_set() {
     // make sure we haven't got anything in the `preprocessor` table
     assert!(cfg.preprocessors::<toml::Value>().unwrap().is_empty());
 
-    let got = determine_preprocessors(&cfg);
+    let got = determine_preprocessors(&cfg, Path::new(""));
 
     assert!(got.is_ok());
     assert_eq!(got.as_ref().unwrap().len(), 2);
@@ -60,7 +60,7 @@ fn use_default_preprocessors_works() {
     let mut cfg = Config::default();
     cfg.build.use_default_preprocessors = false;
 
-    let got = determine_preprocessors(&cfg).unwrap();
+    let got = determine_preprocessors(&cfg, Path::new("")).unwrap();
 
     assert_eq!(got.len(), 0);
 }
@@ -83,7 +83,7 @@ fn can_determine_third_party_preprocessors() {
     // make sure the `preprocessor.random` table exists
     assert!(cfg.get::<Value>("preprocessor.random").unwrap().is_some());
 
-    let got = determine_preprocessors(&cfg).unwrap();
+    let got = determine_preprocessors(&cfg, Path::new("")).unwrap();
 
     assert!(got.into_iter().any(|p| p.name() == "random"));
 }
@@ -114,7 +114,7 @@ fn preprocessor_before_must_be_array() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    assert!(determine_preprocessors(&cfg).is_err());
+    assert!(determine_preprocessors(&cfg, Path::new("")).is_err());
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn preprocessor_after_must_be_array() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    assert!(determine_preprocessors(&cfg).is_err());
+    assert!(determine_preprocessors(&cfg, Path::new("")).is_err());
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn preprocessor_order_is_honored() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    let preprocessors = determine_preprocessors(&cfg).unwrap();
+    let preprocessors = determine_preprocessors(&cfg, Path::new("")).unwrap();
     let index = |name| {
         preprocessors
             .iter()
@@ -179,7 +179,7 @@ fn cyclic_dependencies_are_detected() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    assert!(determine_preprocessors(&cfg).is_err());
+    assert!(determine_preprocessors(&cfg, Path::new("")).is_err());
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn dependencies_dont_register_undefined_preprocessors() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    let preprocessors = determine_preprocessors(&cfg).unwrap();
+    let preprocessors = determine_preprocessors(&cfg, Path::new("")).unwrap();
 
     assert!(
         !preprocessors
@@ -212,7 +212,7 @@ fn dependencies_dont_register_builtin_preprocessors_if_disabled() {
 
     let cfg = Config::from_str(cfg_str).unwrap();
 
-    let preprocessors = determine_preprocessors(&cfg).unwrap();
+    let preprocessors = determine_preprocessors(&cfg, Path::new("")).unwrap();
 
     assert!(
         !preprocessors

--- a/tests/testsuite/preprocessor.rs
+++ b/tests/testsuite/preprocessor.rs
@@ -75,6 +75,7 @@ fn example() -> CmdPreprocessor {
     CmdPreprocessor::new(
         "nop-preprocessor".to_string(),
         "cargo run --quiet --example nop-preprocessor --".to_string(),
+        std::env::current_dir().unwrap(),
     )
 }
 
@@ -140,11 +141,11 @@ fn relative_command_path() {
             .expect_stdout(str![""])
             .expect_stderr(str![[r#"
 [TIMESTAMP] [INFO] (mdbook_driver::mdbook): Book building has started
-[TIMESTAMP] [WARN] (mdbook_driver::builtin_preprocessors::cmd): The command wasn't found, is the "my-preprocessor" preprocessor installed?
-[TIMESTAMP] [WARN] (mdbook_driver::builtin_preprocessors::cmd): [TAB]Command: preprocessors/my-preprocessor
 [TIMESTAMP] [INFO] (mdbook_driver::mdbook): Running the html backend
 [TIMESTAMP] [INFO] (mdbook_html::html_handlebars::hbs_renderer): HTML book written to `[ROOT]/src/../book`
 
 "#]]);
-    });
+    })
+    .check_file("support-check", "html")
+    .check_file("preprocessor-ran", "test");
 }


### PR DESCRIPTION
This changes preprocessors so that:

- Relative paths in the `command` value are relative to the book root.
- The process current directory is the book root.

This makes it so that it isn't dependent on the directory where `mdbook` is executed.

Fixes https://github.com/rust-lang/mdBook/issues/1424