### PR TITLE
Fix mdbook-core book tests

### DIFF
--- a/crates/mdbook-core/src/book.rs
+++ b/crates/mdbook-core/src/book.rs
@@ -6,6 +6,9 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 
+#[cfg(test)]
+mod tests;
+
 /// A tree structure representing a book.
 ///
 /// For the moment a book is just a collection of [`BookItems`] which are

--- a/crates/mdbook-core/src/book/tests.rs
+++ b/crates/mdbook-core/src/book/tests.rs
@@ -14,111 +14,110 @@ fn section_number_has_correct_dotted_representation() {
     }
 }
 
-    #[test]
-    fn book_iter_iterates_over_sequential_items() {
-        let sections = vec![
-                BookItem::Chapter(Chapter {
-                    name: String::from("Chapter 1"),
-                    content: String::from("# Chapter 1"),
-                    ..Default::default()
-                }),
+#[test]
+fn book_iter_iterates_over_sequential_items() {
+    let items = vec![
+        BookItem::Chapter(Chapter {
+            name: String::from("Chapter 1"),
+            content: String::from("# Chapter 1"),
+            ..Default::default()
+        }),
+        BookItem::Separator,
+    ];
+    let book = Book::new_with_items(items);
+
+    let should_be: Vec<_> = book.sections.iter().collect();
+
+    let got: Vec<_> = book.iter().collect();
+
+    assert_eq!(got, should_be);
+}
+
+#[test]
+fn for_each_mut_visits_all_items() {
+    let items = vec![
+        BookItem::Chapter(Chapter {
+            name: String::from("Chapter 1"),
+            content: String::from("# Chapter 1"),
+            number: None,
+            path: Some(PathBuf::from("Chapter_1/index.md")),
+            source_path: Some(PathBuf::from("Chapter_1/index.md")),
+            parent_names: Vec::new(),
+            sub_items: vec![
+                BookItem::Chapter(Chapter::new(
+                    "Hello World",
+                    String::new(),
+                    "Chapter_1/hello.md",
+                    Vec::new(),
+                )),
                 BookItem::Separator,
-            ];
-        let book = Book::new_with_sections(sections);
+                BookItem::Chapter(Chapter::new(
+                    "Goodbye World",
+                    String::new(),
+                    "Chapter_1/goodbye.md",
+                    Vec::new(),
+                )),
+            ],
+        }),
+        BookItem::Separator,
+    ];
+    let mut book = Book::new_with_items(items);
 
-        let should_be: Vec<_> = book.sections.iter().collect();
+    let num_items = book.iter().count();
+    let mut visited = 0;
 
-        let got: Vec<_> = book.iter().collect();
+    book.for_each_mut(|_| visited += 1);
 
-        assert_eq!(got, should_be);
-    }
+    assert_eq!(visited, num_items);
+}
 
-    #[test]
-    fn for_each_mut_visits_all_items() {
-        let sections = vec![
-                BookItem::Chapter(Chapter {
-                    name: String::from("Chapter 1"),
-                    content: String::from("# Chapter 1"),
-                    number: None,
-                    path: Some(PathBuf::from("Chapter_1/index.md")),
-                    source_path: Some(PathBuf::from("Chapter_1/index.md")),
-                    parent_names: Vec::new(),
-                    sub_items: vec![
-                        BookItem::Chapter(Chapter::new(
-                            "Hello World",
-                            String::new(),
-                            "Chapter_1/hello.md",
-                            Vec::new(),
-                        )),
-                        BookItem::Separator,
-                        BookItem::Chapter(Chapter::new(
-                            "Goodbye World",
-                            String::new(),
-                            "Chapter_1/goodbye.md",
-                            Vec::new(),
-                        )),
-                    ],
-                }),
+#[test]
+fn iterate_over_nested_book_items() {
+    let items = vec![
+        BookItem::Chapter(Chapter {
+            name: String::from("Chapter 1"),
+            content: String::from("# Chapter 1"),
+            number: None,
+            path: Some(PathBuf::from("Chapter_1/index.md")),
+            source_path: Some(PathBuf::from("Chapter_1/index.md")),
+            parent_names: Vec::new(),
+            sub_items: vec![
+                BookItem::Chapter(Chapter::new(
+                    "Hello World",
+                    String::new(),
+                    "Chapter_1/hello.md",
+                    Vec::new(),
+                )),
                 BookItem::Separator,
-            ];
-        let mut book = Book::new_with_sections(sections);
+                BookItem::Chapter(Chapter::new(
+                    "Goodbye World",
+                    String::new(),
+                    "Chapter_1/goodbye.md",
+                    Vec::new(),
+                )),
+            ],
+        }),
+        BookItem::Separator,
+    ];
+    let book = Book::new_with_items(items);
 
-        let num_items = book.iter().count();
-        let mut visited = 0;
+    let got: Vec<_> = book.iter().collect();
 
-        book.for_each_mut(|_| visited += 1);
+    assert_eq!(got.len(), 5);
 
-        assert_eq!(visited, num_items);
-    }
+    // checking the chapter names are in the order should be sufficient here...
+    let chapter_names: Vec<String> = got
+        .into_iter()
+        .filter_map(|i| match *i {
+            BookItem::Chapter(ref ch) => Some(ch.name.clone()),
+            _ => None,
+        })
+        .collect();
+    let should_be: Vec<_> = vec![
+        String::from("Chapter 1"),
+        String::from("Hello World"),
+        String::from("Goodbye World"),
+    ];
 
-    #[test]
-    fn iterate_over_nested_book_items() {
-        let sections = vec![
-                BookItem::Chapter(Chapter {
-                    name: String::from("Chapter 1"),
-                    content: String::from("# Chapter 1"),
-                    number: None,
-                    path: Some(PathBuf::from("Chapter_1/index.md")),
-                    source_path: Some(PathBuf::from("Chapter_1/index.md")),
-                    parent_names: Vec::new(),
-                    sub_items: vec![
-                        BookItem::Chapter(Chapter::new(
-                            "Hello World",
-                            String::new(),
-                            "Chapter_1/hello.md",
-                            Vec::new(),
-                        )),
-                        BookItem::Separator,
-                        BookItem::Chapter(Chapter::new(
-                            "Goodbye World",
-                            String::new(),
-                            "Chapter_1/goodbye.md",
-                            Vec::new(),
-                        )),
-                    ],
-                }),
-                BookItem::Separator,
-            ];
-        let book = Book::new_with_sections(sections);
-
-        let got: Vec<_> = book.iter().collect();
-
-        assert_eq!(got.len(), 5);
-
-        // checking the chapter names are in the order should be sufficient here...
-        let chapter_names: Vec<String> = got
-            .into_iter()
-            .filter_map(|i| match *i {
-                BookItem::Chapter(ref ch) => Some(ch.name.clone()),
-                _ => None,
-            })
-            .collect();
-        let should_be: Vec<_> = vec![
-            String::from("Chapter 1"),
-            String::from("Hello World"),
-            String::from("Goodbye World"),
-        ];
-
-        assert_eq!(chapter_names, should_be);
-    }
-
+    assert_eq!(chapter_names, should_be);
+}


### PR DESCRIPTION
These tests were moved in https://github.com/rust-lang/mdBook/pull/2766, but the `mod tests` was missing. This fixes this missing `mod`, and updates the tests so that they pass.