### PR TITLE
fix(html): detect redirect loops at build time

### DIFF
--- a/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
+++ b/crates/mdbook-html/src/html_handlebars/hbs_renderer.rs
@@ -245,6 +245,7 @@ impl HtmlHandlebars {
         }
 
         debug!("Emitting redirects");
+        detect_redirect_loops(redirects)?;
         let redirects = combine_fragment_redirects(redirects);
 
         for (original, (dest, fragment_map)) in redirects {
@@ -637,6 +638,69 @@ struct RenderChapterContext<'a> {
     book_config: BookConfig,
     html_config: HtmlConfig,
     chapter_titles: &'a HashMap<PathBuf, String>,
+}
+
+/// Returns the redirect source path used in `[output.html.redirect]` keys.
+fn canonical_redirect_source(path: &str) -> String {
+    if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+fn redirect_destination_is_external(dest: &str) -> bool {
+    let dest = dest.trim();
+    dest.starts_with("http://") || dest.starts_with("https://") || dest.starts_with("//")
+}
+
+/// Detects cycles in `[output.html.redirect]` before emitting redirect pages.
+fn detect_redirect_loops(redirects: &HashMap<String, String>) -> Result<()> {
+    use std::collections::HashSet;
+
+    let mut visited = HashSet::new();
+    let mut sources: Vec<_> = redirects.keys().collect();
+    sources.sort();
+    for start in sources {
+        if visited.contains(start) {
+            continue;
+        }
+        let mut path: Vec<&str> = Vec::new();
+        let mut current = start.as_str();
+        loop {
+            if let Some(pos) = path.iter().position(|&p| p == current) {
+                let mut cycle = String::new();
+                for source in &path[pos..] {
+                    if !cycle.is_empty() {
+                        cycle.push_str(" -> ");
+                    }
+                    cycle.push_str(source);
+                    if let Some(dest) = redirects.get(*source) {
+                        cycle.push_str(" -> ");
+                        cycle.push_str(dest);
+                    }
+                }
+                bail!("redirect loop detected: {cycle}");
+            }
+            visited.insert(current.to_owned());
+            path.push(current);
+            let Some(dest) = redirects.get(current) else {
+                break;
+            };
+            if redirect_destination_is_external(dest) {
+                break;
+            }
+            let canonical = canonical_redirect_source(dest);
+            let Some((next, _)) = redirects
+                .get_key_value(&canonical)
+                .or_else(|| redirects.get_key_value(dest))
+            else {
+                break;
+            };
+            current = next.as_str();
+        }
+    }
+    Ok(())
 }
 
 /// Redirect mapping.

--- a/tests/testsuite/redirects.rs
+++ b/tests/testsuite/redirects.rs
@@ -33,6 +33,21 @@ There must be an entry without the `#` fragment to determine the default destina
     });
 }
 
+// Redirect loops should fail at build time.
+#[test]
+fn redirect_loop() {
+    BookTest::from_dir("redirects/redirect_loop").run("build", |cmd| {
+        cmd.expect_failure().expect_stderr(str![[r#"
+ INFO Book building has started
+ INFO Running the html backend
+ERROR Rendering failed
+[TAB]Caused by: Unable to emit redirects
+[TAB]Caused by: redirect loop detected: /chapter_1.html#a -> chapter_2.html#b -> /chapter_2.html#b -> chapter_1.html#a
+
+"#]]);
+    });
+}
+
 // Invalid redirect for an existing page.
 #[test]
 fn redirect_existing_page() {

--- a/tests/testsuite/redirects/redirect_loop/book.toml
+++ b/tests/testsuite/redirects/redirect_loop/book.toml
@@ -1,0 +1,6 @@
+[book]
+title = "redirect_loop"
+
+[output.html.redirect]
+"/chapter_1.html#a" = "chapter_2.html#b"
+"/chapter_2.html#b" = "chapter_1.html#a"

--- a/tests/testsuite/redirects/redirect_loop/src/SUMMARY.md
+++ b/tests/testsuite/redirects/redirect_loop/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)
+- [Chapter 2](./chapter_2.md)

--- a/tests/testsuite/redirects/redirect_loop/src/chapter_1.md
+++ b/tests/testsuite/redirects/redirect_loop/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/tests/testsuite/redirects/redirect_loop/src/chapter_2.md
+++ b/tests/testsuite/redirects/redirect_loop/src/chapter_2.md
@@ -1,0 +1,1 @@
+# Chapter 2


### PR DESCRIPTION
## Summary

Detects cycles in `[output.html.redirect]` during the HTML build and fails with a clear error instead of generating redirect pages that reload indefinitely in the browser.

Example error:

```
redirect loop detected: /chapter_1.html#a -> chapter_2.html#b -> /chapter_2.html#b -> chapter_1.html#a
```

External destinations (`http://`, `https://`, `//`) terminate the chain and are not treated as redirect sources.

Fixes #2901.

## Test plan

- [x] Added `redirects/redirect_loop` testsuite case
- [x] `cargo test -p mdbook --test testsuite` (111 passed)