### PR TITLE
Remove `test --dest-dir`

### DIFF
--- a/guide/src/cli/test.md
+++ b/guide/src/cli/test.md
@@ -54,13 +54,6 @@ mdbook test my-book -L target/debug/deps/
 See the `rustdoc` command-line [documentation](https://doc.rust-lang.org/rustdoc/command-line-arguments.html#-l--library-path-where-to-look-for-dependencies)
 for more information.
 
-#### `--dest-dir`
-
-The `--dest-dir` (`-d`) option allows you to change the output directory for the
-book. Relative paths are interpreted relative to the book's root directory. If
-not specified it will default to the value of the `build.build-dir` key in
-`book.toml`, or to `./book`.
-
 #### `--chapter`
 
 The `--chapter` (`-c`) option allows you to test a specific chapter of the

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -4,14 +4,11 @@ use anyhow::Result;
 use clap::ArgAction;
 use clap::builder::NonEmptyStringValueParser;
 use mdbook_driver::MDBook;
-use std::path::PathBuf;
 
 // Create clap subcommand arguments
 pub fn make_subcommand() -> Command {
     Command::new("test")
         .about("Tests that a book's Rust code samples compile")
-        // FIXME: --dest-dir is unused by the test command, it should be removed
-        .arg_dest_dir()
         .arg_root_dir()
         .arg(
             Arg::new("chapter")
@@ -46,9 +43,6 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let book_dir = get_book_dir(args);
     let mut book = MDBook::load(book_dir)?;
 
-    if let Some(dest_dir) = args.get_one::<PathBuf>("dest-dir") {
-        book.config.build.build_dir = dest_dir.to_path_buf();
-    }
     match chapter {
         Some(_) => book.test_chapter(library_paths, chapter),
         None => book.test(library_paths),


### PR DESCRIPTION
This removes the `--dest-dir` flag from the `mdbook test` subcommand because it is unused. The test command does not generate output, so it doesn't need an output directory.