### PR TITLE
Remove outdated comment in mdbook-markdown

### DIFF
--- a/crates/mdbook-markdown/src/lib.rs
+++ b/crates/mdbook-markdown/src/lib.rs
@@ -4,10 +4,6 @@
 //! [mdBook](https://rust-lang.github.io/mdBook/). The [`pulldown_cmark`]
 //! crate is used as the underlying parser. This crate re-exports
 //! [`pulldown_cmark`] so that you can access its types.
-//!
-//! The parser in this library adds several modifications to the
-//! [`pulldown_cmark`] event stream. For example, it adjusts some links,
-//! modifies the behavior of footnotes, and adds various HTML wrappers.
 
 use pulldown_cmark::{Options, Parser};
 


### PR DESCRIPTION
I missed this in https://github.com/rust-lang/mdBook/pull/2844.