### PR TITLE
Fix global keypresses triggering when other elements are in focus

### DIFF
--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -19,6 +19,14 @@ function playground_text(playground, hidden = true) {
     }
 }
 
+/**
+ * Helper for global keypress handlers so they don't trigger when certain elements are active.
+ * @returns {boolean} True if the keypress handler should be skipped.
+ */
+function mdbook_something_else_has_focus(e) {
+    return /^(?:input|select|textarea)$/i.test(e.target.nodeName);
+}
+
 (function codeSnippets() {
     function fetch_with_timeout(url, options, timeout = 6000) {
         return Promise.race([
@@ -648,12 +656,15 @@ aria-label="Show hidden lines"></button>';
 
 (function chapterNavigation() {
     document.addEventListener('keydown', function(e) {
-        if (e.altKey || e.ctrlKey || e.metaKey) {
+        if (e.altKey ||
+            e.ctrlKey ||
+            e.metaKey ||
+            window.search && window.search.hasFocus() ||
+            mdbook_something_else_has_focus(e)
+        ) {
             return;
         }
-        if (window.search && window.search.hasFocus()) {
-            return;
-        }
+
         const html = document.querySelector('html');
 
         function next() {

--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -24,7 +24,10 @@ function playground_text(playground, hidden = true) {
  * @returns {boolean} True if the keypress handler should be skipped.
  */
 function mdbook_something_else_has_focus(e) {
-    return /^(?:input|select|textarea)$/i.test(e.target.nodeName);
+    // Check composedPath in case the event happened from something generated
+    // from the shadowDOM.
+    const target = e.composedPath()[0] || e.target;
+    return /^(?:input|select|textarea)$/i.test(target.nodeName);
 }
 
 (function codeSnippets() {

--- a/crates/mdbook-html/front-end/searcher/searcher.js
+++ b/crates/mdbook-html/front-end/searcher/searcher.js
@@ -357,7 +357,7 @@ window.search = window.search || {};
             e.shiftKey ||
             e.target.type === 'textarea' ||
             e.target.type === 'text' ||
-            !hasFocus() && /^(?:input|select|textarea)$/i.test(e.target.nodeName)
+            !hasFocus() && mdbook_something_else_has_focus(e)
         ) {
             return;
         }

--- a/tests/gui/books/editor/book.toml
+++ b/tests/gui/books/editor/book.toml
@@ -1,0 +1,6 @@
+[book]
+title = "editor"
+language = "en"
+
+[output.html.playground]
+editable = true

--- a/tests/gui/books/editor/src/SUMMARY.md
+++ b/tests/gui/books/editor/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)
+- [Chapter 2](./chapter_2.md)

--- a/tests/gui/books/editor/src/chapter_1.md
+++ b/tests/gui/books/editor/src/chapter_1.md
@@ -1,0 +1,7 @@
+# Chapter 1
+
+```rust,editable
+fn main() {
+    println!("Hello, world!");
+}
+```

--- a/tests/gui/books/editor/src/chapter_2.md
+++ b/tests/gui/books/editor/src/chapter_2.md
@@ -1,0 +1,1 @@
+# Chapter 2

--- a/tests/gui/books/shadow-dom/book.toml
+++ b/tests/gui/books/shadow-dom/book.toml
@@ -1,0 +1,6 @@
+[book]
+title = "shadow-dom"
+language = "en"
+
+[output.html]
+additional-js = ["shadow-dom.js"]

--- a/tests/gui/books/shadow-dom/shadow-dom.js
+++ b/tests/gui/books/shadow-dom/shadow-dom.js
@@ -1,0 +1,38 @@
+(function() {
+    let shadowHost = null;
+    let shadowInput = null;
+
+    document.addEventListener('keypress', function(e) {
+        if (e.key === 'x' || e.key === 'X') {
+            if (shadowHost && shadowHost.isConnected) {
+                shadowInput.focus();
+                return;
+            }
+
+            shadowHost = document.createElement('div');
+            shadowHost.id = 'shadow-input-host';
+            shadowHost.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:9999;';
+
+            document.body.appendChild(shadowHost);
+
+            const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
+            shadowInput = document.createElement('input');
+            shadowInput.type = 'text';
+            shadowInput.id = 'shadow-input';
+            shadowInput.placeholder = 'Shadow DOM input (press Escape to close)';
+            shadowInput.style.cssText = 'font-size:1.2em;padding:8px;width:300px;';
+
+            shadowRoot.appendChild(shadowInput);
+            shadowInput.focus();
+
+            shadowInput.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') {
+                    shadowHost.remove();
+                    shadowHost = null;
+                    shadowInput = null;
+                }
+            });
+        }
+    });
+})();

--- a/tests/gui/books/shadow-dom/src/SUMMARY.md
+++ b/tests/gui/books/shadow-dom/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/tests/gui/books/shadow-dom/src/chapter_1.md
+++ b/tests/gui/books/shadow-dom/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/tests/gui/editor-keypress.goml
+++ b/tests/gui/editor-keypress.goml
@@ -10,9 +10,10 @@ press-key: "s"
 wait-for: 200
 wait-for-css: ("#mdbook-search-wrapper", {"display": "none"})
 
+// ? inside ACE editor shouldn't show global help popup.
 press-key: "?"
 wait-for: 200
-wait-for-css: ("#mdbook-help-container", {"display": "flex"})
+wait-for-css: ("#mdbook-help-container", {"display": "none"})
 
 // Make sure arrow keys don"t navigate.
 press-key: "ArrowRight"

--- a/tests/gui/editor-keypress.goml
+++ b/tests/gui/editor-keypress.goml
@@ -1,0 +1,23 @@
+// Tests for global keypress handlers when ACE editor is in focus.
+// See https://github.com/rust-lang/mdBook/issues/3064
+
+go-to: |DOC_PATH| + "editor/chapter_1.html"
+
+click: ".ace_editor"
+press-key: "s"
+// Wait briefly to allow any event handlers triggered by the keypress to run.
+// Otherwise there is a race here since the wrapper is already display:none.
+wait-for: 200
+wait-for-css: ("#mdbook-search-wrapper", {"display": "none"})
+
+press-key: "?"
+wait-for: 200
+wait-for-css: ("#mdbook-help-container", {"display": "flex"})
+
+// Make sure arrow keys don"t navigate.
+press-key: "ArrowRight"
+wait-for: 200
+assert-window-property: ({"location": |DOC_PATH| + "editor/chapter_1.html"})
+press-key: "ArrowLeft"
+wait-for: 200
+assert-window-property: ({"location": |DOC_PATH| + "editor/chapter_1.html"})

--- a/tests/gui/shadow-dom.goml
+++ b/tests/gui/shadow-dom.goml
@@ -1,0 +1,18 @@
+// Tests the keypress handler when there is a shadow-dom element.
+// See https://github.com/rust-lang/mdBook/issues/2507
+
+go-to: |DOC_PATH| + "shadow-dom/chapter_1.html"
+
+// Open the shadow-dom generated element.
+press-key: 'x'
+wait-for: '#shadow-input-host'
+// See what happens when the s key is pressed.
+press-key: 's'
+wait-for-css-false: ("#mdbook-search-wrapper", {"display": "none"})
+
+// Also try the global key handlers.
+reload:
+press-key: 'x'
+wait-for: '#shadow-input-host'
+press-key: '?'
+wait-for-css: ("#mdbook-help-container", {"display": "flex"})

--- a/tests/gui/shadow-dom.goml
+++ b/tests/gui/shadow-dom.goml
@@ -8,11 +8,13 @@ press-key: 'x'
 wait-for: '#shadow-input-host'
 // See what happens when the s key is pressed.
 press-key: 's'
-wait-for-css-false: ("#mdbook-search-wrapper", {"display": "none"})
+wait-for: 200
+wait-for-css: ("#mdbook-search-wrapper", {"display": "none"})
 
 // Also try the global key handlers.
 reload:
 press-key: 'x'
 wait-for: '#shadow-input-host'
 press-key: '?'
-wait-for-css: ("#mdbook-help-container", {"display": "flex"})
+wait-for: 200
+wait-for-css: ("#mdbook-help-container", {"display": "none"})


### PR DESCRIPTION
This fixes two issues with global keypresses being handled when they shouldn't:

* Pressing `?` in the ACE editor would open the help popup.
* Pressing global keys with a shadow DOM generated element in focus.

I'm still not entirely happy with this solution, since it still feels fairly brittle. Ideally keypresses shouldn't propagate when entered in elements with focus, but clearly things like ACE and other extensions don't do that.

The keypress handling is also still somewhat sloppy. For example, if you have both search results and the theme picker open, pressing up and down will navigate both. Ideally everything would be a little more disciplined based on what has focus, or what the current "mode" is. But trying to clean that up seems to have diminishing returns, and adds risk.

Fixes https://github.com/rust-lang/mdBook/issues/3064
Fixes https://github.com/rust-lang/mdBook/issues/2507