### PR TITLE
Fix raw status ending in the HTML tokenizer

### DIFF
--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -614,6 +614,7 @@ where
                             }
                         }
                         TagKind::EndTag => {
+                            is_raw = false;
                             if self.is_html_tag_matching(&tag.name) {
                                 self.pop();
                             }

--- a/tests/testsuite/rendering/html_blocks/expected/script-in-block.html
+++ b/tests/testsuite/rendering/html_blocks/expected/script-in-block.html
@@ -1,0 +1,7 @@
+<div>
+    HTML block start
+<script>
+    // script stuff <here>
+</script>
+    < still in block
+</div>

--- a/tests/testsuite/rendering/html_blocks/expected/script-in-block.html
+++ b/tests/testsuite/rendering/html_blocks/expected/script-in-block.html
@@ -3,5 +3,5 @@
 <script>
     // script stuff <here>
 </script>
-    < still in block
+    &lt; still in block
 </div>

--- a/tests/testsuite/rendering/html_blocks/src/SUMMARY.md
+++ b/tests/testsuite/rendering/html_blocks/src/SUMMARY.md
@@ -1,3 +1,4 @@
 # Summary
 
 - [Comment in list](./comment-in-list.md)
+- [Script in block](./script-in-block.md)

--- a/tests/testsuite/rendering/html_blocks/src/script-in-block.md
+++ b/tests/testsuite/rendering/html_blocks/src/script-in-block.md
@@ -1,0 +1,7 @@
+<div>
+    HTML block start
+<script>
+    // script stuff <here>
+</script>
+    &lt; still in block
+</div>


### PR DESCRIPTION
This fixes a small mistake where the "raw" status wasn't being reset once exiting the script or style tags. That means any text nodes that followed would be misinterpreted as being raw.