### PR TITLE
for_developers/README.md: clean up introduction

### DIFF
--- a/guide/src/for_developers/README.md
+++ b/guide/src/for_developers/README.md
@@ -9,7 +9,7 @@ the book or render it in a different format.
 The *For Developers* chapters are here to show you the more advanced usage of
 `mdbook`.
 
-The two main ways a developer can hook into the book's build process is via,
+The two main ways a developer can hook into the book's build process are:
 
 - [Preprocessors](preprocessors.md)
 - [Alternative Backends](backends.md)


### PR DESCRIPTION
Given that there are multiple ways listed, use "are" rather than "is"; introduce with list of options with a colon rather than with "via" and a comma.