### PR TITLE
Add collapse all / expand all button for sidebar chapters

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -94,6 +94,9 @@ html.sidebar-visible #mdbook-menu-bar {
 html:not(.js) .left-buttons button {
     display: none;
 }
+#mdbook-sidebar-toggle-anchor:not(:checked) ~ .page-wrapper #mdbook-collapse-all {
+    display: none;
+}
 
 .menu-title {
     display: inline-block;

--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -143,6 +143,10 @@
                 <div id="mdbook-menu-bar-hover-placeholder"></div>
                 <div id="mdbook-menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
+                        {{#if fold_enable}}
+                        <button id="mdbook-collapse-all" class="icon-button" type="button" title="Collapse/Expand all chapters" aria-label="Collapse/Expand all chapters">
+                        </button>
+                        {{/if}}
                         <label id="mdbook-sidebar-toggle" class="icon-button" for="mdbook-sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
                             {{fa "solid" "bars"}}
                         </label>
@@ -274,6 +278,10 @@
         <template id=fa-copy>{{fa "regular" "copy"}}</template>
         <template id=fa-play>{{fa "solid" "play"}}</template>
         <template id=fa-clock-rotate-left>{{fa "solid" "clock-rotate-left"}}</template>
+        {{#if fold_enable}}
+        <template id=fa-square-minus>{{fa "regular" "square-minus"}}</template>
+        <template id=fa-square-plus>{{fa "regular" "square-plus"}}</template>
+        {{/if}}
 
         {{#if live_reload_endpoint}}
         <!-- Livereload script (if served using the cli tool) -->

--- a/crates/mdbook-html/front-end/templates/toc.js.hbs
+++ b/crates/mdbook-html/front-end/templates/toc.js.hbs
@@ -72,27 +72,34 @@ class MDBookSidebarScrollbox extends HTMLElement {
         Array.from(sidebarAnchorToggles).forEach(el => {
             el.addEventListener('click', toggleSection);
         });
-        {{#if fold_enable}}
+{{#if fold_enable}}
         // Collapse All / Expand All button
-        // Deferred to DOMContentLoaded because the button and icon <template>
-        // elements appear later in the HTML body than this custom element.
+        // Deferred to DOMContentLoaded because the button and icon
+        // <template> elements appear later in the HTML body.
         const scrollbox = this;
-        const toggles = sidebarAnchorToggles;
         document.addEventListener('DOMContentLoaded', () => {
-            const collapseAllBtn = document.getElementById('mdbook-collapse-all');
-            const collapseIconHTML = document.getElementById('fa-square-minus').innerHTML;
-            const expandIconHTML = document.getElementById('fa-square-plus').innerHTML;
+            const collapseAllBtn =
+                document.getElementById('mdbook-collapse-all');
+            const collapseIconHTML =
+                document.getElementById('fa-square-minus').innerHTML;
+            const expandIconHTML =
+                document.getElementById('fa-square-plus').innerHTML;
             function getFoldableItems() {
-                return Array.from(scrollbox.querySelectorAll('li.chapter-item, li.header-item')).filter(li => li.querySelector(':scope > ol.section'));
+                const selector = 'li.chapter-item, li.header-item';
+                return Array.from(scrollbox.querySelectorAll(selector))
+                    .filter(li => li.querySelector(':scope > ol.section'));
             }
             function updateCollapseAllButton() {
                 const foldable = getFoldableItems();
-                const anyExpanded = foldable.some(li => li.classList.contains('expanded'));
-                collapseAllBtn.innerHTML = anyExpanded ? collapseIconHTML : expandIconHTML;
+                const anyExpanded = foldable.some(
+                    li => li.classList.contains('expanded'));
+                collapseAllBtn.innerHTML = anyExpanded
+                    ? collapseIconHTML : expandIconHTML;
             }
             collapseAllBtn.addEventListener('click', () => {
                 const foldable = getFoldableItems();
-                const anyExpanded = foldable.some(li => li.classList.contains('expanded'));
+                const anyExpanded = foldable.some(
+                    li => li.classList.contains('expanded'));
                 foldable.forEach(li => {
                     if (anyExpanded) {
                         li.classList.remove('expanded');
@@ -103,12 +110,16 @@ class MDBookSidebarScrollbox extends HTMLElement {
                 updateCollapseAllButton();
             });
             updateCollapseAllButton();
-            // Hook all fold toggles (including header-nav ones added dynamically)
-            Array.from(scrollbox.querySelectorAll('.chapter-fold-toggle')).forEach(el => {
-                el.addEventListener('click', () => setTimeout(updateCollapseAllButton, 0));
+            // Hook all fold toggles (including dynamically added ones)
+            const allToggles =
+                scrollbox.querySelectorAll('.chapter-fold-toggle');
+            Array.from(allToggles).forEach(el => {
+                el.addEventListener('click', () => {
+                    setTimeout(updateCollapseAllButton, 0);
+                });
             });
         });
-        {{/if}}
+{{/if}}
     }
 }
 window.customElements.define('mdbook-sidebar-scrollbox', MDBookSidebarScrollbox);

--- a/crates/mdbook-html/front-end/templates/toc.js.hbs
+++ b/crates/mdbook-html/front-end/templates/toc.js.hbs
@@ -72,6 +72,43 @@ class MDBookSidebarScrollbox extends HTMLElement {
         Array.from(sidebarAnchorToggles).forEach(el => {
             el.addEventListener('click', toggleSection);
         });
+        {{#if fold_enable}}
+        // Collapse All / Expand All button
+        // Deferred to DOMContentLoaded because the button and icon <template>
+        // elements appear later in the HTML body than this custom element.
+        const scrollbox = this;
+        const toggles = sidebarAnchorToggles;
+        document.addEventListener('DOMContentLoaded', () => {
+            const collapseAllBtn = document.getElementById('mdbook-collapse-all');
+            const collapseIconHTML = document.getElementById('fa-square-minus').innerHTML;
+            const expandIconHTML = document.getElementById('fa-square-plus').innerHTML;
+            function getFoldableItems() {
+                return Array.from(scrollbox.querySelectorAll('li.chapter-item, li.header-item')).filter(li => li.querySelector(':scope > ol.section'));
+            }
+            function updateCollapseAllButton() {
+                const foldable = getFoldableItems();
+                const anyExpanded = foldable.some(li => li.classList.contains('expanded'));
+                collapseAllBtn.innerHTML = anyExpanded ? collapseIconHTML : expandIconHTML;
+            }
+            collapseAllBtn.addEventListener('click', () => {
+                const foldable = getFoldableItems();
+                const anyExpanded = foldable.some(li => li.classList.contains('expanded'));
+                foldable.forEach(li => {
+                    if (anyExpanded) {
+                        li.classList.remove('expanded');
+                    } else {
+                        li.classList.add('expanded');
+                    }
+                });
+                updateCollapseAllButton();
+            });
+            updateCollapseAllButton();
+            // Hook all fold toggles (including header-nav ones added dynamically)
+            Array.from(scrollbox.querySelectorAll('.chapter-fold-toggle')).forEach(el => {
+                el.addEventListener('click', () => setTimeout(updateCollapseAllButton, 0));
+            });
+        });
+        {{/if}}
     }
 }
 window.customElements.define('mdbook-sidebar-scrollbox', MDBookSidebarScrollbox);


### PR DESCRIPTION
## Summary

- Adds a **Collapse All / Expand All** button to the menu bar (left of the sidebar toggle) that collapses or expands all foldable chapters and "On This Page" heading groups at once
- Only appears when `[output.html.fold] enable = true`
- Automatically hidden when the sidebar is collapsed
- Icon toggles between ⊟ (collapse) and ⊞ (expand) based on current state
- Syncs icon state when individual fold toggles are clicked

Closes #3050

## Screenshots

### Sidebar expanded — all chapters visible (collapse icon shown)
![Expanded state](https://raw.githubusercontent.com/tupe12334/mdBook/pr-3051-assets/expanded.png)

### After clicking Collapse All — all chapters folded (expand icon shown)
![Collapsed state](https://raw.githubusercontent.com/tupe12334/mdBook/pr-3051-assets/collapsed.png)

### Sidebar hidden — button is not visible
![Sidebar hidden](https://raw.githubusercontent.com/tupe12334/mdBook/pr-3051-assets/sidebar-hidden.png)

## Files changed

| File | Change |
|------|--------|
| `index.hbs` | Added button element in menu bar + icon `<template>` elements |
| `toc.js.hbs` | Added collapse/expand click handler + state sync logic |
| `chrome.css` | Added CSS rule to hide button when sidebar is collapsed |

## Test plan

- [x] Button appears in menu bar when `fold.enable = true`
- [x] Button does NOT appear when `fold.enable = false`
- [x] Clicking collapse icon folds all chapters and "On This Page" groups
- [x] Clicking expand icon expands all foldable items
- [x] Icon syncs when individual fold toggles are clicked
- [x] Button hidden when sidebar is collapsed
- [x] All CI checks pass (15/15)