### PR TITLE
Recommend linkcheck2 fork

### DIFF
--- a/guide/src/continuous-integration.md
+++ b/guide/src/continuous-integration.md
@@ -74,11 +74,11 @@ Some services have Rust pre-installed, but if your service does not, you will ne
 
 Other than making sure the appropriate version of Rust is installed, there's not much more than just running `mdbook test` from the book directory.
 
-You may also want to consider running other kinds of tests, like [mdbook-linkcheck] which will check for broken links.
+You may also want to consider running other kinds of tests, like [mdbook-linkcheck2] which will check for broken links.
 Or if you have your own style checks, spell checker, or any other tests it might be good to run them in CI.
 
 [`mdbook test`]: cli/test.md
-[mdbook-linkcheck]: https://github.com/Michael-F-Bryan/mdbook-linkcheck#continuous-integration
+[mdbook-linkcheck2]: https://github.com/marxin/mdbook-linkcheck2#continuous-integration
 
 ## Deploying
 


### PR DESCRIPTION
With the addition of admonitions in 0.5.0, linkcheck broke, and the PR to fix
 it has been open for a good while. See:
- <https://github.com/Michael-F-Bryan/mdbook-linkcheck/pull/98>
- <https://github.com/jontze/action-mdbook/issues/671>