### PR TITLE
fix(html): preserve sidebar scroll when clicking chapter links

### DIFF
--- a/crates/mdbook-html/front-end/templates/toc.js.hbs
+++ b/crates/mdbook-html/front-end/templates/toc.js.hbs
@@ -40,22 +40,14 @@ class MDBookSidebarScrollbox extends HTMLElement {
         // Track and set sidebar scroll position
         this.addEventListener('click', e => {
             if (e.target.tagName === 'A') {
-                const clientRect = e.target.getBoundingClientRect();
-                const sidebarRect = this.getBoundingClientRect();
-                sessionStorage.setItem('sidebar-scroll-offset', clientRect.top - sidebarRect.top);
+                sessionStorage.setItem('mdbook-sidebar-scroll', String(this.scrollTop));
             }
         }, { passive: true });
-        const sidebarScrollOffset = sessionStorage.getItem('sidebar-scroll-offset');
-        sessionStorage.removeItem('sidebar-scroll-offset');
-        if (sidebarScrollOffset !== null) {
-            // preserve sidebar scroll position when navigating via links within sidebar
-            const activeSection = this.querySelector('.active');
-            if (activeSection) {
-                const clientRect = activeSection.getBoundingClientRect();
-                const sidebarRect = this.getBoundingClientRect();
-                const currentOffset = clientRect.top - sidebarRect.top;
-                this.scrollTop += currentOffset - parseFloat(sidebarScrollOffset);
-            }
+        const savedSidebarScroll = sessionStorage.getItem('mdbook-sidebar-scroll');
+        sessionStorage.removeItem('mdbook-sidebar-scroll');
+        if (savedSidebarScroll !== null) {
+            // Preserve sidebar scroll position when navigating via links within sidebar.
+            this.scrollTop = parseFloat(savedSidebarScroll);
         } else {
             // scroll sidebar to current active section when navigating via
             // 'next/previous chapter' buttons


### PR DESCRIPTION
## Summary

- On sidebar link click, save the scrollbox `scrollTop` in `sessionStorage`
- On the next page, restore that value instead of adjusting by active-link offset

## Motivation

In mdBook 0.5+, clicking a chapter in the sidebar often jumped the TOC back to the top (#3081). The previous logic compared the new page’s `.active` link position to a saved offset from the clicked link, which produced incorrect scroll adjustments.

This matches the existing GUI test `sidebar-scroll.goml`.

## Notes

Some reports link this to clean/prettified URLs (#3034); this fix addresses scroll preservation for normal sidebar navigation regardless.

## Test plan

- [x] `cargo test --test testsuite`
- [ ] CI GUI tests (`sidebar-scroll.goml`)

Fixes #3081