### PR TITLE
Set up new workspace publish workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,11 +51,17 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    permissions:
+      # Required for OIDC token exchange
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)
         run: rustup update stable --no-self-update && rustup default stable
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - name: Publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --workspace --no-verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ hex = "0.4.3"
 html5ever = "0.35.0"
 indexmap = "2.10.0"
 ignore = "0.4.23"
-mdbook-core = { path = "crates/mdbook-core" }
-mdbook-driver = { path = "crates/mdbook-driver" }
-mdbook-html = { path = "crates/mdbook-html" }
-mdbook-markdown = { path = "crates/mdbook-markdown" }
-mdbook-preprocessor = { path = "crates/mdbook-preprocessor" }
-mdbook-renderer = { path = "crates/mdbook-renderer" }
-mdbook-summary = { path = "crates/mdbook-summary" }
+mdbook-core = { path = "crates/mdbook-core", version = "0.5.0-alpha.1" }
+mdbook-driver = { path = "crates/mdbook-driver", version = "0.5.0-alpha.1" }
+mdbook-html = { path = "crates/mdbook-html", version = "0.5.0-alpha.1" }
+mdbook-markdown = { path = "crates/mdbook-markdown", version = "0.5.0-alpha.1" }
+mdbook-preprocessor = { path = "crates/mdbook-preprocessor", version = "0.5.0-alpha.1" }
+mdbook-renderer = { path = "crates/mdbook-renderer", version = "0.5.0-alpha.1" }
+mdbook-summary = { path = "crates/mdbook-summary", version = "0.5.0-alpha.1" }
 memchr = "2.7.5"
 notify = "8.1.0"
 notify-debouncer-mini = "0.6.0"

--- a/examples/remove-emphasis/mdbook-remove-emphasis/Cargo.toml
+++ b/examples/remove-emphasis/mdbook-remove-emphasis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mdbook-remove-emphasis"
 version = "0.1.0"
 edition.workspace = true
+publish = false
 
 [dependencies]
 mdbook-preprocessor.workspace = true


### PR DESCRIPTION
This sets up the publish workflow to use the new OIDC authentication, and to publish the whole workspace at once.

cc https://github.com/rust-lang/mdBook/issues/2768