### PR TITLE
fix(links): support spaces in #include file paths

### DIFF
--- a/crates/mdbook-driver/src/builtin_preprocessors/links.rs
+++ b/crates/mdbook-driver/src/builtin_preprocessors/links.rs
@@ -285,13 +285,18 @@ impl<'a> Link<'a> {
             (_, Some(typ), Some(title)) if typ.as_str() == "title" => {
                 Some(LinkType::Title(title.as_str()))
             }
+            (_, Some(typ), Some(rest)) if typ.as_str() == "include" => {
+                Some(parse_include_path(rest.as_str().trim()))
+            }
+            (_, Some(typ), Some(rest)) if typ.as_str() == "rustdoc_include" => {
+                Some(parse_rustdoc_include_path(rest.as_str().trim()))
+            }
             (_, Some(typ), Some(rest)) => {
                 let mut path_props = rest.as_str().split_whitespace();
                 let file_arg = path_props.next();
                 let props: Vec<&str> = path_props.collect();
 
                 match (typ.as_str(), file_arg) {
-                    ("include", Some(pth)) => Some(parse_include_path(pth)),
                     ("playground", Some(pth)) => Some(LinkType::Playground(pth.into(), props)),
                     ("playpen", Some(pth)) => {
                         warn!(
@@ -301,7 +306,6 @@ impl<'a> Link<'a> {
                         );
                         Some(LinkType::Playground(pth.into(), props))
                     }
-                    ("rustdoc_include", Some(pth)) => Some(parse_rustdoc_include_path(pth)),
                     _ => None,
                 }
             }
@@ -484,6 +488,37 @@ mod tests {
     fn test_find_links_unknown_link_type() {
         let s = "Some random text with {{#playgroundz ar.rs}} and {{#incn}} {{baz}} {{#bar}}...";
         assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+    }
+
+    #[test]
+    fn test_find_links_with_space_in_path() {
+        let s = "Some random text with {{#include fila a.md}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        assert_eq!(
+            res,
+            vec![Link {
+                start_index: 22,
+                end_index: 44,
+                link_type: LinkType::Include(
+                    PathBuf::from("fila a.md"),
+                    RangeOrAnchor::Range(LineRange::from(RangeFull)),
+                ),
+                link_text: "{{#include fila a.md}}",
+            }]
+        );
+    }
+
+    #[test]
+    fn test_find_links_with_space_in_path_and_range() {
+        let s = "Some random text with {{#include fila a.md:1:2}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        assert_eq!(
+            res[0].link_type,
+            LinkType::Include(
+                PathBuf::from("fila a.md"),
+                RangeOrAnchor::Range(LineRange::from(0..2)),
+            ),
+        );
     }
 
     #[test]

--- a/tests/testsuite/includes.rs
+++ b/tests/testsuite/includes.rs
@@ -12,6 +12,9 @@ fn include() {
 <h1 id="basic-includes"><a class="header" href="#basic-includes">Basic Includes</a></h1>
 <h2 id="sample"><a class="header" href="#sample">Sample</a></h2>
 <p>This is a sample include.</p>
+<h2 id="file-with-space-in-name"><a class="header" href="#file-with-space-in-name">File with space in name</a></h2>
+<h1 id="file-with-space"><a class="header" href="#file-with-space">File With Space</a></h1>
+<p>This file name contains a space.</p>
 "##]],
         )
         .check_main_file(

--- a/tests/testsuite/includes/all_includes/src/fila a.md
+++ b/tests/testsuite/includes/all_includes/src/fila a.md
@@ -1,0 +1,3 @@
+# File With Space
+
+This file name contains a space.

--- a/tests/testsuite/includes/all_includes/src/includes.md
+++ b/tests/testsuite/includes/all_includes/src/includes.md
@@ -2,3 +2,7 @@
 
 {{#include sample.md}}
 
+## File with space in name
+
+{{#include fila a.md}}
+


### PR DESCRIPTION
## Summary

`{{#include}}` and `{{#rustdoc_include}}` now use the full captured path instead of splitting on whitespace, so file names and paths may contain spaces (e.g. `{{#include fila a.md}}`). Line ranges still work (`{{#include fila a.md:1:2}}`).

Playground links are unchanged and still use whitespace-separated path and properties.

Fixes #2812.

## Test plan

- [x] Unit tests in `links.rs` for paths with spaces (with and without line ranges)
- [x] Extended `includes/all_includes` testsuite case
- [ ] CI