### PR TITLE
ci: add native Windows ARM64 releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,11 +23,13 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
     name: Deploy ${{ matrix.target }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             rust: stable
             target: x86_64-unknown-linux-musl
           - name: stable x86_64 macos
-            os: macos-latest
+            os: macos-15-intel
             rust: stable
             target: x86_64-apple-darwin
           - name: stable aarch64 macos
@@ -37,6 +37,10 @@ jobs:
             os: windows-latest
             rust: stable
             target: x86_64-pc-windows-msvc
+          - name: stable windows-arm64-msvc
+            os: windows-11-arm
+            rust: stable
+            target: aarch64-pc-windows-msvc
           - name: msrv
             os: ubuntu-22.04
             # sync MSRV with docs: guide/src/guide/installation.md and Cargo.toml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             rust: stable
             target: x86_64-unknown-linux-musl
           - name: stable x86_64 macos
-            os: macos-15-intel
+            os: macos-latest
             rust: stable
             target: x86_64-apple-darwin
           - name: stable aarch64 macos


### PR DESCRIPTION
Closes #3192.

## Summary

- add aarch64-pc-windows-msvc to CI on the native windows-11-arm runner
- include the Windows ARM64 archive in release builds
- preserve the existing Windows x86_64 artifact

## Validation

The complete CI workflow passed in my fork, including native Windows ARM64 compilation, tests, archive creation, and artifact upload:
https://github.com/meop/mdBook/actions/runs/31940828270

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validated it through the linked GitHub Actions run.