### PR TITLE
Improve spacing in sidebar section headings

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -624,6 +624,15 @@ html:not(.js) .sidebar-resize-handle {
     margin-block-start: 0.6em;
 }
 
+.chapter li.header-item {
+    /* Make sure there is plenty of spacing between sections so they don't blend in
+       with each other. */
+    margin-block-end: 0.5em;
+    /* Avoid too much spacing between lines when section heading word wraps so that
+       it can be distinguished between successive headings. */
+    line-height: 1.5em;
+}
+
 /* When expanded, rotate the chevron to point down. */
 .chapter li.expanded > span > .chapter-fold-toggle div {
     transform: rotate(90deg);


### PR DESCRIPTION
This tries to improve the spacing between section headings in the sidebar so that they don't blend together. This is particularly a problem with long headings that word wrap. This just tightens up the spacing when it wraps, and increases the spacing between the sections.

I still don't 100% like how the distinction between sections can be difficult to see. My original prototype had other indicators like bullets, but those ended up not working too well. This might still need some work in the future.

Fixes https://github.com/rust-lang/mdBook/issues/3085