### PR TITLE
Move get_404_output_file to HtmlConfig

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -539,6 +539,14 @@ impl HtmlConfig {
             None => root.join("theme"),
         }
     }
+
+    /// Returns the name of the file used for HTTP 404 "not found" with the `.html` extension.
+    pub fn get_404_output_file(&self) -> String {
+        self.input_404
+            .as_ref()
+            .unwrap_or(&"404.md".to_string())
+            .replace(".md", ".html")
+    }
 }
 
 /// Configuration for how to render the print icon, print.html, and print.css.
@@ -706,7 +714,6 @@ impl<'de, T> Updateable<'de> for T where T: Serialize + Deserialize<'de> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::fs::get_404_output_file;
 
     const COMPLEX_CONFIG: &str = r#"
         [book]
@@ -973,7 +980,7 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, None);
-        assert_eq!(&get_404_output_file(&html_config.input_404), "404.html");
+        assert_eq!(html_config.get_404_output_file(), "404.html");
     }
 
     #[test]
@@ -986,7 +993,7 @@ mod tests {
         let got = Config::from_str(src).unwrap();
         let html_config = got.html_config().unwrap();
         assert_eq!(html_config.input_404, Some("missing.md".to_string()));
-        assert_eq!(&get_404_output_file(&html_config.input_404), "missing.html");
+        assert_eq!(html_config.get_404_output_file(), "missing.html");
     }
 
     #[test]

--- a/crates/mdbook-core/src/utils/fs.rs
+++ b/crates/mdbook-core/src/utils/fs.rs
@@ -196,14 +196,6 @@ fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     }
 }
 
-/// Returns the name of the file used for HTTP 404 "not found" with the `.html` extension.
-pub fn get_404_output_file(input_404: &Option<String>) -> String {
-    input_404
-        .as_ref()
-        .unwrap_or(&"404.md".to_string())
-        .replace(".md", ".html")
-}
-
 #[cfg(test)]
 mod tests {
     use super::copy_files_except_ext;

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -195,7 +195,7 @@ impl HtmlHandlebars {
         data_404.insert("title".to_owned(), json!(title));
         let rendered = handlebars.render("index", &data_404)?;
 
-        let output_file = utils::fs::get_404_output_file(&html_config.input_404);
+        let output_file = html_config.get_404_output_file();
         utils::fs::write_file(destination, output_file, rendered.as_bytes())?;
         debug!("Creating 404.html ✓");
         Ok(())

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -9,7 +9,6 @@ use axum::routing::get;
 use clap::builder::NonEmptyStringValueParser;
 use futures_util::StreamExt;
 use futures_util::sink::SinkExt;
-use mdbook_core::utils::fs::get_404_output_file;
 use mdbook_driver::MDBook;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
@@ -75,9 +74,8 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         .next()
         .ok_or_else(|| anyhow::anyhow!("no address found for {}", address))?;
     let build_dir = book.build_dir_for("html");
-    let html_config = book.config.html_config();
-    let input_404 = html_config.and_then(|c| c.input_404);
-    let file_404 = get_404_output_file(&input_404);
+    let html_config = book.config.html_config().unwrap_or_default();
+    let file_404 = html_config.get_404_output_file();
 
     // A channel used to broadcast to any websockets to reload when a file changes.
     let (tx, _rx) = tokio::sync::broadcast::channel::<Message>(100);


### PR DESCRIPTION
This function was essentially only operating on data from HtmlConfig. It wasn't really a "filesystem" function. So this moves it to be more logically associated with the data it works on.