### PR TITLE
fix(a11y): add skip link to main content

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -1,5 +1,21 @@
 /* CSS for UI elements (a.k.a. chrome) */
 
+.skip-to-content {
+    position: absolute;
+    top: -100px;
+    left: 0;
+    padding: 0.5rem 1rem;
+    background-color: var(--bg);
+    color: var(--fg);
+    z-index: 1000;
+    text-decoration: none;
+    border: 2px solid var(--links);
+}
+
+.skip-to-content:focus {
+    top: 0;
+}
+
 html {
     scrollbar-color: var(--scrollbar) transparent;
 }

--- a/crates/mdbook-html/front-end/templates/index.hbs
+++ b/crates/mdbook-html/front-end/templates/index.hbs
@@ -63,6 +63,7 @@
         <script src="{{ resource "toc.js" }}"></script>
     </head>
     <body>
+    <a class="skip-to-content" href="#mdbook-content">Skip to main content</a>
     <div id="mdbook-help-container">
         <div id="mdbook-help-popup">
             <h2 class="mdbook-help-title">Keyboard shortcuts</h2>
@@ -143,9 +144,9 @@
                 <div id="mdbook-menu-bar-hover-placeholder"></div>
                 <div id="mdbook-menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
-                        <label id="mdbook-sidebar-toggle" class="icon-button" for="mdbook-sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
+                        <button id="mdbook-sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
                             {{fa "solid" "bars"}}
-                        </label>
+                        </button>
                         <button id="mdbook-theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="mdbook-theme-list">
                             {{fa "solid" "paintbrush"}}
                         </button>
@@ -213,7 +214,7 @@
                     });
                 </script>
 
-                <div id="mdbook-content" class="content">
+                <div id="mdbook-content" class="content" tabindex="-1">
                     <main>
                         {{{ content }}}
                     </main>


### PR DESCRIPTION
## Summary

- Add a "Skip to main content" link as the first focusable element in the page
- Link targets `#mdbook-content` (with `tabindex="-1"` for focus on activation)
- Visually hidden until focused, matching common doc-site patterns (Docusaurus, Starlight)

## Motivation

Keyboard users had no way to bypass repeated navigation blocks (sidebar, menu bar), failing WCAG 2.4.1 (#2107).

## Test plan

- [x] `cargo test --test testsuite` (110 passed)

Fixes #2107