### PR TITLE
Add job to automatically update dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,20 @@
+name: Update dependencies
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: bash ci/install-rust.sh stable x86_64-unknown-linux-gnu
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --locked
+      - name: Update dependencies
+        run: ci/update-dependencies.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/ci/update-dependencies.sh
+++ b/ci/update-dependencies.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Updates all compatible Cargo dependencies.
+#
+# I wasn't able to get Renovate to update compatible dependencies in a way
+# that I like, so this script takes care of it. This uses `cargo upgrade` to
+# ensure that `Cargo.toml` also gets updated. This also makes sure that all
+# transitive dependencies are updated.
+
+set -ex
+
+git fetch origin update-dependencies
+if git checkout update-dependencies
+then
+    git reset --hard origin/master
+else
+    git checkout -b update-dependencies
+fi
+
+cat > commit-message << 'EOF'
+Update cargo dependencies
+
+```
+EOF
+cargo upgrade >> commit-message
+echo '```' >> commit-message
+if git diff --quiet
+then
+    echo "No changes detected, exiting."
+    exit 0
+fi
+# Also update any transitive dependencies.
+cargo update
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git add Cargo.toml Cargo.lock
+git commit -F commit-message
+
+git push --force origin update-dependencies
+
+gh pr create --fill \
+    --head update-dependencies \
+    --base master

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -4,6 +4,9 @@
 # Allows @rustbot ready, review, author, or blocked
 [shortcut]
 
+# Closes/reopens PRs created by the GitHub Actions bot so that checks will run.
+[bot-pull-requests]
+
 [relabel]
 allow-unauthenticated = [
     # For Issue areas


### PR DESCRIPTION
This adds a job to automatically update cargo dependencies once a month. I've added this script instead of using Renovate because I couldn't get Renovate to update versions in `Cargo.toml`. I also wanted to batch transitive dependency updates all in one PR.