### PR TITLE
Remove external website tests

### DIFF
--- a/tests/gui/redirect.goml
+++ b/tests/gui/redirect.goml
@@ -23,16 +23,6 @@ assert-window-property: ({"location": |DOC_PATH| + "prefix.html"})
 go-to: |DOC_PATH| + "rename-page-fragment-elsewhere.html#orig"
 assert-window-property: ({"location": |DOC_PATH| + "suffix.html#new"})
 
-// Goes to an external site.
-go-to: |DOC_PATH| + "full-url-with-fragment.html"
-assert-window-property: ({"location": "https://www.rust-lang.org/#fragment"})
-
-// External site with fragment renames.
-go-to: |DOC_PATH| + "full-url-with-fragment-map.html#a"
-assert-window-property: ({"location": "https://www.rust-lang.org/#new1"})
-go-to: |DOC_PATH| + "full-url-with-fragment-map.html#b"
-assert-window-property: ({"location": "https://www.rust-lang.org/#new2"})
-
 // Rename fragment on an existing page.
 go-to: |DOC_PATH| + "prefix.html#orig"
 assert-window-property: ({"location": |DOC_PATH| + "prefix.html#new"})


### PR DESCRIPTION
These tests have been flaky, and in general it was probably unwise to try to rely on an external site like this. I was unable to determine exactly why the test is failing. The page loads, and then puppeteer throws an error.

I don't know if it is really feasible to bring these back in some form. It's probably more effort than it is worth.

Closes https://github.com/rust-lang/mdBook/issues/2765