### PR TITLE
tests/testsuite/main.rs: remove unused `glob_one` import

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -25,6 +25,6 @@ mod theme;
 mod toc;
 
 mod prelude {
-    pub use crate::book_test::{BookTest, glob_one, read_to_string};
+    pub use crate::book_test::{BookTest, read_to_string};
     pub use snapbox::str;
 }


### PR DESCRIPTION
Noticed in the CI logs