### PR TITLE
serve: Fix repeated error message when HTML config is invalid

### DIFF
--- a/src/cmd/watch/poller.rs
+++ b/src/cmd/watch/poller.rs
@@ -41,7 +41,6 @@ pub fn rebuild_on_change(
 
     loop {
         std::thread::sleep(Duration::new(1, 0));
-        watcher.set_roots(&book);
         let start = Instant::now();
         let paths = watcher.scan();
         let elapsed = start.elapsed().as_secs_f64();
@@ -67,6 +66,7 @@ pub fn rebuild_on_change(
                         post_build();
                     }
                     book = b;
+                    watcher.set_roots(&book);
                 }
                 Err(e) => error!("failed to load book config: {e:?}"),
             }


### PR DESCRIPTION
This fixes an issue where `mdbook serve` would repeatedly show an error message every second if the `output.html` config had a problem. The issue is that `set_roots` was doing more work than I realized. It is not necessary to call it every time in the main polling loop, since the roots only change when the book configuration changes.

The solution is to just reset the roots whenever the book config changes.

Fixes https://github.com/rust-lang/mdBook/issues/2946