### PR TITLE
ci: add native Linux ARM64 GNU releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
             os: ubuntu-22.04
             rust: stable
             target: x86_64-unknown-linux-musl
+          - name: stable aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            rust: stable
+            target: aarch64-unknown-linux-gnu
           - name: stable x86_64 macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
## Summary

- add `aarch64-unknown-linux-gnu` to CI on GitHub's native `ubuntu-24.04-arm` runner
- include the Linux ARM64 GNU archive in release builds

## Validation

The complete CI workflow passed in my fork, including native Linux ARM64 compilation, tests, archive creation, and artifact upload:

https://github.com/meop/mdBook/actions/runs/33244485949

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validated it through the linked GitHub Actions run.
