### PR TITLE
Fix typo in searcher.js comment

### DIFF
--- a/crates/mdbook-html/front-end/searcher/searcher.js
+++ b/crates/mdbook-html/front-end/searcher/searcher.js
@@ -142,7 +142,7 @@ window.search = window.search || {};
         const teaser = makeTeaser(escapeHTML(result.doc.body), searchterms);
         teaser_count++;
 
-        // The ?URL_MARK_PARAM= parameter belongs inbetween the page and the #heading-anchor
+        // The ?URL_MARK_PARAM= parameter belongs in between the page and the #heading-anchor
         const url = doc_urls[result.ref].split('#');
         if (url.length === 1) { // no anchor found
             url.push('');


### PR DESCRIPTION
## Purpose
Fix a typo in the search result comment by changing `inbetween` to `in between` in `crates/mdbook-html/front-end/searcher/searcher.js`.

This is a single-file comment-only change with no behavior impact.

## References
- Closes #3069
- N/A for tests; comment-only change
