### PR TITLE
Improve broken include error locations

### DIFF
--- a/crates/mdbook-driver/src/builtin_preprocessors/links.rs
+++ b/crates/mdbook-driver/src/builtin_preprocessors/links.rs
@@ -119,7 +119,18 @@ where
                 previous_end_index = link.end_index;
             }
             Err(e) => {
-                error!("Error updating \"{}\", {}", link.link_text, e);
+                let line = s[..link.start_index]
+                    .bytes()
+                    .filter(|b| *b == b'\n')
+                    .count()
+                    + 1;
+                error!(
+                    "Error updating \"{}\" in {}:{}, {}",
+                    link.link_text,
+                    source.display(),
+                    line,
+                    e
+                );
                 for cause in e.chain().skip(1) {
                     warn!("Caused By: {}", cause);
                 }

--- a/tests/testsuite/includes.rs
+++ b/tests/testsuite/includes.rs
@@ -70,6 +70,28 @@ Around the world, around the world</p>
         );
 }
 
+// Checks that errors include where the broken include appears.
+#[test]
+fn broken_include_error_location() {
+    BookTest::from_dir("includes/all_includes")
+        .change_file(
+            "src/includes.md",
+            "# Basic Includes\n\n{{#include src/not-found.md}}\n",
+        )
+        .change_file("src/recursive.md", "Not recursive.\n")
+        .run("build", |cmd| {
+            cmd.expect_stderr(str![[r#"
+ INFO Book building has started
+ERROR Error updating "{{#include src/not-found.md}}" in includes.md:3, Could not read file for link {{#include src/not-found.md}} ([ROOT]/src/src/not-found.md)
+ WARN Caused By: failed to read `[ROOT]/src/src/not-found.md`
+ WARN Caused By: [NOT_FOUND]
+ INFO Running the html backend
+ INFO HTML book written to `[ROOT]/book`
+
+"#]]);
+        });
+}
+
 // Checks the behavior of `{{#playground}}` include.
 #[test]
 fn playground_include() {


### PR DESCRIPTION
Fixes #1892.\n\n## Summary\n- include the source chapter path and line number when the link preprocessor reports a broken include/playground/rustdoc_include directive\n- add a testsuite regression test for a missing include\n\n## Validation\n- cargo fmt --check\n- cargo check\n- cargo test broken_include_error_location --test testsuite\n- cargo test includes --test testsuite\n\n## Risk\nLow: this only changes diagnostic text emitted for link preprocessor failures and adds test coverage; build behavior is unchanged.