### PR TITLE
Enable hash-files by default

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -482,6 +482,8 @@ pub struct HtmlConfig {
     pub redirect: HashMap<String, String>,
     /// If this option is turned on, "cache bust" static files by adding
     /// hashes to their file names.
+    ///
+    /// The default is `true`.
     pub hash_files: bool,
 }
 
@@ -509,7 +511,7 @@ impl Default for HtmlConfig {
             edit_url_template: None,
             live_reload_endpoint: None,
             redirect: HashMap::new(),
-            hash_files: false,
+            hash_files: true,
         }
     }
 }

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -165,7 +165,7 @@ The following configuration options are available:
   For example, `css/chrome.css` may become `css/chrome-9b8f428e.css`.
   Chapter HTML files are not renamed.
   Static CSS and JS files can reference each other using `{{ resource "filename" }}` directives.
-  Defaults to `false` (in a future release, this may change to `true`).
+  Defaults to `true`.
 
 [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
 

--- a/tests/testsuite/book_test.rs
+++ b/tests/testsuite/book_test.rs
@@ -124,8 +124,8 @@ impl BookTest {
     /// Returns the summary contents from `toc.js`.
     #[track_caller]
     pub fn toc_js_html(&self) -> String {
-        let full_path = self.dir.join("book/toc.js");
-        let actual = read_to_string(&full_path);
+        let toc_path = glob_one(&self.dir, "book/toc*.js");
+        let actual = read_to_string(&toc_path);
         let inner = actual
             .lines()
             .filter_map(|line| {

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -25,6 +25,6 @@ mod theme;
 mod toc;
 
 mod prelude {
-    pub use crate::book_test::{BookTest, read_to_string};
+    pub use crate::book_test::{BookTest, glob_one, read_to_string};
     pub use snapbox::str;
 }

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -6,8 +6,8 @@ use snapbox::file;
 use std::path::Path;
 
 fn read_book_index(root: &Path) -> serde_json::Value {
-    let index = root.join("book/searchindex.js");
-    let index = read_to_string(index);
+    let index_path = glob_one(root, "book/searchindex*.js");
+    let index = read_to_string(&index_path);
     let index =
         index.trim_start_matches("window.search = Object.assign(window.search, JSON.parse('");
     let index = index.trim_end_matches("'));");
@@ -87,7 +87,7 @@ fn reasonable_search_index() {
 #[test]
 fn search_index_hasnt_changed_accidentally() {
     BookTest::from_dir("search/reasonable_search_index").check_file(
-        "book/searchindex.js",
+        "book/searchindex*.js",
         file!["search/reasonable_search_index/expected_index.js"],
     );
 }

--- a/tests/testsuite/theme.rs
+++ b/tests/testsuite/theme.rs
@@ -48,24 +48,24 @@ This is a modified index.hbs!
 #[test]
 fn default_fonts() {
     BookTest::init(|_| {})
-        .check_file_contains("book/index.html", "fonts/fonts.css")
+        .check_file_contains("book/index.html", "fonts/fonts-[..].css")
         .check_file_list(
             "book/fonts",
             str![[r#"
 book/fonts/OPEN-SANS-LICENSE.txt
 book/fonts/SOURCE-CODE-PRO-LICENSE.txt
-book/fonts/fonts.css
-book/fonts/open-sans-v17-all-charsets-300.woff2
-book/fonts/open-sans-v17-all-charsets-300italic.woff2
-book/fonts/open-sans-v17-all-charsets-600.woff2
-book/fonts/open-sans-v17-all-charsets-600italic.woff2
-book/fonts/open-sans-v17-all-charsets-700.woff2
-book/fonts/open-sans-v17-all-charsets-700italic.woff2
-book/fonts/open-sans-v17-all-charsets-800.woff2
-book/fonts/open-sans-v17-all-charsets-800italic.woff2
-book/fonts/open-sans-v17-all-charsets-italic.woff2
-book/fonts/open-sans-v17-all-charsets-regular.woff2
-book/fonts/source-code-pro-v11-all-charsets-500.woff2
+book/fonts/fonts-[..].css
+book/fonts/open-sans-v17-all-charsets-300-[..].woff2
+book/fonts/open-sans-v17-all-charsets-300italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-600-[..].woff2
+book/fonts/open-sans-v17-all-charsets-600italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-700-[..].woff2
+book/fonts/open-sans-v17-all-charsets-700italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-800-[..].woff2
+book/fonts/open-sans-v17-all-charsets-800italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-regular-[..].woff2
+book/fonts/source-code-pro-v11-all-charsets-500-[..].woff2
 "#]],
         );
 }
@@ -76,7 +76,7 @@ fn theme_fonts_copied() {
     BookTest::init(|bb| {
         bb.copy_theme(true);
     })
-    .check_file_contains("book/index.html", "fonts/fonts.css")
+    .check_file_contains("book/index.html", "fonts/fonts-[..].css")
     .check_file_list(
         "theme/fonts",
         str![[r#"
@@ -96,23 +96,25 @@ theme/fonts/open-sans-v17-all-charsets-regular.woff2
 theme/fonts/source-code-pro-v11-all-charsets-500.woff2
 "#]],
     )
+    // Note that license files get hashed, which is not like the behavior when
+    // the theme directory is empty. It kinda makes sense, but is weird.
     .check_file_list(
         "book/fonts",
         str![[r#"
-book/fonts/OPEN-SANS-LICENSE.txt
-book/fonts/SOURCE-CODE-PRO-LICENSE.txt
-book/fonts/fonts.css
-book/fonts/open-sans-v17-all-charsets-300.woff2
-book/fonts/open-sans-v17-all-charsets-300italic.woff2
-book/fonts/open-sans-v17-all-charsets-600.woff2
-book/fonts/open-sans-v17-all-charsets-600italic.woff2
-book/fonts/open-sans-v17-all-charsets-700.woff2
-book/fonts/open-sans-v17-all-charsets-700italic.woff2
-book/fonts/open-sans-v17-all-charsets-800.woff2
-book/fonts/open-sans-v17-all-charsets-800italic.woff2
-book/fonts/open-sans-v17-all-charsets-italic.woff2
-book/fonts/open-sans-v17-all-charsets-regular.woff2
-book/fonts/source-code-pro-v11-all-charsets-500.woff2
+book/fonts/OPEN-SANS-LICENSE-[..].txt
+book/fonts/SOURCE-CODE-PRO-LICENSE-[..].txt
+book/fonts/fonts-[..].css
+book/fonts/open-sans-v17-all-charsets-300-[..].woff2
+book/fonts/open-sans-v17-all-charsets-300italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-600-[..].woff2
+book/fonts/open-sans-v17-all-charsets-600italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-700-[..].woff2
+book/fonts/open-sans-v17-all-charsets-700italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-800-[..].woff2
+book/fonts/open-sans-v17-all-charsets-800italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-italic-[..].woff2
+book/fonts/open-sans-v17-all-charsets-regular-[..].woff2
+book/fonts/source-code-pro-v11-all-charsets-500-[..].woff2
 "#]],
     );
 }
@@ -121,20 +123,20 @@ book/fonts/source-code-pro-v11-all-charsets-500.woff2
 #[test]
 fn fonts_css() {
     BookTest::from_dir("theme/fonts_css")
-        .check_file_contains("book/index.html", "fonts/fonts.css")
+        .check_file_contains("book/index.html", "fonts/fonts-[..].css")
         .check_file(
-            "book/fonts/fonts.css",
+            "book/fonts/fonts-*.css",
             str![[r#"
 /*custom*/
 
 "#]],
         )
-        .check_file("book/fonts/myfont.woff", str![[""]])
+        .check_file("book/fonts/myfont-*.woff", str![[""]])
         .check_file_list(
             "book/fonts",
             str![[r#"
-book/fonts/fonts.css
-book/fonts/myfont.woff
+book/fonts/fonts-[..].css
+book/fonts/myfont-[..].woff
 "#]],
         );
 }
@@ -167,12 +169,12 @@ fn custom_fonts_css() {
 
 "#]]);
         })
-        .check_file_contains("book/index.html", "fonts.css")
+        .check_file_contains("book/index.html", "fonts-[..].css")
         .check_file_list(
             "book/fonts",
             str![[r#"
-book/fonts/fonts.css
-book/fonts/myfont.woff
+book/fonts/fonts-[..].css
+book/fonts/myfont-[..].woff
 "#]],
         );
 }


### PR DESCRIPTION
This enables the hash-files setting by default. We have been running it for a while, and it seems most of the issues have been resolved. This should help with more reliably loading content like the toc contents.