### PR TITLE
fix: point the fold chevron down in RTL books

### DIFF
--- a/crates/mdbook-html/front-end/css/chrome.css
+++ b/crates/mdbook-html/front-end/css/chrome.css
@@ -643,6 +643,12 @@ html:not(.js) .sidebar-resize-handle {
     transform: rotate(90deg);
 }
 
+/* In RTL, the `❱` glyph is bidi-mirrored so it points left, and rotating it by
+   90deg would make it point up instead of down. Rotate the other way. */
+[dir=rtl] .chapter li.expanded > span > .chapter-fold-toggle div {
+    transform: rotate(-90deg);
+}
+
 .chapter a.current-header {
     color: var(--sidebar-active);
 }

--- a/tests/gui/books/rtl-fold/book.toml
+++ b/tests/gui/books/rtl-fold/book.toml
@@ -1,0 +1,7 @@
+[book]
+title = "rtl-fold"
+text-direction = "rtl"
+
+[output.html.fold]
+enable = true
+level = 0

--- a/tests/gui/books/rtl-fold/src/SUMMARY.md
+++ b/tests/gui/books/rtl-fold/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Introduction](./intro.md)
+    - [Sub chapter](./sub.md)

--- a/tests/gui/books/rtl-fold/src/intro.md
+++ b/tests/gui/books/rtl-fold/src/intro.md
@@ -1,0 +1,1 @@
+# Introduction

--- a/tests/gui/books/rtl-fold/src/sub.md
+++ b/tests/gui/books/rtl-fold/src/sub.md
@@ -1,0 +1,1 @@
+# Sub chapter

--- a/tests/gui/rtl-fold.goml
+++ b/tests/gui/rtl-fold.goml
@@ -1,0 +1,17 @@
+// Tests that the fold chevron rotates the correct way with RTL text direction.
+
+set-window-size: (1400, 800)
+go-to: |DOC_PATH| + "rtl-fold/index.html"
+assert-attribute: ("html", {"dir": "rtl"})
+
+store-value: (chevron, ".chapter li > span > .chapter-fold-toggle div")
+
+// The current chapter starts expanded, and its chevron must point down (and
+// not up like it used to).
+assert-css: (|chevron|, {"transform": "matrix(0, -1, 1, 0, 0, 0)"})
+
+// Once collapsed, the chevron is not rotated: the `❱` glyph is mirrored by the
+// RTL bidi algorithm, so it already points towards the start of the line.
+click: ".chapter .chapter-fold-toggle"
+// `transform` is a 0.5s transition, so wait for it to settle.
+wait-for-css: (|chevron|, {"transform": "none"})


### PR DESCRIPTION
Fixes #2894.

## Cause

The expanded chevron is rotated 90°:

```css
.chapter li.expanded > span > .chapter-fold-toggle div { transform: rotate(90deg); }
```

In an RTL document the browser has *already* bidi-mirrored the `❱` glyph, so it points left before any rotation. Rotating that by +90° points it **up**, which is the "^" in your report.

Collapsed is fine as-is — the mirroring alone is exactly what's wanted there.

## Fix

One rule, mirroring the existing one:

```css
[dir=rtl] .chapter li.expanded > span > .chapter-fold-toggle div { transform: rotate(-90deg); }
```

Computed transform on an expanded toggle in an RTL book goes from `matrix(0, 1, -1, 0, 0, 0)` to `matrix(0, -1, 1, 0, 0, 0)`. LTR is untouched — I captured every toggle's computed transform with and without the change and diffed: byte-identical.

## Checked rather than assumed

- **Specificity**: the new rule is (0,3,4) against the LTR rule's (0,2,4), and it also comes later in the file, so it wins on both counts.
- **The JS-built header toggles are covered too.** `toc.js.hbs` appends them into the same `span.chapter-link-wrapper` inside `.chapter`, so the selector matches. I built a book with `sidebar_header_nav` and h3/h4/h5 nesting and confirmed the computed transform on a header toggle.
- **The bidi-mirroring claim was verified by pixels**, not by reasoning about it: I screenshotted the collapsed glyph at 4× DPR and computed its ink centroid — 0.508 in LTR (pointing right) versus 0.471 in RTL (pointing left), with identical ink mass. Held for both a Latin title and an Arabic title inside the RTL document, so the surrounding-context worry didn't materialise.

## Test

`tests/gui/rtl-fold.goml` with a small RTL fixture book. GUI tests run here (`npm install` + `npx puppeteer browsers install chrome`):

```
cargo test --test gui   24 succeeded, 0 failed
npm run lint            clean
```

Load-bearing — stashing only the CSS change:

```
[ERROR] line 11: expected `matrix(0, -1, 1, 0, 0, 0)`, found `matrix(0, 1, -1, 0, 0, 0)`
<= doc-ui tests done: 0 succeeded, 1 failed
```

One gap worth naming: the fixture has no h3+ headings, so the test doesn't cover the JS header toggles, even though the fix applies to them. Happy to extend it if you'd like that pinned too.

No CHANGELOG entry, since CONTRIBUTING says those are generated at release time.
