### PR TITLE
Add text-autospace for CJKs

### DIFF
--- a/crates/mdbook-html/front-end/css/general.css
+++ b/crates/mdbook-html/front-end/css/general.css
@@ -24,11 +24,13 @@ code {
     font-family: var(--mono-font) !important;
     font-size: var(--code-font-size);
     direction: ltr !important;
+    text-autospace: no-autospace;
 }
 
 /* make long words/inline code not x overflow */
 main {
     overflow-wrap: break-word;
+    text-autospace: normal;
 }
 
 /* make wide tables scroll if they overflow */


### PR DESCRIPTION
The CSS property `text-autospace` has finally work for all mainstream browsers (you can see this news in the top banner of the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-autospace)). This property will automatically insert spaces between CJK and non-CJK characters and around punctuation, which is the preferred approach for CJK typesettings (This typesetting rule is adopted in the [Chinese version of "The Rust Programming Language"](https://kaisery.github.io/trpl-zh-cn/), where all spaces are manually inserted).

Before applying this property:

<img width="780" height="131" alt="截屏2026-02-02 10 49 25" src="https://github.com/user-attachments/assets/f5d0c25f-c88e-4354-b94e-a9bf646489d4" />

After applying this property:

<img width="780" height="131" alt="截屏2026-02-02 10 54 52" src="https://github.com/user-attachments/assets/75b04e50-35cf-4727-8930-42d61e18502f" />

The property will only add spaces if there is no space, and if the author has manually inserted spaces, there will be no difference.