### PR TITLE
Change crates.io publish to be re-runnable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,21 +48,3 @@ jobs:
       run: rustup update stable --no-self-update && rustup default stable
     - name: Deploy the User Guide to GitHub Pages using the gh-pages branch
       run: ci/publish-guide.sh
-  publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    permissions:
-      # Required for OIDC token exchange
-      id-token: write
-    environment: publish
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Install Rust (rustup)
-        run: rustup update stable --no-self-update && rustup default stable
-      - name: Authenticate with crates.io
-        id: auth
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
-      - name: Publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --workspace --no-verify

--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -1,0 +1,32 @@
+name: Publish to crates.io
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for OIDC token exchange
+      id-token: write
+    environment: publish
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Install Rust (rustup)
+        run: rustup update stable --no-self-update && rustup default stable
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: ci/publish-crates-io.sh

--- a/ci/publish-crates-io.sh
+++ b/ci/publish-crates-io.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+function publish {
+    crate_name="$1"
+    manifest="$2"
+
+    # Get the version from Cargo.toml
+    version=`sed -n -E 's/^version = "(.*)"/\1/p' $manifest`
+
+    # Check crates.io if it is already published
+    set +e
+    output=`curl --fail --silent --head --location https://static.crates.io/crates/$crate_name/$version/download`
+    res="$?"
+    set -e
+    case $res in
+        0)
+            echo "${crate_name}@${version} appears to already be published"
+            return
+            ;;
+        22) ;;
+        *)
+            echo "Failed to check ${crate_name}@${version} res: $res"
+            echo "$output"
+            exit 1
+            ;;
+    esac
+
+    cargo publish --manifest-path $manifest --no-verify
+}
+
+publish mdbook-core crates/mdbook-core/Cargo.toml
+publish mdbook-markdown crates/mdbook-markdown/Cargo.toml
+publish mdbook-renderer crates/mdbook-renderer/Cargo.toml
+publish mdbook-html crates/mdbook-html/Cargo.toml
+publish mdbook-preprocessor crates/mdbook-preprocessor/Cargo.toml
+publish mdbook-summary crates/mdbook-summary/Cargo.toml
+publish mdbook-driver crates/mdbook-driver/Cargo.toml
+publish mdbook Cargo.toml


### PR DESCRIPTION
This changes the crates.io publish so that it is re-runnable in case there is a problem with the publish. This means it cannot use `--workspace`, and needs to check if something is already published.

This isn't ideal, but there aren't many other choices here.