### PR TITLE
Don't rebuild preprocessor map during test

### DIFF
--- a/crates/mdbook-driver/src/mdbook.rs
+++ b/crates/mdbook-driver/src/mdbook.rs
@@ -263,11 +263,6 @@ impl MDBook {
             }
         }
 
-        // Index Preprocessor is disabled so that chapter paths
-        // continue to point to the actual markdown files.
-        self.preprocessors = determine_preprocessors(&self.config, &self.root)?;
-        self.preprocessors
-            .shift_remove_entry(IndexPreprocessor::NAME);
         let (book, _) = self.preprocess_book(&TestRenderer)?;
 
         let color_output = std::io::stderr().is_terminal();

--- a/tests/testsuite/preprocessor.rs
+++ b/tests/testsuite/preprocessor.rs
@@ -54,8 +54,8 @@ fn test_with_custom_preprocessor() {
     book.test(vec![]).unwrap();
 
     let inner = spy.lock().unwrap();
-    assert_eq!(inner.run_count, 0);
-    assert_eq!(inner.rendered_with, Vec::<String>::new());
+    assert_eq!(inner.run_count, 1);
+    assert_eq!(inner.rendered_with, ["test"]);
 }
 
 // No-op preprocessor works.


### PR DESCRIPTION
This fixes a problem where custom preprocessors were not being registered when running tests. This was caused by the test function rebuilding the preprocessor map.

This removes the code that was rebuilding the preprocessors and removing the IndexPreprocessor when running tests. Skipping IndexPreprocessor was added back in https://github.com/rust-lang/mdBook/pull/741 to fix https://github.com/rust-lang/mdBook/issues/724 which was caused by https://github.com/rust-lang/mdBook/pull/685 which added the IndexPreprocessor.

Additionally, https://github.com/rust-lang/mdBook/pull/1986 added running *all* preprocessors.

The IndexPreprocessor was removed because in the past the code was testing against the source directly, and the path from `chapter.path` is the converted `index.md` file, and that filename does not exist in the source. This isn't a problem anymore because due to https://github.com/rust-lang/mdBook/pull/891 it is not reading from the `src` directory.

Note that this results in a minor change where the chapter path changes from `README.md` to `index.md` in the output and the `--chapter` option. I think I'm ok with that change, though it would be easy to switch it back if that's an issue.