### PR TITLE
Fix error message for config.get deserialization error

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -204,7 +204,7 @@ impl Config {
                 value
                     .clone()
                     .try_into()
-                    .with_context(|| "Failed to deserialize `{name}`")
+                    .with_context(|| format!("Failed to deserialize `{name}`"))
             })
             .transpose()
     }
@@ -1156,6 +1156,9 @@ mod tests {
         "#;
         let cfg = Config::from_str(src).unwrap();
         let err = cfg.get::<String>("preprocessor.foo.x").unwrap_err();
-        assert_eq!(err.to_string(), "Failed to deserialize `{name}`");
+        assert_eq!(
+            err.to_string(),
+            "Failed to deserialize `preprocessor.foo.x`"
+        );
     }
 }


### PR DESCRIPTION
The error message for a deserialization failure was missing a call to `format!`.