### PR TITLE
Fix color for rustdoc error messages

### DIFF
--- a/crates/mdbook-driver/src/mdbook.rs
+++ b/crates/mdbook-driver/src/mdbook.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::Builder as TempFileBuilder;
 use topological_sort::TopologicalSort;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 #[cfg(test)]
 mod tests;
@@ -329,8 +329,8 @@ impl MDBook {
 
                 if !output.status.success() {
                     failed = true;
-                    error!(
-                        "rustdoc returned an error:\n\
+                    eprintln!(
+                        "ERROR rustdoc returned an error:\n\
                         \n--- stdout\n{}\n--- stderr\n{}",
                         String::from_utf8_lossy(&output.stdout),
                         String::from_utf8_lossy(&output.stderr)


### PR DESCRIPTION
Due to a change in tracing-subscriber where it escapes ANSI codes, the output from rustdoc was changed to be escaped instead of colored. This fixes the issue by just printing to the console directly.

This does not have a test because it is difficult to emulate a terminal in the testsuite, and I don't feel like adding color overrides at the moment.

Ref:
- https://github.com/rust-lang/mdBook/pull/2829 -- Switched to tracing
- https://github.com/advisories/GHSA-xwfj-jgwm-7wp5 -- CVE-2025-58160
- https://github.com/tokio-rs/tracing/issues/3378 -- Discussion of supporting color codes.

Eventually mdbook's primary output should migrate away from using log messages, and instead use a structured console system. However, that's a ways off.