### PR TITLE
Fix print output inheriting screen theme colors

### DIFF
--- a/crates/mdbook-html/front-end/css/print.css
+++ b/crates/mdbook-html/front-end/css/print.css
@@ -1,4 +1,26 @@
 
+/* Always use the light content palette when printing, regardless of the
+   selected screen theme. */
+html:root {
+    --bg: hsl(0, 0%, 100%);
+    --fg: hsl(0, 0%, 0%);
+    --inline-code-color: #301900;
+    --theme-popup-border: #cccccc;
+    --theme-hover: #e6e6e6;
+    --quote-bg: hsl(197, 37%, 96%);
+    --quote-border: hsl(197, 37%, 91%);
+    --table-border-color: hsl(0, 0%, 95%);
+    --table-header-bg: hsl(0, 0%, 80%);
+    --table-alternate-bg: hsl(0, 0%, 97%);
+    --color-scheme: light;
+    --footnote-highlight: #7e7eff;
+    --blockquote-note-color: #0969da;
+    --blockquote-tip-color: #008000;
+    --blockquote-important-color: #8250df;
+    --blockquote-warning-color: #9a6700;
+    --blockquote-caution-color: #b52731;
+}
+
 #mdbook-sidebar,
 #mdbook-menu-bar,
 .nav-chapters,


### PR DESCRIPTION
Fixes #1934.

## Summary

- reset print-only content variables to mdBook's existing light palette
- keep all selected screen themes unchanged
- cover page, text, quotes, tables, keyboard keys, footnotes, and callouts through the shared variables

## Verification

- Chrome print-media computed-style matrix for ayu, coal, light, navy, rust, and no-JavaScript navy
- navy screen-media negative control
- `cargo test -p mdbook-html --lib`
- `cargo fmt --check`
- `git diff --check`
