### PR TITLE
Fix missing font-awesome icons in the guide

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -145,9 +145,9 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fab-github` which looks like <i class="fa fab-github"></i>.
-  If you are not using GitHub, another option to consider is `fa-code-fork` which looks like <i class="fa fa-code-fork"></i>.
+  If you are not using GitHub, another option to consider is `fa-code-fork` which looks like <i class="fas fa-code-fork"></i>.
 - **edit-url-template:** Edit url template, when provided shows a
-  "Suggest an edit" button (which looks like <i class="fa fa-edit"></i>) for directly jumping to editing the currently
+  "Suggest an edit" button (which looks like <i class="fas fa-pencil"></i>) for directly jumping to editing the currently
   viewed page. For e.g. GitHub projects set this to
   `https://github.com/<owner>/<repo>/edit/<branch>/{path}` or for
   Bitbucket projects set it to
@@ -178,7 +178,7 @@ The following configuration options are available:
 ### `[output.html.print]`
 
 The `[output.html.print]` table provides options for controlling the printable output.
-By default, mdBook will include an icon on the top right of the book (which looks like <i class="fa fa-print"></i>) that will print the book as a single page.
+By default, mdBook will include an icon on the top right of the book (which looks like <i class="fas fa-print"></i>) that will print the book as a single page.
 
 ```toml
 [output.html.print]

--- a/guide/src/format/mdbook.md
+++ b/guide/src/format/mdbook.md
@@ -73,7 +73,7 @@ nothidden():
 
 ## Rust playground
 
-Rust language code blocks will automatically get a play button (<i class="fa fa-play"></i>) which will execute the code and display the output just below the code block.
+Rust language code blocks will automatically get a play button (<i class="fas fa-play"></i>) which will execute the code and display the output just below the code block.
 This works by sending the code to the [Rust Playground].
 
 ```rust

--- a/guide/src/guide/reading.md
+++ b/guide/src/guide/reading.md
@@ -42,7 +42,7 @@ Tapping the menu bar will scroll the page to the top.
 ## Search
 
 Each book has a built-in search system.
-Pressing the search icon (<i class="fa fa-search"></i>) in the menu bar, or pressing the <kbd>/</kbd> or <kbd>S</kbd> key on the keyboard will open an input box for entering search terms.
+Pressing the search icon <i class="fas fa-magnifying-glass"></i> in the menu bar, or pressing the <kbd>/</kbd> or <kbd>S</kbd> key on the keyboard will open an input box for entering search terms.
 Typing some terms will show matching chapters and sections in real time.
 
 Clicking any of the results will jump to that section.


### PR DESCRIPTION
After the switch in https://github.com/rust-lang/mdBook/pull/1330, some of the icons were renamed.