### PR TITLE
fix(css): add spacing between sidebar on-page headings

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -643,6 +643,11 @@ html:not(.js) .sidebar-resize-handle {
     padding-left: 0;
 }
 
+.on-this-page li.header-item {
+    margin-block-end: 0.5em;
+    line-height: 1.5em;
+}
+
 /* Horizontal line in chapter list. */
 .spacer {
     width: 100%;


### PR DESCRIPTION
## Summary

Adds vertical spacing between heading entries in the sidebar “on this page” navigation so adjacent headings are easier to distinguish.

```css
.on-this-page li.header-item {
    margin-block-end: 0.5em;
    line-height: 1.5em;
}
```

Fixes #3085.

## Test plan

- [x] Visual change only (CSS); scoped to `.on-this-page li.header-item` so chapter list spacing is unchanged
- [ ] CI (including GUI heading-nav tests)