### PR TITLE
use <div role="note"> instead of <blockquote> for admonitions

### DIFF
--- a/crates/mdbook-html/front-end/css/general.css
+++ b/crates/mdbook-html/front-end/css/general.css
@@ -156,8 +156,7 @@ blockquote {
     border-block-end: .1em solid var(--quote-border);
 }
 
-/* TODO: Remove .warning in a future version of mdbook, it is replaced by
-blockquote tags. */
+/* TODO: Remove .warning in a future version of mdbook, it is replaced by admonitions. */
 .warning {
     margin: 20px;
     padding: 0 20px;
@@ -328,70 +327,68 @@ dd > p {
 }
 
 /* Remove some excess space from the bottom. */
-.blockquote-tag p:last-child {
+.admonition-tag p:last-child {
     margin-bottom: 2px;
 }
 
-.blockquote-tag {
+.admonition-tag {
+    /* Same margin and color as for blockquote */
+    margin: 20px 0;
+    color: var(--fg);
     /* Add some padding to make the vertical bar a little taller than the text.*/
     padding: 2px 0px 2px 20px;
     /* Add a solid color bar on the left side. */
     border-inline-start-style: solid;
     border-inline-start-width: 4px;
-    /* Disable the background color from normal blockquotes . */
-    background-color: inherit;
-    /* Disable border blocks from blockquotes. */
-    border-block-start: none;
-    border-block-end: none;
 }
 
-.blockquote-tag-title svg {
+.admonition-tag-title svg {
     fill: currentColor;
     /* Add space between the icon and the title. */
     margin-right: 8px;
 }
 
-.blockquote-tag-note {
+.admonition-tag-note {
     border-inline-start-color: var(--blockquote-note-color);
 }
 
-.blockquote-tag-tip {
+.admonition-tag-tip {
     border-inline-start-color: var(--blockquote-tip-color);
 }
 
-.blockquote-tag-important {
+.admonition-tag-important {
     border-inline-start-color: var(--blockquote-important-color);
 }
 
-.blockquote-tag-warning {
+.admonition-tag-warning {
     border-inline-start-color: var(--blockquote-warning-color);
 }
 
-.blockquote-tag-caution {
+.admonition-tag-caution {
     border-inline-start-color: var(--blockquote-caution-color);
 }
 
-.blockquote-tag-note .blockquote-tag-title {
+.admonition-tag-note .admonition-tag-title {
     color: var(--blockquote-note-color);
 }
 
-.blockquote-tag-tip .blockquote-tag-title {
+.admonition-tag-tip .admonition-tag-title {
     color: var(--blockquote-tip-color);
 }
 
-.blockquote-tag-important .blockquote-tag-title {
+.admonition-tag-important .admonition-tag-title {
     color: var(--blockquote-important-color);
 }
 
-.blockquote-tag-warning .blockquote-tag-title {
+.admonition-tag-warning .admonition-tag-title {
     color: var(--blockquote-warning-color);
 }
 
-.blockquote-tag-caution .blockquote-tag-title {
+.admonition-tag-caution .admonition-tag-title {
     color: var(--blockquote-caution-color);
 }
 
-.blockquote-tag-title {
+.admonition-tag-title {
     /* Slightly increase the weight for more emphasis. */
     font-weight: 600;
     /* Vertically center the icon with the text. */
@@ -401,7 +398,7 @@ dd > p {
     margin: 2px 0 8px 0;
 }
 
-.blockquote-tag-title .fa-svg {
+.admonition-tag-title .fa-svg {
     fill: currentColor;
     /* Add some space between the icon and the text. */
     margin-right: 8px;

--- a/crates/mdbook-html/src/html/admonitions.rs
+++ b/crates/mdbook-html/src/html/admonitions.rs
@@ -15,6 +15,7 @@ const ICON_WARNING: &str = r#"<path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086
 // This icon is from GitHub, MIT License, see https://github.com/primer/octicons
 const ICON_CAUTION: &str = r#"<path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>"#;
 
+/// HTML class, icon, and text for the element to create
 pub(crate) fn select_tag(kind: BlockQuoteKind) -> (&'static str, &'static str, &'static str) {
     match kind {
         BlockQuoteKind::Note => ("note", ICON_NOTE, "Note"),

--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -392,15 +392,16 @@ where
                 el
             }
             Tag::BlockQuote(kind) => {
-                let mut b = Element::new("blockquote");
                 if let Some(kind) = kind {
+                    let mut b = Element::new("div");
                     let (class_kind, icon, text) = super::admonitions::select_tag(kind);
-                    let class = format!("blockquote-tag blockquote-tag-{class_kind}");
+                    let class = format!("admonition-tag admonition-tag-{class_kind}");
                     b.insert_attr("class", class.into());
+                    b.insert_attr("role", "note".into());
                     self.push(Node::Element(b));
 
-                    let mut title = Element::new("p");
-                    title.insert_attr("class", "blockquote-tag-title".into());
+                    let mut title = Element::new("span");
+                    title.insert_attr("class", "admonition-tag-title".into());
                     self.push(Node::Element(title));
 
                     let mut svg = Element::new("svg");
@@ -416,7 +417,7 @@ where
                     self.pop();
                     return;
                 }
-                b
+                Element::new("blockquote")
             }
             Tag::CodeBlock(kind) => {
                 let mut code = Element::new("code");

--- a/tests/testsuite/markdown/admonitions/expected/admonitions.html
+++ b/tests/testsuite/markdown/admonitions/expected/admonitions.html
@@ -1,25 +1,20 @@
 <h1 id="admonitions"><a class="header" href="#admonitions">Admonitions</a></h1>
-<blockquote class="blockquote-tag blockquote-tag-note">
-<p class="blockquote-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>Note</p>
+<div class="admonition-tag admonition-tag-note" role="note"><span class="admonition-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>Note</span>
 <p>This is a note.</p>
 <p>There are multiple paragraphs.</p>
-</blockquote>
-<blockquote class="blockquote-tag blockquote-tag-tip">
-<p class="blockquote-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"></path></svg>Tip</p>
+</div>
+<div class="admonition-tag admonition-tag-tip" role="note"><span class="admonition-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"></path></svg>Tip</span>
 <p>This is a tip.</p>
-</blockquote>
-<blockquote class="blockquote-tag blockquote-tag-important">
-<p class="blockquote-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Important</p>
+</div>
+<div class="admonition-tag admonition-tag-important" role="note"><span class="admonition-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Important</span>
 <p>This is important.</p>
-</blockquote>
-<blockquote class="blockquote-tag blockquote-tag-warning">
-<p class="blockquote-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Warning</p>
+</div>
+<div class="admonition-tag admonition-tag-warning" role="note"><span class="admonition-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Warning</span>
 <p>This is a warning.</p>
-</blockquote>
-<blockquote class="blockquote-tag blockquote-tag-caution">
-<p class="blockquote-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>Caution</p>
+</div>
+<div class="admonition-tag admonition-tag-caution" role="note"><span class="admonition-tag-title"><svg viewbox="0 0 16 16" width="18" height="18"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>Caution</span>
 <p>This is a caution.</p>
-</blockquote>
+</div>
 <blockquote>
 <p>[!UNKNOWN]
 This is an unknown tag.</p>


### PR DESCRIPTION
Also, render the 'title' in a `<span>` instead of a `<p>`. This is semantically closer to what assistive tooling supports. For reference, see also:
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role
- https://www.w3.org/TR/WCAG21/#name-role-value (even has a note)

see #3026 