### PR TITLE
Don't serialize the default for `book.src`

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -297,12 +297,18 @@ pub struct BookConfig {
     /// An optional description for the book.
     pub description: Option<String>,
     /// Location of the book source relative to the book's root directory.
+    #[serde(skip_serializing_if = "is_default_src")]
     pub src: PathBuf,
     /// The main language of the book.
     pub language: Option<String>,
     /// The direction of text in the book: Left-to-right (LTR) or Right-to-left (RTL).
     /// When not specified, the text direction is derived from [`BookConfig::language`].
     pub text_direction: Option<TextDirection>,
+}
+
+/// Helper for serde serialization.
+fn is_default_src(src: &PathBuf) -> bool {
+    src == Path::new("src")
 }
 
 impl Default for BookConfig {

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -28,7 +28,6 @@ All done, no errors...
         str![[r#"
 [book]
 authors = []
-src = "src"
 language = "en"
 
 "#]],
@@ -94,7 +93,6 @@ All done, no errors...
         str![[r#"
 [book]
 authors = []
-src = "src"
 language = "en"
 
 "#]],
@@ -128,7 +126,6 @@ All done, no errors...
 [book]
 title = "Example title"
 authors = []
-src = "src"
 language = "en"
 
 "#]],

--- a/tests/testsuite/renderer.rs
+++ b/tests/testsuite/renderer.rs
@@ -188,7 +188,6 @@ fn backends_receive_render_context_via_stdin() {
       "authors": [],
       "description": null,
       "language": "en",
-      "src": "src",
       "text-direction": null,
       "title": null
     },


### PR DESCRIPTION
This changes the serialization so that `book.src` is not serialized if it is the default. This removes the somewhat pointless `src = "src"` which shows up in the default `mdbook init` output. Deserialization should still default to `"src"`.