### PR TITLE
Ignore invalid top-level environment variable config keys

### DIFF
--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -213,10 +213,11 @@ unknown field `title`, expected `edition`
 fn env_invalid_config_key() {
     BookTest::from_dir("config/empty").run("build", |cmd| {
         cmd.env("MDBOOK_FOO", "testing")
-            .expect_failure()
             .expect_stdout(str![[""]])
             .expect_stderr(str![[r#"
-ERROR invalid key `foo`
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `[ROOT]/book`
 
 "#]]);
     });


### PR DESCRIPTION
This changes it so that top-level environment variable config keys like `MDBOOK_FOO` are ignored instead of generating an error. It's just too inconvenient since it is common for users to set environment variables like `MDBOOK_VERSION` or whatever for their own scripts.