### PR TITLE
Fix previous-chapter nav hover overlapping sidebar resize handle

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -158,6 +158,7 @@ html:not(.js) .left-buttons button {
 }
 
 .nav-chapters.previous {
+    /* Ensure that the previous arrow does not overlap the resize indicator. */
     margin-inline-start: var(--sidebar-resize-indicator-width);
 }
 

--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -157,6 +157,10 @@ html:not(.js) .left-buttons button {
     transition: background-color 0.15s, color 0.15s;
 }
 
+.nav-chapters.previous {
+    margin-inline-start: var(--sidebar-resize-indicator-width);
+}
+
 .nav-wrapper {
     margin-block-start: 50px;
     display: none;


### PR DESCRIPTION
The nav arrow is position:fixed and starts at the sidebar's right edge, but the resize handle indicator dots protrude 8px beyond the sidebar. The nav's hover background was painting over that zone, hiding the dots.

Adding margin-inline-start equal to the resize indicator width pushes the nav just past the handle so the two no longer overlap.

Before/After:
<img width="162" height="174" alt="Screenshot from 2026-06-10 10-49-31" src="https://github.com/user-attachments/assets/19f2fd0c-dfca-430f-81ed-3cf9ffe6c580" />
<img width="154" height="149" alt="image" src="https://github.com/user-attachments/assets/23af2ee3-5aa0-49bc-bb55-b063785a7806" />



Before/After:
<img width="220" height="698" alt="Screenshot from 2026-06-10 11-00-25" src="https://github.com/user-attachments/assets/20cf7854-29a3-457f-8494-ba384c1d4ca0" /> <img width="220" height="698" alt="Screenshot from 2026-06-10 11-02-03" src="https://github.com/user-attachments/assets/d867b907-6434-4d1e-b75e-3e960c1976a8" />


