### PR TITLE
Disable update-dependencies on forks

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -8,6 +8,7 @@ jobs:
   update:
     name: Update dependencies
     runs-on: ubuntu-latest
+    if: github.repository == 'rust-lang/mdBook'
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust


### PR DESCRIPTION
This disables the update-dependencies cron job in forks. It's not uncommon for people to leave GitHub Actions enabled in a fork (which in my experience seems to be the default?), and this unfortunately means that this job will run in all those forks which is probably not what people want.