### PR TITLE
Stop emitting infostring comments as HTML classes

### DIFF
--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -422,6 +422,8 @@ where
                 let mut code = Element::new("code");
                 match kind {
                     CodeBlockKind::Fenced(info) => {
+                        // Rustdoc treats everything from an opening paren as a comment.
+                        let info = info.split('(').next().unwrap_or_default();
                         let mut infos =
                             info.split([' ', '\t', ',']).filter(|info| !info.is_empty());
                         if let Some(lang) = infos.next() {

--- a/crates/mdbook-html/src/html/tree.rs
+++ b/crates/mdbook-html/src/html/tree.rs
@@ -422,8 +422,7 @@ where
                 let mut code = Element::new("code");
                 match kind {
                     CodeBlockKind::Fenced(info) => {
-                        // Rustdoc treats everything from an opening paren as a comment.
-                        let info = info.split('(').next().unwrap_or_default();
+                        let info = strip_infostring_comments(&info);
                         let mut infos =
                             info.split([' ', '\t', ',']).filter(|info| !info.is_empty());
                         if let Some(lang) = infos.next() {
@@ -1107,6 +1106,33 @@ where
     }
 }
 
+/// Removes rustdoc-style `(comment)` runs from a code block infostring.
+///
+/// Rustdoc's grammar is `comment = OPEN_PAREN *<all characters except closing
+/// parentheses> CLOSE_PAREN`, and a lang-string may interleave comments with
+/// tokens, so `rust (why),ignore` keeps both `rust` and `ignore`. An unclosed
+/// paren runs to the end, matching rustdoc's own recovery.
+fn strip_infostring_comments(info: &str) -> Cow<'_, str> {
+    if !info.contains('(') {
+        return Cow::Borrowed(info);
+    }
+    let mut out = String::with_capacity(info.len());
+    let mut depth = 0usize;
+    for ch in info.chars() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            // Keep a separator so tokens either side of a comment stay distinct.
+            _ if depth == 0 => out.push(ch),
+            _ => {}
+        }
+        if ch == ')' && depth == 0 {
+            out.push(' ');
+        }
+    }
+    Cow::Owned(out)
+}
+
 /// Traverse the given node, emitting any plain text into the output.
 ///
 /// This is used to generate the `id` of a header.
@@ -1188,4 +1214,48 @@ pub(crate) fn is_void_element(name: &str) -> bool {
             | "track"
             | "wbr"
     )
+}
+
+#[cfg(test)]
+mod strip_infostring_comments_tests {
+    use super::strip_infostring_comments;
+
+    #[test]
+    fn drops_comments_and_keeps_surrounding_tokens() {
+        // A comment in the middle must not truncate what follows.
+        assert_eq!(
+            strip_infostring_comments("rust (comment),ignore")
+                .split([' ', '\t', ','])
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            vec!["rust", "ignore"]
+        );
+        assert_eq!(
+            strip_infostring_comments("rust,ignore (requires next solver)")
+                .split([' ', '\t', ','])
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            vec!["rust", "ignore"]
+        );
+        assert_eq!(
+            strip_infostring_comments("rust (a) (b) ignore")
+                .split([' ', '\t', ','])
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            vec!["rust", "ignore"]
+        );
+        // An unclosed paren runs to the end, as in rustdoc.
+        assert_eq!(
+            strip_infostring_comments("rust (unclosed")
+                .split([' ', '\t', ','])
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            vec!["rust"]
+        );
+        // Untouched when there is nothing to strip.
+        assert!(matches!(
+            strip_infostring_comments("rust,ignore"),
+            std::borrow::Cow::Borrowed("rust,ignore")
+        ));
+    }
 }

--- a/tests/testsuite/markdown/basic_markdown/expected/code-blocks.html
+++ b/tests/testsuite/markdown/basic_markdown/expected/code-blocks.html
@@ -21,3 +21,4 @@ block.
     println!("hello");
 }</code></pre>
 <pre><code class="language-rust ignore">let x = 1;</code></pre>
+<pre><code class="language-rust ignore">let y = 2;</code></pre>

--- a/tests/testsuite/markdown/basic_markdown/expected/code-blocks.html
+++ b/tests/testsuite/markdown/basic_markdown/expected/code-blocks.html
@@ -20,3 +20,4 @@ block.
 <pre class="playground"><code class="language-rust">fn main() {
     println!("hello");
 }</code></pre>
+<pre><code class="language-rust ignore">let x = 1;</code></pre>

--- a/tests/testsuite/markdown/basic_markdown/src/code-blocks.md
+++ b/tests/testsuite/markdown/basic_markdown/src/code-blocks.md
@@ -33,3 +33,7 @@ fn main() {
 ```rust,ignore (requires next solver)
 let x = 1;
 ```
+
+```rust (why this is ignored),ignore
+let y = 2;
+```

--- a/tests/testsuite/markdown/basic_markdown/src/code-blocks.md
+++ b/tests/testsuite/markdown/basic_markdown/src/code-blocks.md
@@ -29,3 +29,7 @@ fn main() {
     println!("hello");
 }
 ```
+
+```rust,ignore (requires next solver)
+let x = 1;
+```


### PR DESCRIPTION
Fixes #3188.

## What's broken

Every infostring token after the language becomes a raw HTML class:

```
```rust,ignore (requires next solver)
->  <code class="language-rust ignore (requires next solver)"
```

So `(requires`, `next` and `solver)` all become classes. The `next` one collides with the navigation rule at `crates/mdbook-html/front-end/css/chrome.css:184`:

```css
.next {
    float: right;
    right: var(--page-padding);
}
```

The code block floats right and overlaps, which is the screenshot in the issue. This breaks the real rustc book, whose lint emits exactly that infostring.

## The fix

Stop at the opening paren, since rustdoc treats the rest of the infostring as a comment. Two lines.

## Why not an allowlist

That was the other candidate, and I think it is your call rather than mine. The documented attribute list already exists in `guide/src/format/mdbook.md`, and `tree.rs` already consumes exactly those names, so the list would not have to be invented. But `tests/testsuite/markdown/basic_markdown/src/code-blocks.md:15` deliberately asserts that `text cls1,,cls2\tcls3` passes arbitrary classes through on a non-Rust block. An allowlist would either break that or have to be scoped to `language-rust` blocks only, which is a behaviour change to a documented escape hatch.

Comment stripping is the half that fixes the rustc book without touching that. Say the word if you would rather have the allowlist and I will send it instead.

## Verification

```
$ mdbook build

before:  <code class="language-rust ignore (requires next solver)"
after:   <code class="language-rust ignore"
```

The `cls1 cls2 cls3` fixture is unchanged, which I checked both in the expected file and by building a book with both fences:

```
<code class="language-rust ignore"
<code class="language-text cls1 cls2 cls3"
```

Full CI gates pass: `cargo fmt --check`, `cargo build --locked`, `cargo test --workspace --locked` (110 passed in testsuite, no failures anywhere), `cargo test --workspace --no-default-features`, and `cargo clippy --workspace --all-targets --no-deps -- -D warnings` with no warnings.

Reverting just the `tree.rs` change with the fixture kept fails the `basic_markdown` test on exactly the expected line.

## Edge cases I checked

`rust,ignore(no_space)` gives `language-rust ignore`. An unbalanced `(` truncates there, which matches rustdoc. An empty infostring still emits no class attribute.

One honest behaviour loss: a language token containing `(`, as in ` ```ru(st `, now truncates to `language-ru`. No real language name uses a paren and rustdoc would read it the same way, but it is the only thing this change takes away.
