### PR TITLE
Fix broken a tag

### DIFF
--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -227,6 +227,7 @@
                                 {{else}}
                                 {{fa "solid" "angle-left"}}
                                 {{/if}}
+                            </a>
                         {{/if}}
 
                         {{#if next}}


### PR DESCRIPTION
This fixes the missing close `</a>` tag for the "previous" button.