### PR TITLE
Use capital letters to indicate the default value in (y/n) prompts

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -41,7 +41,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         // Skip this if `--force` is present
         if !args.get_flag("force") && theme_dir.exists() {
             println!("This could potentially overwrite files already present in that directory.");
-            print!("\nAre you sure you want to continue? (y/n) ");
+            print!("\nAre you sure you want to continue? (y/N) ");
 
             // Read answer from user and exit if it's not 'yes'
             if confirm() {
@@ -58,7 +58,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
             _ => builder.create_gitignore(false),
         };
     } else if !args.get_flag("force") {
-        println!("\nDo you want a .gitignore to be created? (y/n)");
+        println!("\nDo you want a .gitignore to be created? (y/N)");
         if confirm() {
             builder.create_gitignore(true);
         }

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -12,7 +12,7 @@ fn basic_init() {
     test.run("init", |cmd| {
         cmd.expect_stdout(str![[r#"
 
-Do you want a .gitignore to be created? (y/n)
+Do you want a .gitignore to be created? (y/N)
 What title would you like to give the book? 
 
 All done, no errors...
@@ -109,7 +109,7 @@ fn no_git_config_with_title() {
     test.run("init", |cmd| {
         cmd.expect_stdout(str![[r#"
 
-Do you want a .gitignore to be created? (y/n)
+Do you want a .gitignore to be created? (y/N)
 
 All done, no errors...
 


### PR DESCRIPTION
Fix #2395

Improve the two yes/no prompts by capitalizing the default choice, No

In both scenarios, nothing happens if the user types anything else than the few strings mentioned in the confirm() function in src/cmd/init.rs

