### PR TITLE
Add note to changelog about a change in heading ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The following is a summary of the changes that may require your attention when u
   [#2847](https://github.com/rust-lang/mdBook/pull/2847)
 - Added support for admonitions. These are enabled by default, with the option `output.html.admonitions` to disable it.
   [#2851](https://github.com/rust-lang/mdBook/pull/2851)
+- Headers that start or end with HTML characters like `<`, `&`, or `>` now replace those characters in the link ID with `-` instead of being stripped. This brings the header ID generation closer to other tools and sites.
+  [#2844](https://github.com/rust-lang/mdBook/pull/2844)
 
 ### CLI changes
 


### PR DESCRIPTION
I didn't fully appreciate that this changed in https://github.com/rust-lang/mdBook/pull/2844 which changed how text content was collected from heading tags.