### PR TITLE
Change scrollbar background to transparent

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -1,7 +1,7 @@
 /* CSS for UI elements (a.k.a. chrome) */
 
 html {
-    scrollbar-color: var(--scrollbar) var(--bg);
+    scrollbar-color: var(--scrollbar) transparent;
 }
 #mdbook-searchresults a,
 .content a:link,


### PR DESCRIPTION
This PR sets the default scrollbar background color to transparent.

This change results in the scrollbar background having the same background color of the element it scrolls:

<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/f33f1f3f-ec4d-4391-b937-27bb355fc9cf" />

Closes #2930.