### PR TITLE
Support publishing a pre-release version of the guide

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,16 +46,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Build book
-      run: cargo run -- build guide
     - name: Deploy the User Guide to GitHub Pages using the gh-pages branch
-      env:
-        GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
-      run: |
-        touch guide/book/.nojekyll
-        curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy
-        cd guide/book
-        /tmp/deploy
+      run: ci/publish-guide.sh
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest

--- a/ci/publish-guide.sh
+++ b/ci/publish-guide.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# This publishes the user guide to GitHub Pages.
+#
+# If this is a pre-release, then it goes in a separate directory called "pre-release".
+# Commits are amended to avoid keeping history which can balloon the repo size.
+set -ex
+
+cargo run --no-default-features -F search -- build guide
+
+VERSION=$(cargo metadata --format-version 1 --no-deps | jq '.packages[] | select(.name == "mdbook") | .version')
+
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE=true
+else
+    PRERELEASE=false
+fi
+
+git fetch origin gh-pages
+git worktree add gh-pages gh-pages
+git config user.name "Deploy from CI"
+git config user.email ""
+cd gh-pages
+if [[ "$PRERELEASE" == "true" ]]
+then
+    rm -rf pre-release
+    mv ../guide/book pre-release
+    git add pre-release
+    git commit --amend -m "Deploy $GITHUB_SHA pre-release to gh-pages"
+else
+    # Delete everything except pre-release and .git.
+    find . -mindepth 1 -maxdepth 1 -not -name "pre-release" -not -name ".git" -exec rm -rf {} +
+    # Copy the guide here.
+    find ../guide/book/ -mindepth 1 -maxdepth 1 -exec mv {} . \;
+    git add .
+    git commit --amend -m "Deploy $GITHUB_SHA to gh-pages"
+fi
+
+git push --force origin +gh-pages


### PR DESCRIPTION
This changes the publishing process so that when publishing the guide and the current version is a pre-release, it will be pushed to a directory called `/pre-release/`.

This also switches from using simpleinfra's SSH-based script to a simple push using normal git commands.