### PR TITLE
Fix grammar in rustdoc comments

### DIFF
--- a/crates/mdbook-html/src/html/print.rs
+++ b/crates/mdbook-html/src/html/print.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 /// Takes all the chapter trees, modifies them to be suitable to render for
-/// the print page, and returns an string of all the chapters rendered to a
+/// the print page, and returns a string of all the chapters rendered to a
 /// single HTML page.
 pub(crate) fn render_print_page(mut chapter_trees: Vec<ChapterTree<'_>>) -> String {
     let (id_remap, mut id_counter) = make_ids_unique(&mut chapter_trees);

--- a/crates/mdbook-summary/src/lib.rs
+++ b/crates/mdbook-summary/src/lib.rs
@@ -25,15 +25,15 @@ use tracing::{debug, trace, warn};
 ///
 /// **Prefix Chapter:** Before the main numbered chapters you can add a couple
 /// of elements that will not be numbered. This is useful for forewords,
-/// introductions, etc. There are however some constraints. You can not nest
-/// prefix chapters, they should all be on the root level. And you can not add
+/// introductions, etc. However, there are some constraints. You cannot nest
+/// prefix chapters; they should all be on the root level. And you cannot add
 /// prefix chapters once you have added numbered chapters.
 ///
 /// ```markdown
 /// [Title of prefix element](relative/path/to/markdown.md)
 /// ```
 ///
-/// **Part Title:** An optional title for the next collect of numbered chapters. The numbered
+/// **Part Title:** An optional title for the next collection of numbered chapters. The numbered
 /// chapters can be broken into as many parts as desired.
 ///
 /// **Numbered Chapter:** Numbered chapters are the main content of the book,


### PR DESCRIPTION
This fixes a few grammar issues in rustdoc comments for the summary parser and print page rendering code.

No behavior is changed.