### PR TITLE
Avoid divide-by-zero in heading nav computation

### DIFF
--- a/crates/mdbook-html/front-end/templates/toc.js.hbs
+++ b/crates/mdbook-html/front-end/templates/toc.js.hbs
@@ -132,7 +132,7 @@ window.customElements.define('mdbook-sidebar-scrollbox', MDBookSidebarScrollbox)
         // proportional to the difference in size.
         if (documentHeight < windowHeight * 2) {
             const maxPixelsBelow = documentHeight - windowHeight;
-            const t = 1 - pixelsBelow / maxPixelsBelow;
+            const t = 1 - pixelsBelow / Math.max(1, maxPixelsBelow);
             const clamp = Math.max(0, Math.min(1, t));
             adjustedBottomAdd *= clamp;
         }


### PR DESCRIPTION
This particular value can go to zero when the document height and the window height are exactly the same value. This causes a NaN which causes the "current" heading nav bug to not update properly. This clamps the value to 1 to avoid that.