### PR TITLE
Add vim key bindings for navigation

### DIFF
--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -718,6 +718,7 @@ aria-label="Show hidden lines"></button>';
         }
 
         switch (e.key) {
+        case 'l':
         case 'ArrowRight':
             e.preventDefault();
             if (html.dir === 'rtl') {
@@ -726,6 +727,7 @@ aria-label="Show hidden lines"></button>';
                 next();
             }
             break;
+        case 'h':
         case 'ArrowLeft':
             e.preventDefault();
             if (html.dir === 'rtl') {
@@ -734,6 +736,22 @@ aria-label="Show hidden lines"></button>';
                 prev();
             }
             break;
+        case 'j':
+          e.preventDefault();
+          window.scrollBy({ top: 80, behavior: 'smooth' });
+          break;
+        case 'k':
+          e.preventDefault();
+          window.scrollBy({ top: -80, behavior: 'smooth' });
+          break;
+        case 'd':
+          e.preventDefault();
+          window.scrollBy({ top: window.innerHeight, behavior: 'smooth' });
+          break;
+        case 'u':
+          e.preventDefault();
+          window.scrollBy({ top: -window.innerHeight, behavior: 'smooth' });
+          break;
         }
     });
 })();

--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -67,7 +67,8 @@
         <div id="mdbook-help-popup">
             <h2 class="mdbook-help-title">Keyboard shortcuts</h2>
             <div>
-                <p>Press <kbd>←</kbd> or <kbd>→</kbd> to navigate between chapters</p>
+                <p>Press <kbd>←</kbd>/<kbd>→</kbd> or <kbd>h</kbd>/<kbd>l</kbd> to navigate between chapters</p>
+                <p>Press <kbd>j</kbd>/<kbd>k</kbd> or <kbd>d</kbd>/<kbd>u</kbd> to scroll the page up and down</p>
                 {{#if search_enabled}}
                 <p>Press <kbd>S</kbd> or <kbd>/</kbd> to search in the book</p>
                 {{/if}}

--- a/guide/src/guide/reading.md
+++ b/guide/src/guide/reading.md
@@ -23,6 +23,8 @@ The **arrow buttons** at the bottom of the page can be used to navigate to the p
 
 The **left and right arrow keys** on the keyboard can be used to navigate to the previous or the next chapter.
 
+Additionally, Vim-style key bindings (<kbd>H</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, <kbd>L</kbd>, <kbd>D</kbd> and <kbd>U</kbd>) can be used for navigation.
+
 ## Top menu bar
 
 The menu bar at the top of the page provides some icons for interacting with the book.


### PR DESCRIPTION
This change adds Vim-style key bindings for easier navigation without leaving the home row.

Implemented are:
- `h` and  `l` for going to the previous and next page
- `j` and `k` for scrolling up and down
- `d` and `u` for scrolling up and down by one page

(Note: This is my first ever PR, please tell me if I did something wrong)

closes #2936 