### PR TITLE
docs: document print.html and reserved print.md

### DIFF
--- a/guide/src/format/configuration/renderers.md
+++ b/guide/src/format/configuration/renderers.md
@@ -188,6 +188,16 @@ page-break = true # insert page-break after each chapter
   rendered. Defaults to `true`.
 - **page-break:** Insert page breaks between chapters. Defaults to `true`.
 
+#### `print.html` and `print.md`
+
+When print support is enabled, mdBook writes **`print.html`** to the book output directory.
+This file contains the entire book on a single page.
+The print icon in the menu bar (see [Reading a book](../../guide/reading.md)) opens this file for printing.
+
+**`print.md` is reserved** for internal use.
+Do not create `src/print.md` or add it to `SUMMARY.md`.
+If you do, the build fails with the error `print.md is reserved for internal use`.
+
 ### `[output.html.fold]`
 
 The `[output.html.fold]` table provides options for controlling folding of the chapter listing in the navigation sidebar.

--- a/guide/src/guide/reading.md
+++ b/guide/src/guide/reading.md
@@ -33,7 +33,7 @@ The icons displayed will depend on the settings of how the book was generated.
 | <i class="fas fa-bars"></i> | Opens and closes the chapter listing sidebar. |
 | <i class="fas fa-paintbrush"></i> | Opens a picker to choose a different color theme. |
 | <i class="fas fa-magnifying-glass"></i> | Opens a search bar for searching within the book. |
-| <i class="fas fa-print"></i> | Instructs the web browser to print the entire book. |
+| <i class="fas fa-print"></i> | Opens **print.html**, which contains the entire book on one page for printing. |
 | <i class="fab fa-github"></i> | Opens a link to the website that hosts the source code of the book. |
 | <i class="fas fa-pencil"></i> | Opens a page to directly edit the source of the page you are currently reading. |
 


### PR DESCRIPTION
## Summary

Fixes #3088.

Documents how printable output works:

- **`print.html`** — auto-generated when `[output.html.print]` is enabled; opened by the print menu icon
- **`print.md`** — reserved; must not appear in `src/` or `SUMMARY.md`

## Changes

- `guide/src/format/configuration/renderers.md` — new subsection under `[output.html.print]`
- `guide/src/guide/reading.md` — clarify print icon behavior

## Test plan

- [x] Documentation only (no code changes)