### PR TITLE
Don't copy console prompt symbols or output lines

### DIFF
--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -755,7 +755,19 @@ aria-label="Show hidden lines"></button>';
         text: function(trigger) {
             hideTooltip(trigger);
             const playground = trigger.closest('pre');
-            return playground_text(playground, false);
+            let text = playground_text(playground, false);
+
+            // Often console code blocks begin with a dollar or hash prompt and have
+            // example output. Copying and pasting this into a terminal will fail.
+            // Instead, strip the prompts and skip the output lines.
+            const codeBlock = playground.querySelector('code');
+            if (codeBlock && codeBlock.classList.contains('language-console')) {
+                text = text.split('\n')
+                    .filter(line => line.startsWith('$ ') || line.startsWith('# '))
+                    .map(line => line.substring(2))
+                    .join('\n');
+            }
+            return text;
         },
     });
 

--- a/guide/src/format/mdbook.md
+++ b/guide/src/format/mdbook.md
@@ -71,6 +71,51 @@ nothidden():
 ```
 ~~~
 
+## Console code blocks
+
+Console code blocks (annotated with `console`) provide special copy behavior to make it easier to copy commands into your terminal.
+Console examples often include shell prompts (`$ ` or `# `) followed by commands, along with the output from running those commands.
+
+When you click the copy button (<i class="fa fa-copy"></i>) on a console code block, mdBook will:
+
+- Only copy lines that begin with `$ ` or `# ` (the actual commands)
+- Strip the prompt prefix from those lines
+- Skip lines without prompts (command output)
+
+This allows you to paste commands directly into your terminal without manually removing prompts or cleaning up output. Example:
+
+~~~markdown
+```console
+$ echo "Hello, World!"
+Hello, World!
+$ ls -la
+total 64
+drwxr-xr-x  5 user  staff  160 Jan 1 12:00 .
+```
+~~~
+
+The code block above will render with both commands and output visible:
+
+```console
+$ echo "Hello, World!"
+Hello, World!
+$ ls -la
+total 64
+drwxr-xr-x  5 user  staff  160 Jan 1 12:00 .
+```
+
+However, when copied, it will only include the commands without the prompts:
+
+```text
+echo "Hello, World!"
+ls -la
+```
+
+This makes it easy to copy and paste multi-line commands directly into your terminal.
+
+See also the other supported languages with
+[syntax highlighting](/format/theme/syntax-highlighting.html).
+
 ## Rust playground
 
 Rust language code blocks will automatically get a play button (<i class="fas fa-play"></i>) which will execute the code and display the output just below the code block.

--- a/guide/src/format/theme/syntax-highlighting.md
+++ b/guide/src/format/theme/syntax-highlighting.md
@@ -24,6 +24,7 @@ your own `highlight.js` file:
 - bash
 - c
 - coffeescript
+- console
 - cpp
 - csharp
 - css


### PR DESCRIPTION
Fixes https://github.com/rust-lang/mdBook/issues/864.
Replaces and closes https://github.com/rust-lang/mdBook/pull/1110.

As commonly requested for the Rust book (at least in https://github.com/rust-lang/book/issues/1756, https://github.com/rust-lang/book/issues/2179, https://github.com/rust-lang/book/issues/2420, https://github.com/rust-lang/book/issues/2700, https://github.com/rust-lang/book/issues/2807, https://github.com/rust-lang/book/issues/3011, https://github.com/rust-lang/book/issues/3283, https://github.com/rust-lang/book/issues/3341, https://github.com/rust-lang/book/pull/3762), don't copy any `$ ` or `# ` prompts when copying `console` examples.

Unlike https://github.com/rust-lang/mdBook/pull/1110 and https://github.com/rust-lang/mdBook/pull/1346, this PR also skips the output lines when copying.

For example, copying:

```console
$ echo "Hello, World!"
Hello, World!
$ ls -la
total 64
drwxr-xr-x  5 user  staff  160 Jan 1 12:00 .
```

Puts only the commands in the clipboard:

```sh
echo "Hello, World!"
ls -la
```

This means you can paste it right away into your terminal and run it without having to edit further.