### PR TITLE
Simplify GUI tests runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "0.21.3",
+    "browser-ui-test": "0.22.1",
     "eslint": "^9.34.0"
   },
   "scripts": {

--- a/tests/gui/runner.rs
+++ b/tests/gui/runner.rs
@@ -5,9 +5,8 @@
 //! information.
 
 use serde_json::Value;
-use std::collections::HashSet;
 use std::env::current_dir;
-use std::fs::{read_dir, read_to_string, remove_dir_all};
+use std::fs::{read_to_string, remove_dir_all};
 use std::process::Command;
 
 fn get_available_browser_ui_test_version_inner(global: bool) -> Option<String> {
@@ -86,52 +85,21 @@ fn main() {
     let mut command = Command::new("npx");
     command
         .arg("browser-ui-test")
-        .args(["--variable", "DOC_PATH", book_dir.as_str()]);
+        .args(["--variable", "DOC_PATH", book_dir.as_str()])
+        .args(["--display-format", "compact"]);
 
-    let mut filters = Vec::new();
     for arg in std::env::args().skip(1) {
         if arg == "--disable-headless-test" {
             command.arg("--no-headless");
         } else if arg.starts_with("--") {
             command.arg(arg);
         } else {
-            filters.push(arg);
+            command.args(["--filter", arg.as_str()]);
         }
     }
 
     let test_dir = "tests/gui";
-    if filters.is_empty() {
-        command.args(["--test-folder", test_dir]);
-    } else {
-        let files = read_dir(test_dir)
-            .map(|dir| {
-                dir.filter_map(|entry| entry.ok())
-                    .map(|entry| entry.path())
-                    .filter(|path| {
-                        path.extension().is_some_and(|ext| ext == "goml") && path.is_file()
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or(Vec::new());
-        let mut matches = HashSet::new();
-        for filter in filters {
-            for file in files.iter().filter(|f| {
-                f.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.contains(&filter))
-            }) {
-                matches.insert(file.display().to_string());
-            }
-        }
-        if matches.is_empty() {
-            println!("No test found");
-            return;
-        }
-        command.arg("--test-files");
-        for entry in matches {
-            command.arg(entry);
-        }
-    }
+    command.args(["--test-folder", test_dir]);
 
     // Then we run the GUI tests on it.
     let status = command.status().expect("failed to get command output");


### PR DESCRIPTION
When running the tests, it now looks like this:

```
$ cargo test --test gui
   Compiling mdbook v0.5.0-alpha.1 (/home/imperio/rust/mdBook)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running tests/gui/runner.rs (target/debug/deps/gui-9ac52dc99d522383)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/mdbook build /home/imperio/rust/mdBook/test_book`
2025-09-08 17:29:25 [INFO] (mdbook_driver::mdbook): Book building has started
2025-09-08 17:29:25 [INFO] (mdbook_driver::mdbook): Running the html backend
2025-09-08 17:29:26 [INFO] (mdbook_html::html_handlebars::hbs_renderer): HTML book written to `/home/imperio/rust/mdBook/test_book/book`
=> Running 14 doc-ui tests (on 16 threads)...

..............                                     (14/14)


<= doc-ui tests done: 14 succeeded, 0 failed, 0 filtered out
```