### PR TITLE
test: cover editable playground includes

### DIFF
--- a/tests/testsuite/includes.rs
+++ b/tests/testsuite/includes.rs
@@ -83,6 +83,13 @@ fn playground_include() {
 </span><span class="boring">   // You can even hide lines! :D
 </span><span class="boring">  println!("I am hidden! Expand the code snippet to see me");
 </span>}</code></pre>
+<h2 id="editable-playground"><a class="header" href="#editable-playground">Editable Playground</a></h2>
+<pre class="playground"><code class="language-rust editable">fn main() {
+    println!("Hello World!");
+<span class="boring">
+</span><span class="boring">   // You can even hide lines! :D
+</span><span class="boring">  println!("I am hidden! Expand the code snippet to see me");
+</span>}</code></pre>
 "##]]);
 }
 

--- a/tests/testsuite/includes/all_includes/src/playground.md
+++ b/tests/testsuite/includes/all_includes/src/playground.md
@@ -1,3 +1,7 @@
 # Playground Includes
 
 {{#playground example.rs}}
+
+## Editable Playground
+
+{{#playground example.rs editable}}


### PR DESCRIPTION
## Summary

- extend the existing playground include fixture with the `editable` form
- assert that the rendered code block preserves the `editable` class

This covers one of the remaining integration-test cases listed in #2677 without changing runtime behavior.

## Validation

- red proof: the targeted test failed after adding the fixture because the snapshot did not contain the editable heading and `language-rust editable` class
- `cargo test --test testsuite includes::playground_include -- --exact`
- `cargo test --test testsuite`
- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Disclosure

This change was prepared with OpenAI Codex assistance and manually reviewed and validated with the commands above.
