### PR TITLE
fix(search): stop type-ahead search from polluting browser history

### DIFF
--- a/crates/mdbook-html/front-end/searcher/searcher.js
+++ b/crates/mdbook-html/front-end/searcher/searcher.js
@@ -485,7 +485,7 @@ window.search = window.search || {};
             removeChildren(searchresults);
         }
 
-        setSearchUrlParameters(searchterm, 'push_if_new_search_else_replace');
+        setSearchUrlParameters(searchterm, 'replace');
 
         // Remove marks
         marker.unmark();


### PR DESCRIPTION
## Summary

- Use `history.replaceState` (via `setSearchUrlParameters(..., 'replace')`) on each keypress while searching
- Previously the first keystroke used `pushState`, adding a history entry per new search session and cluttering the browser history list

## Motivation

Type-ahead search updated `?search=` on every keystroke; even with replace for subsequent keys, the initial `pushState` and URL churn created noisy history (#2635, reported by @ehuss).

## Test plan

- [x] `cargo test --test testsuite`
- [ ] Manual: type in search box, confirm browser history dropdown is not filled with partial queries

Fixes #2635