### PR TITLE
Hide the sidebar resize indicator when JS isn't available

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -534,6 +534,11 @@ html:not(.sidebar-resizing) .sidebar {
     cursor: col-resize;
     width: calc(var(--sidebar-resize-indicator-width) - var(--sidebar-resize-indicator-space));
 }
+
+html:not(.js) .sidebar-resize-handle {
+    display: none;
+}
+
 /* sidebar-hidden */
 #mdbook-sidebar-toggle-anchor:not(:checked) ~ .sidebar {
     transform: translateX(calc(0px - var(--sidebar-width) - var(--sidebar-resize-indicator-width)));


### PR DESCRIPTION
Hi there!

mdBook is set up to enable browsing of documentation, even when scripting isn't available. And for the most part, it works well enough.

However, #819 added a resize handle, and #2209 adds a small indicator for this handle. This resize handle requires Javascript in order to work properly - and otherwise does nothing but add visual clutter when scripting isn't available.

This PR adds a small style inside a `<noscript>` tag, that hides the resize indicator when scripting isn't available.

I'm unfortunately not too familiar with HTML/CSS conventions - most of my knowledge comes from browsing MDN. Plus, this is my first contribution to mdBook, and to the rust-lang org in general. So if there's a more preferred way of doing this, please let me know.

(P.S. I've allowed edits by maintainers on this PR, so feel free to use that if need be.)