### PR TITLE
Test and add a fix for multiple footnotes in a row

### DIFF
--- a/tests/testsuite/markdown/footnotes/expected/footnotes.html
+++ b/tests/testsuite/markdown/footnotes/expected/footnotes.html
@@ -7,6 +7,7 @@
 <p>Testing when referring to something earlier.<sup class="footnote-reference" id="fr-define-before-use-1"><a href="#footnote-define-before-use">6</a></sup></p>
 <p>Footnote that is defined multiple times.<sup class="footnote-reference" id="fr-multiple-definitions-1"><a href="#footnote-multiple-definitions">7</a></sup></p>
 <p>And another<sup class="footnote-reference" id="fr-in-between-1"><a href="#footnote-in-between">8</a></sup> that references the duplicate again.<sup class="footnote-reference" id="fr-multiple-definitions-2"><a href="#footnote-multiple-definitions">7</a></sup></p>
+<p>Multiple footnotes in a row.<sup class="footnote-reference" id="fr-a-1"><a href="#footnote-a">9</a></sup><sup class="footnote-reference" id="fr-b-1"><a href="#footnote-b">10</a></sup><sup class="footnote-reference" id="fr-c-1"><a href="#footnote-c">11</a></sup></p>
 <hr>
 <ol class="footnote-definition"><li id="footnote-1">
 <p>This is a footnote. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>
@@ -42,5 +43,14 @@ With a reference inside.<sup class="footnote-reference" id="fr-1-2"><a href="#fo
 </li>
 <li id="footnote-in-between">
 <p>Footnote between duplicates. <a href="#fr-in-between-1">↩</a></p>
+</li>
+<li id="footnote-a">
+<p>Footnote 1 <a href="#fr-a-1">↩</a></p>
+</li>
+<li id="footnote-b">
+<p>Footnote 2 <a href="#fr-b-1">↩</a></p>
+</li>
+<li id="footnote-c">
+<p>Footnote 3 <a href="#fr-c-1">↩</a></p>
 </li>
 </ol>

--- a/tests/testsuite/markdown/footnotes/expected/footnotes.html
+++ b/tests/testsuite/markdown/footnotes/expected/footnotes.html
@@ -7,7 +7,7 @@
 <p>Testing when referring to something earlier.<sup class="footnote-reference" id="fr-define-before-use-1"><a href="#footnote-define-before-use">6</a></sup></p>
 <p>Footnote that is defined multiple times.<sup class="footnote-reference" id="fr-multiple-definitions-1"><a href="#footnote-multiple-definitions">7</a></sup></p>
 <p>And another<sup class="footnote-reference" id="fr-in-between-1"><a href="#footnote-in-between">8</a></sup> that references the duplicate again.<sup class="footnote-reference" id="fr-multiple-definitions-2"><a href="#footnote-multiple-definitions">7</a></sup></p>
-<p>Multiple footnotes in a row.<sup class="footnote-reference" id="fr-a-1"><a href="#footnote-a">9</a></sup><sup class="footnote-reference" id="fr-b-1"><a href="#footnote-b">10</a></sup><sup class="footnote-reference" id="fr-c-1"><a href="#footnote-c">11</a></sup></p>
+<p>Multiple footnotes in a row.<sup class="footnote-reference" id="fr-a-1"><a href="#footnote-a">9</a></sup> <sup class="footnote-reference" id="fr-b-1"><a href="#footnote-b">10</a></sup> <sup class="footnote-reference" id="fr-c-1"><a href="#footnote-c">11</a></sup></p>
 <hr>
 <ol class="footnote-definition"><li id="footnote-1">
 <p>This is a footnote. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>

--- a/tests/testsuite/markdown/footnotes/src/footnotes.md
+++ b/tests/testsuite/markdown/footnotes/src/footnotes.md
@@ -45,3 +45,9 @@ And another[^in-between] that references the duplicate again.[^multiple-definiti
 [^in-between]: Footnote between duplicates.
 
 [^multiple-definitions]: This is the second definition of the footnote with tag multiple-definitions
+
+Multiple footnotes in a row.[^a][^b][^c]
+
+[^a]: Footnote 1
+[^b]: Footnote 2
+[^c]: Footnote 3


### PR DESCRIPTION
This adds a test for multiple footnotes in a row, which was broken in a previous version of pulldown-cmark.

This also fixes a rendering issue where the footnotes had no space separating them. It does this by adding a space character when it detects multiple footnote events in a row.

Closes https://github.com/rust-lang/mdBook/issues/2687
