### PR TITLE
Generate linkable IDs for punctuation-only headings

### DIFF
--- a/crates/mdbook-html/src/utils.rs
+++ b/crates/mdbook-html/src/utils.rs
@@ -73,6 +73,8 @@ pub(crate) fn unique_id(id: &str, used: &mut HashSet<String>) -> String {
 }
 
 /// Generates an HTML id from the given text.
+///
+/// Falls back to `section` when no valid ID characters remain.
 pub(crate) fn id_from_content(content: &str) -> String {
     // This is intended to be close to how header ID generation is done in
     // other sites and tools, but is not 100% the same. Not all sites and
@@ -83,7 +85,7 @@ pub(crate) fn id_from_content(content: &str) -> String {
     // - https://pandoc.org/MANUAL.html#extension-auto_identifiers
     // - https://kramdown.gettalong.org/converter/html#auto-ids
     // - https://docs.rs/comrak/latest/comrak/options/struct.Extension.html#structfield.header_ids
-    content
+    let id = content
         .trim()
         .to_lowercase()
         .chars()
@@ -96,7 +98,13 @@ pub(crate) fn id_from_content(content: &str) -> String {
                 None
             }
         })
-        .collect()
+        .collect::<String>();
+
+    if id.is_empty() {
+        "section".to_owned()
+    } else {
+        id
+    }
 }
 
 #[cfg(test)]
@@ -128,7 +136,9 @@ mod tests {
         assert_eq!(id_from_content("中文"), "中文");
         assert_eq!(id_from_content("にほんご"), "にほんご");
         assert_eq!(id_from_content("한국어"), "한국어");
-        assert_eq!(id_from_content(""), "");
+        assert_eq!(id_from_content(""), "section");
+        assert_eq!(id_from_content("   "), "section");
+        assert_eq!(id_from_content("!.():"), "section");
         assert_eq!(id_from_content("中文標題 CJK title"), "中文標題-cjk-title");
         assert_eq!(id_from_content("Über"), "über");
     }

--- a/tests/testsuite/rendering/header_links/expected/header_links.html
+++ b/tests/testsuite/rendering/header_links/expected/header_links.html
@@ -1,7 +1,8 @@
 <h1 id="header-links"><a class="header" href="#header-links">Header Links</a></h1>
 <h2 id="foobar"><a class="header" href="#foobar">Foo^bar</a></h2>
-<h3 id=""><a class="header" href="#"></a></h3>
-<h4 id="-1"><a class="header" href="#-1"></a></h4>
+<h3 id="section"><a class="header" href="#section">!.():</a></h3>
+<h4 id="section-1"><a class="header" href="#section-1"></a></h4>
+<h5 id="explicit-punctuation"><a class="header" href="#explicit-punctuation">!!!</a></h5>
 <h2 id="hï"><a class="header" href="#hï">Hï</a></h2>
 <h2 id="repeat"><a class="header" href="#repeat">Repeat</a></h2>
 <h2 id="repeat-1"><a class="header" href="#repeat-1">Repeat</a></h2>

--- a/tests/testsuite/rendering/header_links/src/header_links.md
+++ b/tests/testsuite/rendering/header_links/src/header_links.md
@@ -2,9 +2,11 @@
 
 ## Foo^bar
 
-###
+### !.():
 
 ####
+
+##### !!! {#explicit-punctuation}
 
 ## Hï
 


### PR DESCRIPTION
## Summary

- use `section` when heading text has no characters that can form an automatic HTML ID
- keep generated IDs unique as `section`, `section-1`, and so on
- cover punctuation-only, empty, and explicitly identified headings

## Why

Punctuation-only headings currently render with `id=""` and `href="#"`, so the generated header link points to the page root instead of the heading. A second such heading becomes `-1`.

This follows the fallback used by Pandoc and kramdown while leaving explicit IDs unchanged.

Fixes #3002.

## Validation

- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --document-private-items --no-deps`
- `cargo fmt --check`
- `git diff --check`
