### PR TITLE
feat: URLs with no index.html suffix 

### DIFF
--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -518,6 +518,9 @@ pub struct HtmlConfig {
     /// If enabled, the sidebar includes navigation for headers on the current
     /// page. Default is `true`.
     pub sidebar_header_nav: bool,
+    /// If enabled, HTML files will not have the `.html` extension in URLs.
+    /// Defaults to `false`.
+    pub no_html_extension: bool,
 }
 
 impl Default for HtmlConfig {
@@ -548,6 +551,7 @@ impl Default for HtmlConfig {
             redirect: HashMap::new(),
             hash_files: true,
             sidebar_header_nav: true,
+            no_html_extension: false,
         }
     }
 }

--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -129,7 +129,7 @@
             <!-- populated by js -->
             <mdbook-sidebar-scrollbox class="sidebar-scrollbox"></mdbook-sidebar-scrollbox>
             <noscript>
-                <iframe class="sidebar-iframe-outer" src="{{ path_to_root }}toc.html"></iframe>
+                {{#if no_html_extension}}<iframe class="sidebar-iframe-outer" src="{{ path_to_root }}_toc/"></iframe>{{else}}<iframe class="sidebar-iframe-outer" src="{{ path_to_root }}toc.html"></iframe>{{/if}}
             </noscript>
             <div id="mdbook-sidebar-resize-handle" class="sidebar-resize-handle">
                 <div class="sidebar-resize-indicator"></div>
@@ -168,7 +168,7 @@
 
                     <div class="right-buttons">
                         {{#if print_enable}}
-                        <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
+                        {{#if no_html_extension}}<a href="{{ path_to_root }}_print/" title="Print this book" aria-label="Print this book">{{else}}<a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">{{/if}}
                             {{fa "solid" "print" "print-button"}}
                         </a>
                         {{/if}}

--- a/crates/mdbook-html/front-end/templates/toc.js.hbs
+++ b/crates/mdbook-html/front-end/templates/toc.js.hbs
@@ -11,9 +11,15 @@ class MDBookSidebarScrollbox extends HTMLElement {
         this.innerHTML = '{{#toc}}{{/toc}}';
         // Set the current, active page, and reveal it if it's hidden
         let current_page = document.location.href.toString().split('#')[0].split('?')[0];
+        {{#if no_html_extension}}
+        if (current_page.endsWith('index.html')) {
+            current_page = current_page.slice(0, -'index.html'.length);
+        }
+{{else}}
         if (current_page.endsWith('/')) {
             current_page += 'index.html';
         }
+{{/if}}
         const links = Array.prototype.slice.call(this.querySelectorAll('a'));
         const l = links.length;
         for (let i = 0; i < l; ++i) {
@@ -23,10 +29,20 @@ class MDBookSidebarScrollbox extends HTMLElement {
                 link.href = path_to_root + href;
             }
             // The 'index' page is supposed to alias the first chapter in the book.
+            {{#if no_html_extension}}
+            let link_href = link.href;
+            if (link_href.endsWith('index.html')) {
+                link_href = link_href.slice(0, -'index.html'.length);
+            }
+            if (link_href === current_page
+                || i === 0
+                && path_to_root === '') {
+{{else}}
             if (link.href === current_page
                 || i === 0
                 && path_to_root === ''
                 && current_page.endsWith('/index.html')) {
+{{/if}}
                 link.classList.add('active');
                 let parent = link.parentElement;
                 while (parent) {

--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -19,6 +19,7 @@ use pulldown_cmark::{Alignment, CodeBlockKind, CowStr, Event, LinkType, Tag, Tag
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
+use std::path::Path;
 use tracing::{trace, warn};
 
 /// Helper to create a [`QualName`].
@@ -542,7 +543,12 @@ where
                 let href: StrTendril = if matches!(link_type, LinkType::Email) {
                     format!("mailto:{dest_url}").into()
                 } else {
-                    fix_link(dest_url).into_tendril()
+                    fix_link(
+                        dest_url,
+                        self.options.path,
+                        self.options.config.no_html_extension,
+                    )
+                    .into_tendril()
                 };
                 let mut a = Element::new("a");
                 a.insert_attr("href", href);
@@ -558,7 +564,12 @@ where
                 id: _,
             } => {
                 let mut img = Element::new("img");
-                let src = fix_link(dest_url).into_tendril();
+                let src = fix_link(
+                    dest_url,
+                    self.options.path,
+                    self.options.config.no_html_extension,
+                )
+                .into_tendril();
                 img.insert_attr("src", src);
                 if !title.is_empty() {
                     img.insert_attr("title", title.into_tendril());
@@ -675,7 +686,11 @@ where
             self_closing: tag.self_closing,
             was_raw: true,
         };
-        fix_html_link(&mut el);
+        fix_html_link(
+            &mut el,
+            self.options.path,
+            self.options.config.no_html_extension,
+        );
         self.push(Node::Element(el));
         if is_closed {
             // No end element.
@@ -1089,10 +1104,14 @@ fn text_in_node(node: NodeRef<'_, Node>, output: &mut String) {
 
 /// Modifies links to work with HTML.
 ///
-/// For local paths, this changes the `.md` extension to `.html`.
-fn fix_link<'a>(link: CowStr<'a>) -> CowStr<'a> {
+/// For local paths, this changes the `.md` extension to `.html` when
+/// `clean_urls` is `false`, or to a trailing-slash clean URL when `true`.
+///
+/// When `clean_urls` is `true`, this also prepends `path_to_root` to ensure
+/// links work correctly from pages in subdirectories.
+fn fix_link<'a>(link: CowStr<'a>, source_path: &Path, clean_urls: bool) -> CowStr<'a> {
     static_regex!(SCHEME_LINK, r"^[a-z][a-z0-9+.-]*:");
-    static_regex!(MD_LINK, r"(?P<link>.*)\.md(?P<anchor>#.*)?");
+    static_regex!(MD_LINK, r"(?P<link>.*)\.md(?P<anchor>#[^?]*)?");
 
     if link.starts_with('#') {
         // Fragment-only link.
@@ -1105,8 +1124,22 @@ fn fix_link<'a>(link: CowStr<'a>) -> CowStr<'a> {
 
     // This is a relative link, adjust it as necessary.
     if let Some(caps) = MD_LINK.captures(&link) {
-        let mut fixed_link = String::from(&caps["link"]);
-        fixed_link.push_str(".html");
+        let link_stem = &caps["link"];
+        let mut fixed_link = if clean_urls {
+            // For clean URLs, pages are in subdirectories, so we need path_to_root.
+            let path_to_root = super::super::utils::clean_url_path_to_root(source_path);
+            let url_stem = if link_stem == "index" {
+                // Link to book index - just use path_to_root
+                String::new()
+            } else if let Some(parent) = link_stem.strip_suffix("/index") {
+                format!("{parent}/")
+            } else {
+                format!("{link_stem}/")
+            };
+            format!("{path_to_root}{url_stem}")
+        } else {
+            format!("{link_stem}.html")
+        };
         if let Some(anchor) = caps.name("anchor") {
             fixed_link.push_str(anchor.as_str());
         }
@@ -1117,13 +1150,13 @@ fn fix_link<'a>(link: CowStr<'a>) -> CowStr<'a> {
 }
 
 /// Calls [`fix_link`] for HTML elements.
-fn fix_html_link(el: &mut Element) {
+fn fix_html_link(el: &mut Element, source_path: &Path, clean_urls: bool) {
     if el.name() != "a" {
         return;
     }
     for attr in ["href", "xlink:href"] {
         if let Some(value) = el.attr(attr) {
-            let fixed = fix_link(value.into());
+            let fixed = fix_link(value.into(), source_path, clean_urls);
             el.insert_attr(attr, fixed.into_tendril());
         }
     }
@@ -1152,4 +1185,73 @@ pub(crate) fn is_void_element(name: &str) -> bool {
             | "track"
             | "wbr"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fix_link;
+    use pulldown_cmark::CowStr;
+    use std::path::Path;
+
+    fn fl(s: &str, source: &str, clean: bool) -> String {
+        fix_link(CowStr::Borrowed(s), Path::new(source), clean).into_string()
+    }
+
+    #[test]
+    fn fix_link_html_default() {
+        // With clean_urls=false, .md links become .html without path_to_root prefix.
+        assert_eq!(fl("chapter-b.md", "chapter-a.md", false), "chapter-b.html");
+    }
+
+    #[test]
+    fn fix_link_clean_url_basic() {
+        // With clean_urls=true, links get path_to_root prepended.
+        // From root-level chapter-a.md, path_to_root = "../"
+        assert_eq!(fl("chapter-b.md", "chapter-a.md", true), "../chapter-b/");
+    }
+
+    #[test]
+    fn fix_link_clean_url_from_index() {
+        // From index.md at root, path_to_root = "" (no extra ../)
+        assert_eq!(fl("chapter-b.md", "index.md", true), "chapter-b/");
+    }
+
+    #[test]
+    fn fix_link_clean_url_nested() {
+        // From nested chapter, path_to_root = "../../"
+        assert_eq!(fl("other.md", "foo/bar.md", true), "../../other/");
+    }
+
+    #[test]
+    fn fix_link_clean_url_index() {
+        // Links to index.md become ./
+        assert_eq!(fl("index.md", "chapter-a.md", true), "../");
+    }
+
+    #[test]
+    fn fix_link_clean_url_nested_index() {
+        // Links to foo/index.md become foo/
+        assert_eq!(fl("foo/index.md", "chapter-a.md", true), "../foo/");
+    }
+
+    #[test]
+    fn fix_link_clean_url_with_anchor() {
+        assert_eq!(
+            fl("foo/bar.md#section", "index.md", true),
+            "foo/bar/#section"
+        );
+    }
+
+    #[test]
+    fn fix_link_clean_url_external_unchanged() {
+        assert_eq!(
+            fl("https://example.com", "chapter-a.md", true),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn fix_link_clean_url_anchor_only_unchanged() {
+        assert_eq!(fl("#anchor", "chapter-a.md", true), "#anchor");
+    }
 }

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -3,7 +3,7 @@ use super::static_files::StaticFiles;
 use crate::html::ChapterTree;
 use crate::html::{build_trees, render_markdown, serialize};
 use crate::theme::Theme;
-use crate::utils::{clean_url_link_path, clean_url_output_path, clean_url_path_to_root, ToUrlPath};
+use crate::utils::{ToUrlPath, clean_url_link_path, clean_url_output_path, clean_url_path_to_root};
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
 use mdbook_core::book::{Book, BookItem, Chapter};
@@ -386,7 +386,12 @@ impl Renderer for HtmlHandlebars {
             let default = mdbook_core::config::Search::default();
             let search = html_config.search.as_ref().unwrap_or(&default);
             if search.enable {
-                super::search::create_files(&search, &mut static_files, &chapter_trees)?;
+                super::search::create_files(
+                    &search,
+                    &mut static_files,
+                    &chapter_trees,
+                    html_config.no_html_extension,
+                )?;
             }
         }
 

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -157,6 +157,7 @@ impl HtmlHandlebars {
         src_dir: &Path,
         handlebars: &mut Handlebars<'_>,
         data: &mut serde_json::Map<String, serde_json::Value>,
+        not_found_dir: Option<&str>,
     ) -> Result<()> {
         let content_404 = if let Some(ref filename) = html_config.input_404 {
             let path = src_dir.join(filename);
@@ -202,11 +203,21 @@ impl HtmlHandlebars {
             title.push_str(book_title);
         }
         data_404.insert("title".to_owned(), json!(title));
+        if not_found_dir.is_some() {
+            data_404.insert("path_to_root".to_owned(), json!("../"));
+        }
         let rendered = handlebars.render("index", &data_404)?;
 
-        let output_file = ctx.destination.join(html_config.get_404_output_file());
-        fs::write(output_file, rendered)?;
-        debug!("Creating 404.html ✓");
+        if let Some(dir) = not_found_dir {
+            let output_file = ctx.destination.join(format!("{dir}/index.html"));
+            fs::create_dir_all(output_file.parent().unwrap())?;
+            fs::write(output_file, rendered)?;
+            debug!("Creating {dir}/index.html ✓");
+        } else {
+            let output_file = ctx.destination.join(html_config.get_404_output_file());
+            fs::write(output_file, rendered)?;
+            debug!("Creating 404.html ✓");
+        }
         Ok(())
     }
 
@@ -216,6 +227,7 @@ impl HtmlHandlebars {
         handlebars: &Handlebars<'_>,
         data: &mut serde_json::Map<String, serde_json::Value>,
         chapter_trees: Vec<ChapterTree<'_>>,
+        no_html_extension: bool,
     ) -> Result<String> {
         let print_content = crate::html::render_print_page(chapter_trees);
 
@@ -231,7 +243,11 @@ impl HtmlHandlebars {
         data.insert("content".to_owned(), json!(print_content));
         data.insert(
             "path_to_root".to_owned(),
-            json!(fs::path_to_root(Path::new("print.md"))),
+            if no_html_extension {
+                json!("../")
+            } else {
+                json!(fs::path_to_root(Path::new("print.md")))
+            },
         );
 
         debug!("Render template");
@@ -314,6 +330,28 @@ impl HtmlHandlebars {
 
         Ok(())
     }
+}
+
+/// Validates that chapter paths don't conflict with reserved special page directories.
+/// When `no-html-extension` is enabled, special pages use underscore-prefixed directories
+/// (_print/, _toc/, _404/). Any chapter that would conflict with these is an error.
+fn validate_no_reserved_conflict(chapter_trees: &[ChapterTree<'_>]) -> Result<()> {
+    let reserved = ["_print", "_toc", "_404"];
+    for ct in chapter_trees {
+        if let Some(path) = &ct.chapter.path {
+            for reserved_name in reserved {
+                if path.starts_with(reserved_name) {
+                    bail!(
+                        "Chapter path '{}' conflicts with reserved special page directory '{}/'. \
+                         Please rename the chapter to avoid paths starting with '_print', '_toc', or '_404'.",
+                        path.display(),
+                        reserved_name
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 impl Renderer for HtmlHandlebars {
@@ -413,15 +451,42 @@ impl Renderer for HtmlHandlebars {
 
         handlebars.register_helper("resource", Box::new(resource_helper));
 
+        // Compute special page directory names for clean URL mode.
+        // When clean URLs are enabled, validate no chapter conflicts with reserved directories
+        if html_config.no_html_extension {
+            validate_no_reserved_conflict(&chapter_trees)?;
+        }
+
+        // Special page directories: always use underscore-prefixed paths when clean URLs enabled
+        let (print_dir, toc_dir, not_found_dir) = if html_config.no_html_extension {
+            ("_print", "_toc", "_404")
+        } else {
+            // When disabled, these are just file basenames (print.html, toc.html, 404.html)
+            ("print", "toc", "404")
+        };
+
         debug!("Render toc html");
         {
             data.insert("is_toc_html".to_owned(), json!(true));
             data.insert("path".to_owned(), json!("toc.html"));
+            if html_config.no_html_extension {
+                data.insert("path_to_root".to_owned(), json!("../"));
+            }
             let rendered_toc = handlebars.render("toc_html", &data)?;
-            fs::write(destination.join("toc.html"), rendered_toc)?;
-            debug!("Creating toc.html ✓");
+            if html_config.no_html_extension {
+                let toc_path = destination.join(format!("{toc_dir}/index.html"));
+                fs::create_dir_all(toc_path.parent().unwrap())?;
+                fs::write(toc_path, rendered_toc)?;
+                debug!("Creating {toc_dir}/index.html ✓");
+            } else {
+                fs::write(destination.join("toc.html"), rendered_toc)?;
+                debug!("Creating toc.html ✓");
+            }
             data.remove("path");
             data.remove("is_toc_html");
+            if html_config.no_html_extension {
+                data.remove("path_to_root");
+            }
         }
 
         fs::write(
@@ -449,16 +514,35 @@ impl Renderer for HtmlHandlebars {
 
         // Render 404 page
         if html_config.input_404 != Some("".to_string()) {
-            self.render_404(ctx, &html_config, &src_dir, &mut handlebars, &mut data)?;
+            let not_found_opt = html_config.no_html_extension.then_some(not_found_dir);
+            self.render_404(
+                ctx,
+                &html_config,
+                &src_dir,
+                &mut handlebars,
+                &mut data,
+                not_found_opt,
+            )?;
         }
 
         // Render the print version.
         if html_config.print.enable {
-            let print_rendered =
-                self.render_print_page(ctx, &handlebars, &mut data, chapter_trees)?;
-
-            fs::write(destination.join("print.html"), print_rendered)?;
-            debug!("Creating print.html ✓");
+            let print_rendered = self.render_print_page(
+                ctx,
+                &handlebars,
+                &mut data,
+                chapter_trees,
+                html_config.no_html_extension,
+            )?;
+            if html_config.no_html_extension {
+                let print_path = destination.join(format!("{print_dir}/index.html"));
+                fs::create_dir_all(print_path.parent().unwrap())?;
+                fs::write(print_path, print_rendered)?;
+                debug!("Creating {print_dir}/index.html ✓");
+            } else {
+                fs::write(destination.join("print.html"), print_rendered)?;
+                debug!("Creating print.html ✓");
+            }
         }
 
         self.emit_redirects(&ctx.destination, &handlebars, &html_config.redirect)

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -572,6 +572,10 @@ fn make_data(
         "sidebar_header_nav".to_owned(),
         json!(html_config.sidebar_header_nav),
     );
+    data.insert(
+        "no_html_extension".to_owned(),
+        json!(html_config.no_html_extension),
+    );
 
     let search = html_config.search.clone();
     if cfg!(feature = "search") {

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -3,7 +3,7 @@ use super::static_files::StaticFiles;
 use crate::html::ChapterTree;
 use crate::html::{build_trees, render_markdown, serialize};
 use crate::theme::Theme;
-use crate::utils::{clean_url_output_path, clean_url_path_to_root, ToUrlPath};
+use crate::utils::{clean_url_link_path, clean_url_output_path, clean_url_path_to_root, ToUrlPath};
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
 use mdbook_core::book::{Book, BookItem, Chapter};
@@ -111,12 +111,15 @@ impl HtmlHandlebars {
 
         let mut nav = |name: &str, ch: Option<&Chapter>| {
             let Some(ch) = ch else { return };
-            let path = ch
-                .path
-                .as_ref()
-                .unwrap()
-                .with_extension("html")
-                .to_url_path();
+            let path = if ctx.html_config.no_html_extension {
+                clean_url_link_path(&ch.path.as_ref().unwrap().with_extension("html"))
+            } else {
+                ch.path
+                    .as_ref()
+                    .unwrap()
+                    .with_extension("html")
+                    .to_url_path()
+            };
             let obj = json!( {
                 "title": ch.name,
                 "link": path,
@@ -241,6 +244,7 @@ impl HtmlHandlebars {
             "toc",
             Box::new(helpers::toc::RenderToc {
                 no_section_label: html_config.no_section_label,
+                no_html_extension: html_config.no_html_extension,
             }),
         );
         handlebars.register_helper("fa", Box::new(helpers::fontawesome::fa_helper));

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -3,7 +3,7 @@ use super::static_files::StaticFiles;
 use crate::html::ChapterTree;
 use crate::html::{build_trees, render_markdown, serialize};
 use crate::theme::Theme;
-use crate::utils::ToUrlPath;
+use crate::utils::{clean_url_output_path, clean_url_path_to_root, ToUrlPath};
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
 use mdbook_core::book::{Book, BookItem, Chapter};
@@ -64,6 +64,11 @@ impl HtmlHandlebars {
             .to_str()
             .with_context(|| "Could not convert path to str")?;
         let filepath = Path::new(&ctx_path).with_extension("html");
+        let filepath = if ctx.html_config.no_html_extension {
+            clean_url_output_path(&filepath)
+        } else {
+            filepath
+        };
 
         let book_title = ctx
             .data
@@ -83,8 +88,14 @@ impl HtmlHandlebars {
         ctx.data.insert("content".to_owned(), json!(content));
         ctx.data.insert("chapter_title".to_owned(), json!(ch.name));
         ctx.data.insert("title".to_owned(), json!(title));
-        ctx.data
-            .insert("path_to_root".to_owned(), json!(fs::path_to_root(path)));
+        ctx.data.insert(
+            "path_to_root".to_owned(),
+            if ctx.html_config.no_html_extension {
+                json!(clean_url_path_to_root(path))
+            } else {
+                json!(fs::path_to_root(path))
+            },
+        );
         if let Some(ref section) = ch.number {
             ctx.data
                 .insert("section".to_owned(), json!(section.to_string()));
@@ -121,6 +132,7 @@ impl HtmlHandlebars {
 
         // Write to file
         let out_path = ctx.destination.join(filepath);
+        fs::create_dir_all(out_path.parent().unwrap())?;
         fs::write(&out_path, rendered)?;
 
         if prev_ch.is_none() {

--- a/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
@@ -1,15 +1,17 @@
 use std::collections::HashMap;
+use std::path::Path;
 
-use mdbook_core::utils;
-
+use crate::utils::clean_url_path_to_root;
 use handlebars::{
     Context, Handlebars, Helper, HelperDef, Output, RenderContext, RenderError, RenderErrorReason,
 };
+use mdbook_core::utils;
 
 // Handlebars helper to find filenames with hashes in them
 #[derive(Clone)]
 pub(crate) struct ResourceHelper {
     pub hash_map: HashMap<String, String>,
+    pub no_html_extension: bool,
 }
 
 impl HelperDef for ResourceHelper {
@@ -36,7 +38,11 @@ impl HelperDef for ResourceHelper {
             })?
             .replace("\"", "");
 
-        let path_to_root = utils::fs::path_to_root(&base_path);
+        let path_to_root = if self.no_html_extension {
+            clean_url_path_to_root(Path::new(&base_path))
+        } else {
+            utils::fs::path_to_root(&base_path)
+        };
 
         out.write(&path_to_root)?;
         out.write(self.hash_map.get(param).map(|p| &p[..]).unwrap_or(&param))?;

--- a/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/resources.rs
@@ -49,3 +49,92 @@ impl HelperDef for ResourceHelper {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use handlebars::Handlebars;
+    use serde_json::json;
+
+    #[test]
+    fn resource_helper_without_clean_urls() {
+        let helper = ResourceHelper {
+            hash_map: HashMap::new(),
+            no_html_extension: false,
+        };
+
+        let mut hbs = Handlebars::new();
+        hbs.register_helper("resource", Box::new(helper));
+
+        let data = json!({"path": "foo/bar.md"});
+        let result = hbs
+            .render_template("{{resource \"css/style.css\"}}", &data)
+            .unwrap();
+
+        // For foo/bar.md without clean URLs: path_to_root = "../"
+        assert_eq!(result, "../css/style.css");
+    }
+
+    #[test]
+    fn resource_helper_with_clean_urls() {
+        let helper = ResourceHelper {
+            hash_map: HashMap::new(),
+            no_html_extension: true,
+        };
+
+        let mut hbs = Handlebars::new();
+        hbs.register_helper("resource", Box::new(helper));
+
+        let data = json!({"path": "foo/bar.md"});
+        let result = hbs
+            .render_template("{{resource \"css/style.css\"}}", &data)
+            .unwrap();
+
+        // For foo/bar.md with clean URLs: path_to_root = "../../" (extra level for bar/index.html)
+        assert_eq!(result, "../../css/style.css");
+    }
+
+    #[test]
+    fn resource_helper_clean_urls_index_page() {
+        let helper = ResourceHelper {
+            hash_map: HashMap::new(),
+            no_html_extension: true,
+        };
+
+        let mut hbs = Handlebars::new();
+        hbs.register_helper("resource", Box::new(helper));
+
+        let data = json!({"path": "foo/index.md"});
+        let result = hbs
+            .render_template("{{resource \"css/style.css\"}}", &data)
+            .unwrap();
+
+        // For foo/index.md with clean URLs: path_to_root = "../" (no extra level for index pages)
+        assert_eq!(result, "../css/style.css");
+    }
+
+    #[test]
+    fn resource_helper_with_hash_map() {
+        let mut hash_map = HashMap::new();
+        hash_map.insert(
+            "css/style.css".to_string(),
+            "css/style-abc123.css".to_string(),
+        );
+
+        let helper = ResourceHelper {
+            hash_map,
+            no_html_extension: false,
+        };
+
+        let mut hbs = Handlebars::new();
+        hbs.register_helper("resource", Box::new(helper));
+
+        let data = json!({"path": "foo/bar.md"});
+        let result = hbs
+            .render_template("{{resource \"css/style.css\"}}", &data)
+            .unwrap();
+
+        // Should use hashed filename
+        assert_eq!(result, "../css/style-abc123.css");
+    }
+}

--- a/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
@@ -1,4 +1,4 @@
-use crate::utils::ToUrlPath;
+use crate::utils::{ToUrlPath, clean_url_link_path};
 use handlebars::{
     Context, Handlebars, Helper, HelperDef, Output, RenderContext, RenderError, RenderErrorReason,
 };
@@ -10,6 +10,7 @@ use std::{cmp::Ordering, collections::BTreeMap};
 #[derive(Clone, Copy)]
 pub(crate) struct RenderToc {
     pub no_section_label: bool,
+    pub no_html_extension: bool,
 }
 
 impl HelperDef for RenderToc {
@@ -117,7 +118,11 @@ impl HelperDef for RenderToc {
             let path_exists = match item.get("path") {
                 Some(path) if !path.is_empty() => {
                     out.write("<a href=\"")?;
-                    let tmp = Path::new(path).with_extension("html").to_url_path();
+                    let tmp = if self.no_html_extension {
+                        clean_url_link_path(&Path::new(path).with_extension("html"))
+                    } else {
+                        Path::new(path).with_extension("html").to_url_path()
+                    };
 
                     // Add link
                     out.write(&tmp)?;

--- a/crates/mdbook-html/src/html_handlebars/search.rs
+++ b/crates/mdbook-html/src/html_handlebars/search.rs
@@ -1,7 +1,7 @@
 use super::static_files::StaticFiles;
 use crate::html::{ChapterTree, Node};
 use crate::theme::searcher;
-use crate::utils::ToUrlPath;
+use crate::utils::{ToUrlPath, clean_url_link_path};
 use anyhow::{Result, bail};
 use ego_tree::iter::Edge;
 use elasticlunr::{Index, IndexBuilder};
@@ -30,6 +30,7 @@ pub(super) fn create_files(
     search_config: &Search,
     static_files: &mut StaticFiles,
     chapter_trees: &[ChapterTree<'_>],
+    no_html_extension: bool,
 ) -> Result<()> {
     let mut index = IndexBuilder::new()
         .add_field_with_tokenizer("title", Box::new(&tokenize))
@@ -49,7 +50,13 @@ pub(super) fn create_files(
         if !chapter_settings.enable.unwrap_or(true) {
             continue;
         }
-        index_chapter(&mut index, search_config, &mut doc_urls, ct)?;
+        index_chapter(
+            &mut index,
+            search_config,
+            &mut doc_urls,
+            ct,
+            no_html_extension,
+        )?;
     }
 
     let index = write_to_json(index, search_config, doc_urls)?;
@@ -105,8 +112,13 @@ fn index_chapter(
     search_config: &Search,
     doc_urls: &mut Vec<String>,
     chapter_tree: &ChapterTree<'_>,
+    no_html_extension: bool,
 ) -> Result<()> {
-    let anchor_base = chapter_tree.html_path.to_url_path();
+    let anchor_base = if no_html_extension {
+        clean_url_link_path(&chapter_tree.html_path)
+    } else {
+        chapter_tree.html_path.to_url_path()
+    };
 
     let mut in_heading = false;
     let max_section_depth = search_config.heading_split_level;

--- a/crates/mdbook-html/src/html_handlebars/static_files.rs
+++ b/crates/mdbook-html/src/html_handlebars/static_files.rs
@@ -22,6 +22,7 @@ use tracing::debug;
 pub(super) struct StaticFiles {
     static_files: Vec<StaticFile>,
     hash_map: HashMap<String, String>,
+    no_html_extension: bool,
 }
 
 enum StaticFile {
@@ -41,6 +42,7 @@ impl StaticFiles {
         let mut this = StaticFiles {
             hash_map: HashMap::new(),
             static_files,
+            no_html_extension: html_config.no_html_extension,
         };
 
         this.add_builtin("book.js", &theme.js);
@@ -257,7 +259,11 @@ impl StaticFiles {
             }
         }
         let hash_map = self.hash_map;
-        Ok(ResourceHelper { hash_map })
+        let no_html_extension = self.no_html_extension;
+        Ok(ResourceHelper {
+            hash_map,
+            no_html_extension,
+        })
     }
 }
 

--- a/crates/mdbook-html/src/utils.rs
+++ b/crates/mdbook-html/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utilities for processing HTML.
 
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 
 /// Utility function to normalize path elements like `..`.
@@ -99,6 +100,74 @@ pub(crate) fn id_from_content(content: &str) -> String {
         .collect()
 }
 
+/// Converts a logical HTML path to a clean URL link string.
+///
+/// Index pages have their `index.html` stripped, keeping a trailing slash.
+/// Non-index pages have their `.html` extension replaced by `/`.
+///
+/// # Examples
+///
+/// - `foo/bar.html` → `"foo/bar/"`
+/// - `foo/index.html` → `"foo/"`
+/// - `index.html` → `"./"`
+/// - `bar.html` → `"bar/"`
+pub(crate) fn clean_url_link_path(logical_html_path: &Path) -> String {
+    let is_index = logical_html_path.file_stem() == Some(OsStr::new("index"));
+
+    if is_index {
+        match logical_html_path.parent() {
+            Some(parent) if parent.as_os_str().is_empty() => "./".to_string(),
+            Some(parent) => format!("{}/", parent.to_url_path()),
+            None => "./".to_string(),
+        }
+    } else {
+        let without_ext = logical_html_path.with_extension("");
+        format!("{}/", without_ext.to_url_path())
+    }
+}
+
+/// Converts a logical HTML path to the physical output path in clean URL mode.
+///
+/// Index pages are left unchanged. Non-index pages are moved into a
+/// subdirectory so the URL has no extension.
+///
+/// # Examples
+///
+/// - `foo/bar.html` → `PathBuf::from("foo/bar/index.html")`
+/// - `foo/index.html` → `PathBuf::from("foo/index.html")`
+/// - `index.html` → `PathBuf::from("index.html")`
+/// - `bar.html` → `PathBuf::from("bar/index.html")`
+pub(crate) fn clean_url_output_path(logical_html_path: &Path) -> PathBuf {
+    let is_index = logical_html_path.file_stem() == Some(OsStr::new("index"));
+
+    if is_index {
+        logical_html_path.to_path_buf()
+    } else {
+        logical_html_path.with_extension("").join("index.html")
+    }
+}
+
+/// Computes the path-to-root for a source `.md` file in clean URL mode.
+///
+/// Wraps [`mdbook_core::utils::fs::path_to_root`], adding one extra `../`
+/// for non-index files because those pages are served from a subdirectory.
+///
+/// # Examples
+///
+/// - `foo/bar.md` → `"../../"`
+/// - `foo/index.md` → `"../"`
+/// - `index.md` → `""`
+/// - `bar.md` → `"../"`
+/// - `a/b/c.md` → `"../../../"`
+pub(crate) fn clean_url_path_to_root(source_md_path: &Path) -> String {
+    let is_index = source_md_path.file_stem() == Some(OsStr::new("index"));
+    let mut root = mdbook_core::utils::fs::path_to_root(source_md_path);
+    if !is_index {
+        root.push_str("../");
+    }
+    root
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +200,112 @@ mod tests {
         assert_eq!(id_from_content(""), "");
         assert_eq!(id_from_content("中文標題 CJK title"), "中文標題-cjk-title");
         assert_eq!(id_from_content("Über"), "über");
+    }
+
+    #[test]
+    fn clean_url_link_path_root_index() {
+        assert_eq!(clean_url_link_path(Path::new("index.html")), "./");
+    }
+
+    #[test]
+    fn clean_url_link_path_root_non_index() {
+        assert_eq!(clean_url_link_path(Path::new("bar.html")), "bar/");
+    }
+
+    #[test]
+    fn clean_url_link_path_nested_index() {
+        assert_eq!(clean_url_link_path(Path::new("foo/index.html")), "foo/");
+    }
+
+    #[test]
+    fn clean_url_link_path_nested_non_index() {
+        assert_eq!(clean_url_link_path(Path::new("foo/bar.html")), "foo/bar/");
+    }
+
+    #[test]
+    fn clean_url_link_path_deeply_nested() {
+        assert_eq!(clean_url_link_path(Path::new("a/b/c.html")), "a/b/c/");
+        assert_eq!(clean_url_link_path(Path::new("a/b/index.html")), "a/b/");
+    }
+
+    #[test]
+    fn clean_url_output_path_root_index() {
+        assert_eq!(
+            clean_url_output_path(Path::new("index.html")),
+            PathBuf::from("index.html")
+        );
+    }
+
+    #[test]
+    fn clean_url_output_path_root_non_index() {
+        assert_eq!(
+            clean_url_output_path(Path::new("bar.html")),
+            PathBuf::from("bar/index.html")
+        );
+    }
+
+    #[test]
+    fn clean_url_output_path_nested_index() {
+        assert_eq!(
+            clean_url_output_path(Path::new("foo/index.html")),
+            PathBuf::from("foo/index.html")
+        );
+    }
+
+    #[test]
+    fn clean_url_output_path_nested_non_index() {
+        assert_eq!(
+            clean_url_output_path(Path::new("foo/bar.html")),
+            PathBuf::from("foo/bar/index.html")
+        );
+    }
+
+    #[test]
+    fn clean_url_output_path_deeply_nested() {
+        assert_eq!(
+            clean_url_output_path(Path::new("a/b/c.html")),
+            PathBuf::from("a/b/c/index.html")
+        );
+        assert_eq!(
+            clean_url_output_path(Path::new("a/b/index.html")),
+            PathBuf::from("a/b/index.html")
+        );
+    }
+
+    #[test]
+    fn clean_url_path_to_root_root_index() {
+        // index.md at root: path_to_root = "", no extra since index
+        assert_eq!(clean_url_path_to_root(Path::new("index.md")), "");
+    }
+
+    #[test]
+    fn clean_url_path_to_root_root_non_index() {
+        // bar.md at root: path_to_root = "", +"../" since non-index
+        assert_eq!(clean_url_path_to_root(Path::new("bar.md")), "../");
+    }
+
+    #[test]
+    fn clean_url_path_to_root_nested_index() {
+        // foo/index.md: path_to_root = "../", no extra since index
+        assert_eq!(clean_url_path_to_root(Path::new("foo/index.md")), "../");
+    }
+
+    #[test]
+    fn clean_url_path_to_root_nested_non_index() {
+        // foo/bar.md: path_to_root = "../", +"../" since non-index
+        assert_eq!(clean_url_path_to_root(Path::new("foo/bar.md")), "../../");
+    }
+
+    #[test]
+    fn clean_url_path_to_root_deeply_nested() {
+        // a/b/c.md: path_to_root(parent=a/b) = "../../", +"../" since non-index
+        assert_eq!(clean_url_path_to_root(Path::new("a/b/c.md")), "../../../");
+        // a/b/index.md: path_to_root(parent=a/b) = "../../", no extra since index
+        assert_eq!(clean_url_path_to_root(Path::new("a/b/index.md")), "../../");
+        // a/b/c/d.md: path_to_root(parent=a/b/c) = "../../../", +"../" since non-index
+        assert_eq!(
+            clean_url_path_to_root(Path::new("a/b/c/d.md")),
+            "../../../../"
+        );
     }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,12 +4,25 @@ import { defineConfig, globalIgnores } from "eslint/config";
 const handlebarsPreprocessor = {
     processors: {
         "handlebars-js": {
+            meta: {
+                name: 'handlebars-js',
+                version: '1.0.0',
+            },
             preprocess(text, filename) {
                 if (filename.endsWith('.hbs')) {
-                    // This is a really dumb strip, which will likely not work
-                    // for more complex expressions, but for our use is good
-                    // enough for now.
-                    return [text.replace(/\{\{.*?\}\}/g, '')];
+                    // Handle block expressions: {{#if ...}}...{{else}}...{{/if}}
+                    // We keep the first branch and remove the else branch
+                    let result = text;
+                    // Remove {{else}}...{{/if}} (the else branch)
+                    result = result.replace(/\{\{else\}\}[\s\S]*?\{\{\/if\}\}/g, '');
+                    // Remove remaining {{#if ...}} and {{/if}} tags
+                    result = result.replace(/\{\{#if[^}]*\}\}/g, '');
+                    result = result.replace(/\{\{\/if\}\}/g, '');
+                    // Remove simple Handlebars tags
+                    result = result.replace(/\{\{[^}]*\}\}/g, '');
+                    // Strip trailing whitespace from lines that only had handlebars tags
+                    result = result.replace(/[ \t]+$/gm, '');
+                    return [result];
                 }
                 return [text];
             },

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -111,6 +111,7 @@ site-url = "/example-book/"
 cname = "myproject.rs"
 input-404 = "not-found.md"
 sidebar-header-nav = true
+no-html-extension = false
 ```
 
 The following configuration options are available:
@@ -170,6 +171,13 @@ The following configuration options are available:
   Static CSS and JS files can reference each other using `{{ resource "filename" }}` directives.
   Defaults to `true`.
 - **sidebar-header-nav:** If `true`, the sidebar will contain navigation for headers on the current page. Default is `true`.
+- **no-html-extension:** When set to `true`, generates clean URLs without `.html` extensions.
+  All pages are written to directory-based paths (e.g., `chapter/index.html` instead of `chapter.html`).
+  Special pages are placed in `_print/`, `_toc/`, and `_404/` directories.
+  All internal links use trailing-slash format (`chapter/` instead of `chapter.html`).
+  Works with all major static hosting providers (GitHub Pages, Netlify, Cloudflare Pages) and the built-in `mdbook serve` command.
+  **Note:** Chapter paths starting with `_print`, `_toc`, or `_404` will cause a build error.
+  Defaults to `false`.
 
 [custom domain]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -342,3 +342,23 @@ preprocessor saw custom config
         // No HTML output
         .check_file_list("book", str![[""]]);
 }
+
+// Test that no-html-extension config can be parsed from TOML.
+#[test]
+fn config_no_html_extension_true() {
+    let mut test = BookTest::init(|_| {});
+    test.change_file("book.toml", "[output.html]\nno-html-extension = true");
+    let book = test.load_book();
+    let html_config = book.config.html_config().expect("html config should exist");
+    assert_eq!(html_config.no_html_extension, true);
+}
+
+// Test that no-html-extension defaults to false when not specified.
+#[test]
+fn config_no_html_extension_default() {
+    let mut test = BookTest::init(|_| {});
+    test.change_file("book.toml", "[output.html]\n");
+    let book = test.load_book();
+    let html_config = book.config.html_config().expect("html config should exist");
+    assert_eq!(html_config.no_html_extension, false);
+}

--- a/tests/testsuite/rendering.rs
+++ b/tests/testsuite/rendering.rs
@@ -322,3 +322,75 @@ HTML tags must be closed before exiting a markdown element.
             str![[r##"<h3 id="option"><a class="header" href="#option">Option<t></t></a></h3>"##]],
         );
 }
+
+// Checks that the `no-html-extension = true` setting produces directory-based output.
+#[test]
+fn clean_urls_produces_directory_based_output() {
+    let mut test = BookTest::from_dir("rendering/clean_urls");
+    test.build();
+
+    // A. File Structure — verify directory-based index.html files exist.
+    test.check_file_contains("book/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/intro/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/guide/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/guide/getting-started/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/reference/api/endpoints/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/_print/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/_toc/index.html", "<!DOCTYPE HTML");
+    test.check_file_contains("book/_404/index.html", "<!DOCTYPE HTML");
+
+    // Verify flat .html files do NOT exist.
+    assert!(!test.dir.join("book/intro.html").exists());
+    assert!(!test.dir.join("book/guide/getting-started.html").exists());
+    assert!(!test.dir.join("book/print.html").exists());
+    assert!(!test.dir.join("book/toc.html").exists());
+    assert!(!test.dir.join("book/404.html").exists());
+
+    // B. TOC Link Verification — clean URL hrefs in the TOC page.
+    test.check_file_contains("book/_toc/index.html", "href=\"guide/getting-started/\"");
+    test.check_file_contains("book/_toc/index.html", "href=\"intro/\"");
+
+    // C. path_to_root Verification.
+    // Root-level chapter: intro/ needs ../
+    test.check_file_contains("book/intro/index.html", "path_to_root = \"../\"");
+    // Nested chapter: guide/getting-started/ needs ../../
+    test.check_file_contains(
+        "book/guide/getting-started/index.html",
+        "path_to_root = \"../../\"",
+    );
+
+    // D. Print button and TOC iframe use clean URLs.
+    test.check_file_contains("book/intro/index.html", "href=\"../_print/\"");
+    test.check_file_contains("book/intro/index.html", "src=\"../_toc/\"");
+}
+
+// Checks that books without `no-html-extension` still produce flat .html files.
+#[test]
+fn clean_urls_backward_compatible_when_disabled() {
+    let mut test = BookTest::init(|_| {});
+    test.build();
+
+    // Default behavior: flat .html files should exist.
+    assert!(test.dir.join("book/chapter_1.html").exists());
+    // Directory-based file should NOT exist.
+    assert!(!test.dir.join("book/chapter_1/index.html").exists());
+    // print.html and 404.html should be flat.
+    assert!(test.dir.join("book/print.html").exists());
+    assert!(!test.dir.join("book/print/index.html").exists());
+}
+
+// Checks that clean URLs error when a chapter conflicts with a reserved directory.
+#[test]
+fn clean_urls_errors_on_reserved_path_conflict() {
+    BookTest::from_dir("rendering/clean_urls_conflict")
+        .run("build", |cmd| {
+            cmd.expect_failure();
+            cmd.expect_stderr(str![[r#"
+ INFO Book building has started
+ INFO Running the html backend
+ERROR Rendering failed
+[TAB]Caused by: Chapter path '_print/guide.md' conflicts with reserved special page directory '_print/'. Please rename the chapter to avoid paths starting with '_print', '_toc', or '_404'.
+
+"#]]);
+        });
+}

--- a/tests/testsuite/rendering/clean_urls/book.toml
+++ b/tests/testsuite/rendering/clean_urls/book.toml
@@ -1,0 +1,5 @@
+[book]
+title = "Clean URLs Test"
+
+[output.html]
+no-html-extension = true

--- a/tests/testsuite/rendering/clean_urls/src/SUMMARY.md
+++ b/tests/testsuite/rendering/clean_urls/src/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+
+- [Introduction](intro.md)
+- [Guide](guide/index.md)
+  - [Getting Started](guide/getting-started.md)
+  - [Advanced](guide/advanced.md)
+- [Reference](reference/index.md)
+  - [API](reference/api/index.md)
+    - [Endpoints](reference/api/endpoints.md)

--- a/tests/testsuite/rendering/clean_urls/src/guide/advanced.md
+++ b/tests/testsuite/rendering/clean_urls/src/guide/advanced.md
@@ -1,0 +1,15 @@
+# Advanced Topics
+
+## Deep Dive
+
+This chapter covers advanced topics and techniques.
+
+### Performance
+
+Learn about optimization strategies.
+
+### Best Practices
+
+Follow these best practices for optimal results.
+
+See [Getting Started](getting-started.md) for basics or the [Guide Overview](index.md).

--- a/tests/testsuite/rendering/clean_urls/src/guide/getting-started.md
+++ b/tests/testsuite/rendering/clean_urls/src/guide/getting-started.md
@@ -1,0 +1,15 @@
+# Getting Started
+
+## First Steps
+
+This chapter covers the basics of getting started.
+
+### Installation
+
+Follow the setup instructions carefully.
+
+### Configuration
+
+Configure your environment properly.
+
+See [Advanced Topics](advanced.md) for more details, or go back to [Introduction](../intro.md).

--- a/tests/testsuite/rendering/clean_urls/src/guide/index.md
+++ b/tests/testsuite/rendering/clean_urls/src/guide/index.md
@@ -1,0 +1,9 @@
+# Guide
+
+## Overview
+
+This is the guide index page. It demonstrates that index pages don't double-nest.
+
+See [Getting Started](getting-started.md) or [Advanced](advanced.md) topics.
+
+Also check the [Introduction](../intro.md).

--- a/tests/testsuite/rendering/clean_urls/src/intro.md
+++ b/tests/testsuite/rendering/clean_urls/src/intro.md
@@ -1,0 +1,11 @@
+# Introduction
+
+## Welcome
+
+This is the introduction chapter for testing clean URLs.
+
+See the [Getting Started](guide/getting-started.md) guide for more information.
+
+## Overview
+
+This test book demonstrates clean URL generation with multiple nesting levels.

--- a/tests/testsuite/rendering/clean_urls/src/reference/api/endpoints.md
+++ b/tests/testsuite/rendering/clean_urls/src/reference/api/endpoints.md
@@ -1,0 +1,17 @@
+# API Endpoints
+
+## Available Endpoints
+
+### GET /users
+
+Retrieve user information.
+
+### POST /users
+
+Create a new user.
+
+### GET /users/{id}
+
+Retrieve a specific user by ID.
+
+See the [API Overview](index.md) or [Reference](../index.md) for more information.

--- a/tests/testsuite/rendering/clean_urls/src/reference/api/index.md
+++ b/tests/testsuite/rendering/clean_urls/src/reference/api/index.md
@@ -1,0 +1,7 @@
+# API Documentation
+
+## Overview
+
+This is the API documentation index.
+
+See [Endpoints](endpoints.md) for the complete endpoint reference.

--- a/tests/testsuite/rendering/clean_urls/src/reference/index.md
+++ b/tests/testsuite/rendering/clean_urls/src/reference/index.md
@@ -1,0 +1,7 @@
+# Reference
+
+## Documentation
+
+This is the reference section index.
+
+Explore the [API Documentation](api/index.md) for detailed information.

--- a/tests/testsuite/rendering/clean_urls_conflict/book.toml
+++ b/tests/testsuite/rendering/clean_urls_conflict/book.toml
@@ -1,0 +1,5 @@
+[book]
+title = "Conflict Test"
+
+[output.html]
+no-html-extension = true

--- a/tests/testsuite/rendering/clean_urls_conflict/src/SUMMARY.md
+++ b/tests/testsuite/rendering/clean_urls_conflict/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Intro](intro.md)
+- [Print Guide](_print/guide.md)

--- a/tests/testsuite/rendering/clean_urls_conflict/src/_print/guide.md
+++ b/tests/testsuite/rendering/clean_urls_conflict/src/_print/guide.md
@@ -1,0 +1,3 @@
+# Print Guide
+
+This would conflict with the reserved _print directory.

--- a/tests/testsuite/rendering/clean_urls_conflict/src/intro.md
+++ b/tests/testsuite/rendering/clean_urls_conflict/src/intro.md
@@ -1,0 +1,3 @@
+# Intro
+
+This is the intro.


### PR DESCRIPTION
Fixes #1251

```toml
[output.html]
no-html-extension=true
```

```md
**no-html-extension:** When set to `true`, generates clean URLs without `.html` extensions. All pages are written to directory-based paths (e.g., `chapter/index.html` instead of `chapter.html`).

Special pages are placed in `_print/`, `_toc/`, and `_404/` directories.

All internal links use trailing-slash format (`chapter/` instead of `chapter.html`).

Works with all major static hosting providers (GitHub Pages, Netlify, Cloudflare Pages) and the built-in `mdbook serve` command.

**Note:** Chapter paths starting with `_print`, `_toc`, or `_404` will cause a build error.

Defaults to `false`.
```

Vaguely related PRs: https://github.com/rust-lang/mdBook/pull/2570, https://github.com/rust-lang/mdBook/pull/2993, https://github.com/rust-lang/mdBook/pull/3028, https://github.com/rust-lang/mdBook/issues/3034, https://github.com/rust-lang/mdBook/pull/3038