### PR TITLE
feat(core): expose `init_logger` publicly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,6 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "walkdir",
 ]
 
@@ -1087,6 +1086,7 @@ dependencies = [
  "tempfile",
  "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ mdbook-driver.workspace = true
 mdbook-html.workspace = true
 opener.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 
 # Watch feature
 ignore = { workspace = true, optional = true }

--- a/crates/mdbook-core/Cargo.toml
+++ b/crates/mdbook-core/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/mdbook-core/src/utils/mod.rs
+++ b/crates/mdbook-core/src/utils/mod.rs
@@ -8,6 +8,49 @@ pub mod fs;
 mod html;
 mod toml_ext;
 
+/// Initialize the logger with mdBook's default configuration.
+///
+/// This function sets up a tracing subscriber that:
+/// - Uses the `MDBOOK_LOG` environment variable for filtering (or defaults to INFO level)
+/// - Silences noisy dependencies (handlebars, html5ever) unless explicitly requested
+/// - Writes to stderr
+/// - Shows the target only when MDBOOK_LOG is set
+///
+/// This is useful for preprocessor authors who want consistent logging
+/// with mdBook's internal logging.
+pub fn init_logger() {
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_env_var("MDBOOK_LOG")
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
+    let log_env = std::env::var("MDBOOK_LOG");
+    // Silence some particularly noisy dependencies unless the user
+    // specifically asks for them.
+    let silence_unless_specified = |filter: tracing_subscriber::EnvFilter, target| {
+        if !log_env.as_ref().map_or(false, |s| {
+            s.split(',').any(|directive| directive.starts_with(target))
+        }) {
+            filter.add_directive(format!("{target}=warn").parse().unwrap())
+        } else {
+            filter
+        }
+    };
+    let filter = silence_unless_specified(filter, "handlebars");
+    let filter = silence_unless_specified(filter, "html5ever");
+
+    // Don't show the target by default, since it generally isn't useful
+    // unless you are overriding the level.
+    let with_target = log_env.is_ok();
+
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .with_target(with_target)
+        .init();
+}
+
 pub(crate) use self::toml_ext::TomlExt;
 
 pub use self::html::{escape_html, escape_html_attribute};

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod cmd;
 const VERSION: &str = concat!("v", clap::crate_version!());
 
 fn main() {
-    init_logger();
+    utils::init_logger();
 
     let command = create_clap_command();
 
@@ -88,39 +88,6 @@ fn create_clap_command() -> Command {
     let app = app.subcommand(cmd::serve::make_subcommand());
 
     app
-}
-
-fn init_logger() {
-    let filter = tracing_subscriber::EnvFilter::builder()
-        .with_env_var("MDBOOK_LOG")
-        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env_lossy();
-    let log_env = std::env::var("MDBOOK_LOG");
-    // Silence some particularly noisy dependencies unless the user
-    // specifically asks for them.
-    let silence_unless_specified = |filter: tracing_subscriber::EnvFilter, target| {
-        if !log_env.as_ref().map_or(false, |s| {
-            s.split(',').any(|directive| directive.starts_with(target))
-        }) {
-            filter.add_directive(format!("{target}=warn").parse().unwrap())
-        } else {
-            filter
-        }
-    };
-    let filter = silence_unless_specified(filter, "handlebars");
-    let filter = silence_unless_specified(filter, "html5ever");
-
-    // Don't show the target by default, since it generally isn't useful
-    // unless you are overriding the level.
-    let with_target = log_env.is_ok();
-
-    tracing_subscriber::fmt()
-        .without_time()
-        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
-        .with_writer(std::io::stderr)
-        .with_env_filter(filter)
-        .with_target(with_target)
-        .init();
 }
 
 fn get_book_dir(args: &ArgMatches) -> PathBuf {


### PR DESCRIPTION
Preprocessor authors can now call `mdbook_core::utils::init_logger()` to use mdBook's logger configuration (`MDBOOK_LOG` env var, `INFO` default, silenced noisy deps like handlebars/html5ever).

Closes #2049