### PR TITLE
Rename no-section-label to section-label-toc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ version = "0.0.0"
 
 [[package]]
 name = "mdbook-core"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ hex = "0.4.3"
 html5ever = "0.39.0"
 indexmap = "2.14.0"
 ignore = "0.4.25"
-mdbook-core = { path = "crates/mdbook-core", version = "0.5.2" }
+mdbook-core = { path = "crates/mdbook-core", version = "0.6.0" }
 mdbook-driver = { path = "crates/mdbook-driver", version = "0.5.2" }
 mdbook-html = { path = "crates/mdbook-html", version = "0.5.2" }
 mdbook-markdown = { path = "crates/mdbook-markdown", version = "0.5.2" }

--- a/crates/mdbook-core/Cargo.toml
+++ b/crates/mdbook-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-core"
-version = "0.5.2"
+version = "0.6.0"
 description = "The base support library for mdbook, intended for internal use only"
 edition.workspace = true
 license.workspace = true

--- a/crates/mdbook-core/src/config.rs
+++ b/crates/mdbook-core/src/config.rs
@@ -476,8 +476,8 @@ pub struct HtmlConfig {
     pub code: Code,
     /// Print settings.
     pub print: Print,
-    /// Don't render section labels.
-    pub no_section_label: bool,
+    /// Render numeric section labels in the table of contents.
+    pub section_label_toc: bool,
     /// Search settings. If `None`, the default will be used.
     pub search: Option<Search>,
     /// Git repository url. If `None`, the git button will not be shown.
@@ -536,7 +536,7 @@ impl Default for HtmlConfig {
             playground: Playground::default(),
             code: Code::default(),
             print: Print::default(),
-            no_section_label: false,
+            section_label_toc: true,
             search: None,
             git_repository_url: None,
             git_repository_icon: None,

--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -228,7 +228,7 @@ impl HtmlHandlebars {
         handlebars.register_helper(
             "toc",
             Box::new(helpers::toc::RenderToc {
-                no_section_label: html_config.no_section_label,
+                section_label_toc: html_config.section_label_toc,
             }),
         );
         handlebars.register_helper("fa", Box::new(helpers::fontawesome::fa_helper));

--- a/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
+++ b/crates/mdbook-html/src/html_handlebars/helpers/toc.rs
@@ -9,7 +9,7 @@ use std::{cmp::Ordering, collections::BTreeMap};
 // Handlebars helper to construct TOC
 #[derive(Clone, Copy)]
 pub(crate) struct RenderToc {
-    pub no_section_label: bool,
+    pub section_label_toc: bool,
 }
 
 impl HelperDef for RenderToc {
@@ -134,7 +134,7 @@ impl HelperDef for RenderToc {
                 }
             };
 
-            if !self.no_section_label {
+            if self.section_label_toc {
                 // Section does not necessarily exist
                 if let Some(section) = item.get("section") {
                     out.write("<strong aria-hidden=\"true\">")?;

--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -103,7 +103,7 @@ admonitions = true
 mathjax-support = false
 additional-css = ["custom.css", "custom2.css"]
 additional-js = ["custom.js"]
-no-section-label = false
+section-label-toc = true
 git-repository-url = "https://github.com/rust-lang/mdBook"
 git-repository-icon = "fab-github"
 edit-url-template = "https://github.com/rust-lang/mdBook/edit/master/guide/{path}"
@@ -138,9 +138,9 @@ The following configuration options are available:
 - **additional-js:** If you need to add some behaviour to your book without
   removing the current behaviour, you can specify a set of JavaScript files that
   will be loaded alongside the default one.
-- **no-section-label:** mdBook by defaults adds numeric section labels in the table of
-  contents column. For example, "1.", "2.1". Set this option to true to disable
-  those labels. Defaults to `false`.
+- **section-label-toc:** mdBook by default adds numeric section labels in the table
+  of contents column. For example, "1.", "2.1". Set this option to `false` to
+  disable those labels. Defaults to `true`.
 - **git-repository-url:**  A url to the git repository for the book. If provided
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The Font Awesome icon class to use for the git repository link. Defaults to `fab-github` which looks like <i class="fab fa-github"></i>. If you are not using GitHub, another option to consider is `fas-code-fork` which looks like <i class="fas fa-code-fork"></i>. The start of the string should be `fa-` for regular icons, `fas-` for solid icons, or `fab-` for brand icons. See the [free icon set](https://fontawesome.com/v6/search) for the available icons.


### PR DESCRIPTION
Closes #2761.

The `no-section-label` HTML config key was a negative flag whose default was `false`, which made the meaning awkward (double negative). This renames it to `section-label-toc` with a default of `true`, preserving the existing behavior of showing numeric section labels in the table of contents.

The `-toc` suffix anticipates a possible future `section-label-title` companion flag for #2760.

Per @ehuss in #2761, this is a clean rename for 0.5 with no deprecation warning. The existing `HtmlConfig::Default` impl is updated to set `section_label_toc: true`. With `deny_unknown_fields` already on `HtmlConfig`, books that still set `no-section-label` will fail to deserialize with a message that lists `section-label-toc` among the expected fields, so the migration path is discoverable.

### Changes

- `crates/mdbook-core/src/config.rs`: rename the `HtmlConfig` field and flip the default to `true`.
- `crates/mdbook-html/src/html_handlebars/helpers/toc.rs`: rename `RenderToc::no_section_label` to `section_label_toc` and invert the gate.
- `crates/mdbook-html/src/html_handlebars/hbs_renderer.rs`: pass through the renamed field.
- `guide/src/format/configuration/renderers.md`: update the example and the docs entry.

### Verification

Built a small book locally with `section-label-toc = false`, `section-label-toc = true`, and the key omitted; confirmed that `aria-hidden` section-number spans appear only when the flag is `true` (or absent, since default is `true`), and disappear when set to `false`. With the old key, the build now fails with `unknown field 'no-section-label', expected one of ...section-label-toc...`.

`cargo build`, `cargo clippy --workspace --all-targets`, `cargo fmt --check`, and `cargo test --workspace` all pass.