### PR TITLE
Fix: Remove `?highlight=` from URL when highlights are dismissed via clicking

### DIFF
--- a/crates/mdbook-html/front-end/searcher/searcher.js
+++ b/crates/mdbook-html/front-end/searcher/searcher.js
@@ -341,6 +341,11 @@ window.search = window.search || {};
                         marker.unmark();
                     }, 300);
                 }
+                // also removes the `?URL_MARK_PARAM=` search param so that
+                // in-page navigation doesn't make highlights unexpectedly appear again
+                const url = new URL(window.location.href);
+                url.searchParams.delete(URL_MARK_PARAM);
+                history.replaceState(null, '', url);
             };
 
             for (let i = 0; i < markers.length; i++) {

--- a/crates/mdbook-html/front-end/searcher/searcher.js
+++ b/crates/mdbook-html/front-end/searcher/searcher.js
@@ -343,9 +343,7 @@ window.search = window.search || {};
                 }
                 // also removes the `?URL_MARK_PARAM=` search param so that
                 // in-page navigation doesn't make highlights unexpectedly appear again
-                const url = new URL(window.location.href);
-                url.searchParams.delete(URL_MARK_PARAM);
-                history.replaceState(null, '', url);
+                setSearchUrlParameters('', 'replace');
             };
 
             for (let i = 0; i < markers.length; i++) {

--- a/tests/gui/search.goml
+++ b/tests/gui/search.goml
@@ -74,3 +74,24 @@ assert: "#mdbook-searchresults"
 // And now we press `Escape` to close everything.
 press-key: 'Escape'
 wait-for-css: ("#mdbook-search-wrapper", {"display": "none"})
+
+// Search result links should have a `?highlight=` query param, which will highlight
+// the search term when we navigate to the destination page.
+go-to: |DOC_PATH| + "search/index.html?search=kale"
+assert: '[href*="highlight=kale"]'
+
+// On navigation, text on the destination page that matches the search term should be highlighted.
+go-to: |DOC_PATH| + "search/index.html?highlight=kale"
+wait-for: '[data-markjs="true"]'
+assert-text: ('[data-markjs="true"]', "kale", ALL)
+
+// Clicking on any of the highlights should dismiss them.
+click: '[data-markjs="true"]'
+assert-false: '[data-markjs="true"]'
+// The `?highlight=` URL query param should also have been removed
+// (so that highlights don't unexpectedly appear again.)
+assert-window-property-false: ({"location": "highlight=kale"}, CONTAINS)
+// Verify this by clicking on a heading to navigate to its anchor. This would otherwise preserve
+// search params, and if the query param were not removed, highlights would appear again.
+click: 'main h1 a'
+assert-false: '[data-markjs="true"]'


### PR DESCRIPTION
Hi! This fixes #1841.

This should prevent search result highlights from reappearing when doing in-page navigation (like going to a different heading).

I also amended the `search` UI test to test this highlighting functionality.