### PR TITLE
Add triagebot range-diff feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,6 +7,9 @@
 # Closes/reopens PRs created by the GitHub Actions bot so that checks will run.
 [bot-pull-requests]
 
+# When rebasing, this will add a diff link in a comment.
+[range-diff]
+
 [relabel]
 allow-unauthenticated = [
     # For Issue areas


### PR DESCRIPTION
This adds a comment on a PR when the author rebases to have a link to a better diff.