### PR TITLE
Add cargo audit to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,16 @@ jobs:
           echo `pwd`/installed-bins >> $GITHUB_PATH
       - run: cargo semver-checks --workspace
 
+  audit:
+    name: Check crates audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install cargo audit
+        run: rustup update stable && rustup default stable && cargo install cargo-audit --locked
+      - name: Run cargo audit
+        run: cargo audit
+
   # The success job is here to consolidate the total success/failure state of
   # all other jobs. This job is then included in the GitHub branch protection
   # rule which prevents merges unless all other jobs are passing. This makes
@@ -153,6 +163,7 @@ jobs:
       - clippy
       - docs
       - check-version-bump
+      - audit
     runs-on: ubuntu-latest
     steps:
       - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,19 @@ Like formatting your code with `rustfmt`, running clippy regularly and before yo
     typos
     ```
 
+### Auditing dependencies with `cargo audit`
+
+[`cargo audit`](https://github.com/rustsec/cargo-audit) is a tool that checks the repository for known vulnerabilities in the dependencies.
+
+1. Install `cargo audit`:
+    ```
+    cargo install cargo-audit
+    ```
+2. Run it from the repository root:
+    ```
+    cargo audit
+    ```
+
 ## Change requirements
 
 Please consider the following when making a change:


### PR DESCRIPTION
Fix #2574 

Adds a job in the CI, which installs and runs `cargo audit`  
Adds the job in the `Success gate` list to ensure it does not fail silently  
Adds instructions in the contributing guide

I don't know if this should be included in the testsuite, let me know if you think it should belong there as well.

Also, I'm unsure about the `--locked` usage ; I noticed `cargo-audit` removed it from their instructions, but it seems to be the baseline otherwise. I did not mention it in CONTRIBUTING.md, following their doc, but it is present in the CI.

---

On a separate note, I would love to commit some of my time to this repo. @GuillaumeGomez if you feel there are some tasks that would be great for a newcomer to start, I'd gladly try.