### PR TITLE
fix(a11y): make sidebar toggle keyboard focusable

### DIFF
--- a/crates/mdbook-html/front-end/js/book.js
+++ b/crates/mdbook-html/front-end/js/book.js
@@ -551,14 +551,16 @@ aria-label="Show hidden lines"></button>';
         }
     });
     sidebarToggleButton.addEventListener('click', () => {
+        sidebarCheckbox.checked = !sidebarCheckbox.checked;
         /* To allow the sidebar expansion animation, we first need to put back the display. */
-        if (!sidebarCheckbox.checked) {
+        if (sidebarCheckbox.checked) {
             sidebar.style.display = '';
             // Workaround for Safari skipping the animation when changing
             // `display` and a transform in the same event loop. This forces a
             // reflow after updating the display.
             sidebar.offsetHeight;
         }
+        sidebarCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
     function showSidebar() {

--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -143,9 +143,9 @@
                 <div id="mdbook-menu-bar-hover-placeholder"></div>
                 <div id="mdbook-menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
-                        <label id="mdbook-sidebar-toggle" class="icon-button" for="mdbook-sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
+                        <button id="mdbook-sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
                             {{fa "solid" "bars"}}
-                        </label>
+                        </button>
                         <button id="mdbook-theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="mdbook-theme-list">
                             {{fa "solid" "paintbrush"}}
                         </button>


### PR DESCRIPTION
## Summary

- Replace the sidebar hamburger `<label for="checkbox">` with a `<button type="button">`
- Toggle the hidden checkbox from JavaScript and dispatch `change` so existing sidebar logic is unchanged
- Keyboard users can now Tab to the control and activate it with Enter/Space

## Motivation

The label-based toggle was not in the tab order, so keyboard and screen-reader users skipped the first menu control (#2615).

## Test plan

- [x] `cargo test --test testsuite`
- [ ] GUI `sidebar.goml` (CI)

Fixes #2615