### PR TITLE
fix: prevent '?' shortcut from intercepting input in code editors

### DIFF
--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -706,10 +706,20 @@ aria-label="Show hidden lines"></button>';
 
         // Usually needs the Shift key to be pressed
         switch (e.key) {
-        case '?':
+        case '?': {
+            const active = document.activeElement;
+            if (active &&
+                (
+                    active.tagName === 'INPUT' ||
+                    active.tagName === 'TEXTAREA' ||
+                    active.isContentEditable
+                )) {
+                return;
+            }
             e.preventDefault();
             showHelp();
             break;
+        }
         }
 
         // Rest of the keys are only active when the Shift key is not pressed


### PR DESCRIPTION
This adds a guard to the global keydown listener in book.js so that the '?' shortcut does not intercept keypresses when the user is focused inside an input, textarea, or Ace editor block.

Fixes #3064 and https://github.com/rust-lang/rust-by-example/issues/1984