### PR TITLE
fix(html): bump default MathJax CDN to 2.7.5

### DIFF
--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -47,7 +47,7 @@
 
         {{#if mathjax_support}}
         <!-- MathJax -->
-        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{/if}}
 
         <!-- Provide site root and default themes to javascript -->


### PR DESCRIPTION
## Summary

- Updates the default MathJax script URL from 2.7.1 to 2.7.5
- Fixes italic Greek letter rendering on Microsoft Edge (see #2964)

Fixes #2964

## Test plan

- [ ] CI
- [x] Single-line CDN URL change in `index.hbs` template