### PR TITLE
Rename Book.sections to Book.items

### DIFF
--- a/crates/mdbook-core/src/book.rs
+++ b/crates/mdbook-core/src/book.rs
@@ -11,9 +11,9 @@ mod tests;
 
 /// A tree structure representing a book.
 ///
-/// For the moment a book is just a collection of [`BookItems`] which are
-/// accessible by either iterating (immutably) over the book with [`iter()`], or
-/// recursively applying a closure to each section to mutate the chapters, using
+/// A book is just a collection of [`BookItems`] which are accessible by
+/// either iterating (immutably) over the book with [`iter()`], or recursively
+/// applying a closure to each item to mutate the chapters, using
 /// [`for_each_mut()`].
 ///
 /// [`iter()`]: #method.iter
@@ -21,8 +21,8 @@ mod tests;
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Book {
-    /// The sections in this book.
-    pub sections: Vec<BookItem>,
+    /// The items in this book.
+    pub items: Vec<BookItem>,
 }
 
 impl Book {
@@ -33,13 +33,13 @@ impl Book {
 
     /// Creates a new book with the given items.
     pub fn new_with_items(items: Vec<BookItem>) -> Book {
-        Book { sections: items }
+        Book { items }
     }
 
     /// Get a depth-first iterator over the items in the book.
     pub fn iter(&self) -> BookItems<'_> {
         BookItems {
-            items: self.sections.iter().collect(),
+            items: self.items.iter().collect(),
         }
     }
 
@@ -55,12 +55,12 @@ impl Book {
     where
         F: FnMut(&mut BookItem),
     {
-        for_each_mut(&mut func, &mut self.sections);
+        for_each_mut(&mut func, &mut self.items);
     }
 
     /// Append a `BookItem` to the `Book`.
     pub fn push_item<I: Into<BookItem>>(&mut self, item: I) -> &mut Self {
-        self.sections.push(item.into());
+        self.items.push(item.into());
         self
     }
 }

--- a/crates/mdbook-core/src/book/tests.rs
+++ b/crates/mdbook-core/src/book/tests.rs
@@ -26,7 +26,7 @@ fn book_iter_iterates_over_sequential_items() {
     ];
     let book = Book::new_with_items(items);
 
-    let should_be: Vec<_> = book.sections.iter().collect();
+    let should_be: Vec<_> = book.items.iter().collect();
 
     let got: Vec<_> = book.iter().collect();
 

--- a/crates/mdbook-driver/src/load.rs
+++ b/crates/mdbook-driver/src/load.rs
@@ -284,8 +284,8 @@ And here is some \
             PathBuf::from("chapter_1.md"),
             vec![],
         );
-        let sections = vec![BookItem::Chapter(chapter)];
-        let should_be = Book::new_with_items(sections);
+        let items = vec![BookItem::Chapter(chapter)];
+        let should_be = Book::new_with_items(items);
 
         let got = load_book_from_disk(&summary, temp.path()).unwrap();
 

--- a/crates/mdbook-html/src/html_handlebars/search.rs
+++ b/crates/mdbook-html/src/html_handlebars/search.rs
@@ -38,7 +38,7 @@ pub(super) fn create_files(
         .add_field_with_tokenizer("breadcrumbs", Box::new(&tokenize))
         .build();
 
-    let mut doc_urls = Vec::with_capacity(book.sections.len());
+    let mut doc_urls = Vec::with_capacity(book.items.len());
 
     let chapter_configs = sort_search_config(&search_config.chapter);
     validate_chapter_config(&chapter_configs, book)?;

--- a/crates/mdbook-summary/src/lib.rs
+++ b/crates/mdbook-summary/src/lib.rs
@@ -601,9 +601,9 @@ impl<'a> SummaryParser<'a> {
     }
 }
 
-fn update_section_numbers(sections: &mut [SummaryItem], level: usize, by: u32) {
-    for section in sections {
-        if let SummaryItem::Link(ref mut link) = *section {
+fn update_section_numbers(items: &mut [SummaryItem], level: usize, by: u32) {
+    for item in items {
+        if let SummaryItem::Link(ref mut link) = *item {
             if let Some(ref mut number) = link.number {
                 number[level] += by;
             }

--- a/examples/nop-preprocessor.rs
+++ b/examples/nop-preprocessor.rs
@@ -134,7 +134,7 @@ mod nop_lib {
                     "mdbook_version": "0.4.21"
                 },
                 {
-                    "sections": [
+                    "items": [
                         {
                             "Chapter": {
                                 "name": "Chapter 1",

--- a/guide/src/for_developers/preprocessors.md
+++ b/guide/src/for_developers/preprocessors.md
@@ -91,7 +91,7 @@ if __name__ == '__main__':
     # load both the context and the book representations from stdin
     context, book = json.load(sys.stdin)
     # and now, we can just modify the content of the first chapter
-    book['sections'][0]['Chapter']['content'] = '# Hello'
+    book['items'][0]['Chapter']['content'] = '# Hello'
     # we are done with the book's modification, we can just print it to stdout, 
     print(json.dumps(book))
 ```

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -54,7 +54,7 @@ fn preprocessor_cfg_from_env() {
             let mut s = String::new();
             std::io::stdin().read_to_string(&mut s).unwrap();
             std::fs::write("out.txt", s).unwrap();
-            println!("{{\"sections\": []}}");
+            println!("{{\"items\": []}}");
         }
         "#,
     )

--- a/tests/testsuite/preprocessor.rs
+++ b/tests/testsuite/preprocessor.rs
@@ -115,7 +115,7 @@ fn relative_command_path() {
             let mut s = String::new();
             std::io::stdin().read_to_string(&mut s).unwrap();
             std::fs::write("preprocessor-ran", "test").unwrap();
-            println!("{{\"sections\": []}}");
+            println!("{{\"items\": []}}");
         }
         "#,
     )

--- a/tests/testsuite/renderer.rs
+++ b/tests/testsuite/renderer.rs
@@ -167,7 +167,7 @@ fn backends_receive_render_context_via_stdin() {
         str![[r##"
 {
   "book": {
-    "sections": [
+    "items": [
       {
         "Chapter": {
           "content": "# Chapter 1\n",

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -117,7 +117,7 @@ fn with_no_source_path() {
     let test = BookTest::from_dir("search/reasonable_search_index");
     let mut book = test.load_book();
     let chapter = Chapter::new("Sample chapter", String::new(), "sample.html", vec![]);
-    book.book.sections.push(BookItem::Chapter(chapter));
+    book.book.items.push(BookItem::Chapter(chapter));
     book.build().unwrap();
 }
 


### PR DESCRIPTION
This renames the "sections" list to "items". In practice, this list has contained more than just "sections" since parts were added. Also, the rest of the code consistently uses the term "items", since the values it contains are called `BookItem`s. Finally, the naming has always been a little confusing to me.

This is a very disruptive change, and I'm not doing it lightly. However, since there are a number of other API changes going into 0.5, I think now is an ok time to change this.